### PR TITLE
fix: replace deprecated HTTP_422_UNPROCESSABLE_ENTITY with HTTP_422_UNPROCESSABLE_CONTENT

### DIFF
--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -227,7 +227,7 @@ async def receive_webhook(request: Request, settings: SettingsDep) -> WebhookAcc
     except Exception as exc:
         logger.warning("Invalid webhook payload: %s", exc)
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Invalid payload format",
         ) from exc
 


### PR DESCRIPTION
## Summary

- Replaces the deprecated `status.HTTP_422_UNPROCESSABLE_ENTITY` constant with `status.HTTP_422_UNPROCESSABLE_CONTENT` in `src/hermes/server.py:79`
- Eliminates the `DeprecationWarning` emitted during test runs

## Test plan

- [x] All 19 existing tests pass (`pixi run python -m pytest tests/ -v`)
- [x] No new warnings observed during test run

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)