### PR TITLE
chore: add Dockerfile for container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies first for layer caching
+COPY pyproject.toml ./
+RUN pip install --no-cache-dir .
+
+# Copy source (invalidates cache only on code changes)
+COPY src/ src/
+
+# Re-install with source to pick up the actual package code
+RUN pip install --no-cache-dir .
+
+EXPOSE 8085
+
+ENV NATS_URL=nats://localhost:4222
+ENV HERMES_PORT=8085
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:${HERMES_PORT}/health')" || exit 1
+
+RUN useradd -r -s /usr/sbin/nologin hermes
+USER hermes
+
+CMD ["python", "-m", "hermes.server"]


### PR DESCRIPTION
## Summary

ProjectHermes is containerized in the E2E stack (`docker-compose.e2e.yml` references it with build context). This PR adds the Dockerfile to enable building and pushing the service image to registries.

The Dockerfile:
- Installs dependencies from `pyproject.toml`
- Copies source code
- Exposes port 8085 for the FastAPI server
- Sets NATS and port configuration via environment variables
- Includes health checks via the `/health` endpoint
- Runs as non-root `hermes` user

## Checklist

- [x] Dockerfile is compatible with the E2E stack
- [x] Health check matches docker-compose expectations
- [x] Follows best practices (non-root user, layer caching)