### PR TITLE
feat(config): add HERMES_PUBLIC_URL env var for configurable webhook callback URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 NATS_URL=nats://localhost:4222
 HERMES_HOST=127.0.0.1
 HERMES_PORT=8080
+HERMES_PUBLIC_URL=                  # defaults to http://localhost:$HERMES_PORT
 WEBHOOK_SECRET=
 # API key to access /subjects (leave empty to disable the endpoint entirely)
 ADMIN_API_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,11 +33,12 @@ NATS JetStream (via ProjectKeystone)
 
 ## Configuration
 
-| Variable       | Default               | Description                        |
-|----------------|-----------------------|------------------------------------|
-| NATS_URL       | nats://localhost:4222 | NATS server URL                    |
-| HERMES_PORT    | 8080                  | Port Hermes listens on             |
-| WEBHOOK_SECRET |                       | HMAC secret for webhook validation |
+| Variable          | Default                        | Description                                             |
+|-------------------|--------------------------------|---------------------------------------------------------|
+| NATS_URL          | nats://localhost:4222          | NATS server URL                                         |
+| HERMES_PORT       | 8080                           | Port Hermes listens on                                  |
+| HERMES_PUBLIC_URL | http://localhost:{HERMES_PORT} | Externally-reachable base URL for the /webhook endpoint |
+| WEBHOOK_SECRET    |                                | HMAC secret for webhook validation                      |
 
 Configure external services to POST to `http://<hermes-host>:<HERMES_PORT>/webhook`.
 

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from typing import Optional
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _MIN_SECRET_LENGTH = 32
@@ -22,12 +23,19 @@ class Settings(BaseSettings):
     nats_url: str = "nats://localhost:4222"
     hermes_host: str = "127.0.0.1"
     hermes_port: int = 8080
+    hermes_public_url: Optional[str] = None
     webhook_secret: str = ""
     nats_connect_timeout: float = 5.0
     nats_publish_timeout: float = 5.0
     agamemnon_timeout: float = 10.0
     shutdown_timeout: float = 10.0
     enable_dead_letter: bool = True
+
+    @model_validator(mode="after")
+    def _set_public_url_default(self) -> "Settings":
+        if self.hermes_public_url is None:
+            self.hermes_public_url = f"http://localhost:{self.hermes_port}"
+        return self
 
     @field_validator("webhook_secret")
     @classmethod

--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -48,6 +48,7 @@ class HealthResponse(BaseModel):
     nats_connected: bool
     shutting_down: bool = False
     hmac_validation_enabled: bool = False
+    hermes_public_url: str | None = None
 
 
 class WebhookAcceptedResponse(BaseModel):

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -204,11 +204,13 @@ async def health(response: Response) -> HealthResponse:
     connected = publisher.is_connected
     if not connected:
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    cfg = get_settings()
     return HealthResponse(
         status="ok" if connected else "degraded",
         nats_connected=connected,
         shutting_down=_shutdown_event.is_set(),
-        hmac_validation_enabled=bool(get_settings().webhook_secret),
+        hmac_validation_enabled=bool(cfg.webhook_secret),
+        hermes_public_url=cfg.hermes_public_url,
     )
 
 
@@ -296,9 +298,10 @@ def _log_startup_banner(publisher: Publisher, settings: Settings | None = None) 
         settings = get_settings()
     logger.info("hermes version=%s", __version__)
     logger.info(
-        "config nats_url=%s port=%s",
+        "config nats_url=%s port=%s public_url=%s",
         settings.nats_url,
         settings.hermes_port,
+        settings.hermes_public_url,
     )
     logger.info(
         "secrets webhook_secret=%s",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-"""Tests for Settings configuration, focusing on HERMES_HOST."""
+"""Tests for Settings configuration."""
 
 from __future__ import annotations
 
@@ -40,3 +40,29 @@ class TestHermesHostDefault:
 
         s = Settings()
         assert s.hermes_host != "0.0.0.0"
+
+
+class TestHermesPublicUrl:
+    def test_public_url_defaults_to_localhost_port(self) -> None:
+        from hermes.config import Settings
+
+        s = Settings(hermes_port=8080, _env_file=None)
+        assert s.hermes_public_url == "http://localhost:8080"
+
+    def test_public_url_respects_custom_port(self) -> None:
+        from hermes.config import Settings
+
+        s = Settings(hermes_port=9000, _env_file=None)
+        assert s.hermes_public_url == "http://localhost:9000"
+
+    def test_public_url_explicit_override(self) -> None:
+        from hermes.config import Settings
+
+        s = Settings(hermes_public_url="https://hermes.example.com", _env_file=None)
+        assert s.hermes_public_url == "https://hermes.example.com"
+
+    def test_public_url_explicit_override_ignores_port(self) -> None:
+        from hermes.config import Settings
+
+        s = Settings(hermes_port=9090, hermes_public_url="https://hermes.example.com", _env_file=None)
+        assert s.hermes_public_url == "https://hermes.example.com"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -70,6 +70,11 @@ class TestHealthEndpoint:
         body = client.get("/health").json()
         assert "nats_connected" in body
 
+    def test_health_includes_hermes_public_url(self) -> None:
+        client = _build_client()
+        body = client.get("/health").json()
+        assert "hermes_public_url" in body
+
     def test_health_returns_503_when_nats_disconnected(self) -> None:
         client = _build_client_disconnected()
         response = client.get("/health")


### PR DESCRIPTION
## Summary

- Adds `hermes_public_url` field to `Settings` in `config.py`, with a `model_validator` that defaults to `http://localhost:{hermes_port}` when `HERMES_PUBLIC_URL` is not set
- Exposes `hermes_public_url` in the `GET /health` response so operators can verify the configured value
- Documents the new variable in `.env.example` and `CLAUDE.md`

## Test plan

- [x] `tests/test_config.py` — 4 unit tests covering default fallback, custom port default, explicit override, and explicit override with custom port
- [x] `tests/test_webhook.py` — added `test_health_includes_hermes_public_url` asserting the key appears in `/health`
- [x] All 24 tests pass (`pixi run python -m pytest tests/ -v`)
- [x] Lint clean (`just lint`)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)