### PR TITLE
feat(lint): add ruff configuration for consistent linting

### DIFF
--- a/src/hermes/registrar.py
+++ b/src/hermes/registrar.py
@@ -1,5 +1,4 @@
-"""
-registrar.py — REMOVED (ADR-006)
+"""Registrar module removed per ADR-006.
 
 Previously registered ProjectHermes as a webhook receiver with ai-maestro.
 After migration to ProjectAgamemnon, Hermes no longer registers with an

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -8,8 +8,9 @@ import hmac
 import logging
 import signal
 import uuid
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import Annotated, Any, AsyncGenerator
+from typing import Annotated, Any
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import sys
 import os
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -11,36 +11,42 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from hermes.config import Settings
-from hermes.publisher import Publisher
 from hermes.models import WebhookPayload
+from hermes.publisher import Publisher
 
 
 class TestTimeoutSettings:
     """Settings expose configurable timeouts with correct defaults."""
 
     def test_nats_connect_timeout_default(self) -> None:
+        """nats_connect_timeout defaults to 5.0 seconds."""
         s = Settings()
         assert s.nats_connect_timeout == 5.0
 
     def test_nats_publish_timeout_default(self) -> None:
+        """nats_publish_timeout defaults to 5.0 seconds."""
         s = Settings()
         assert s.nats_publish_timeout == 5.0
 
     def test_agamemnon_timeout_default(self) -> None:
+        """agamemnon_timeout defaults to 10.0 seconds."""
         s = Settings()
         assert s.agamemnon_timeout == 10.0
 
     def test_nats_connect_timeout_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """nats_connect_timeout can be overridden via environment variable."""
         monkeypatch.setenv("NATS_CONNECT_TIMEOUT", "15.0")
         s = Settings()
         assert s.nats_connect_timeout == 15.0
 
     def test_nats_publish_timeout_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """nats_publish_timeout can be overridden via environment variable."""
         monkeypatch.setenv("NATS_PUBLISH_TIMEOUT", "3.0")
         s = Settings()
         assert s.nats_publish_timeout == 3.0
 
     def test_agamemnon_timeout_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """agamemnon_timeout can be overridden via environment variable."""
         monkeypatch.setenv("AGAMEMNON_TIMEOUT", "20.0")
         s = Settings()
         assert s.agamemnon_timeout == 20.0
@@ -51,6 +57,7 @@ class TestPublisherConnectTimeout:
 
     @pytest.mark.asyncio
     async def test_connect_passes_timeout(self) -> None:
+        """connect_timeout kwarg is forwarded to nats.connect."""
         pub = Publisher()
         mock_nc = MagicMock()
         mock_nc.jetstream.return_value = MagicMock()
@@ -65,6 +72,7 @@ class TestPublisherConnectTimeout:
 
     @pytest.mark.asyncio
     async def test_connect_default_timeout(self) -> None:
+        """connect_timeout defaults to 5.0 when not specified."""
         pub = Publisher()
         mock_nc = MagicMock()
         mock_nc.jetstream.return_value = MagicMock()
@@ -82,6 +90,7 @@ class TestPublisherPublishTimeout:
     """Publisher.publish() passes timeout to JetStream publish."""
 
     def _make_payload(self) -> WebhookPayload:
+        """Return a minimal WebhookPayload for use in publish tests."""
         return WebhookPayload(
             event="agent.created",
             data={"host": "myhost", "name": "myagent"},
@@ -90,6 +99,7 @@ class TestPublisherPublishTimeout:
 
     @pytest.mark.asyncio
     async def test_publish_passes_timeout(self) -> None:
+        """publish_timeout kwarg is forwarded to JetStream publish."""
         pub = Publisher()
         mock_js = AsyncMock()
         pub._js = mock_js
@@ -101,6 +111,7 @@ class TestPublisherPublishTimeout:
 
     @pytest.mark.asyncio
     async def test_publish_default_timeout(self) -> None:
+        """publish_timeout defaults to 5.0 when not specified."""
         pub = Publisher()
         mock_js = AsyncMock()
         pub._js = mock_js
@@ -111,6 +122,7 @@ class TestPublisherPublishTimeout:
 
     @pytest.mark.asyncio
     async def test_publish_raises_when_not_connected(self) -> None:
+        """Publish raises RuntimeError when the publisher is not connected."""
         pub = Publisher()
         with pytest.raises(RuntimeError, match="not connected"):
             await pub.publish(self._make_payload())

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -24,9 +24,9 @@ def _sign(body: bytes) -> str:
 
 def _build_client() -> TestClient:
     """Build a TestClient with a mocked Publisher and a known webhook secret."""
-    from hermes.server import app
-    from hermes.publisher import Publisher
     from hermes.config import settings
+    from hermes.publisher import Publisher
+    from hermes.server import app
 
     mock_publisher = MagicMock(spec=Publisher)
     mock_publisher.is_connected = True
@@ -55,6 +55,8 @@ def _build_client_disconnected() -> TestClient:
 
 
 class TestHealthEndpoint:
+    """Tests for the GET /health liveness endpoint."""
+
     def test_health_returns_200_when_connected(self) -> None:
         client = _build_client()
         response = client.get("/health")


### PR DESCRIPTION
## Summary

- Adds `[tool.ruff]`, `[tool.ruff.lint]`, and `[tool.ruff.format]` blocks to `pyproject.toml`
- Pins `target-version = "py310"`, `line-length = 100`, and selects rule sets `E, F, W, I, N, D, UP`
- Ignores conflicting docstring rule pairs (`D203`/`D211`, `D212`/`D213`) and `D100`, `D104`, `D417`
- Applies auto-fixes and adds missing docstrings across source and test files to achieve zero violations

## Test plan

- [x] `just lint` — `ruff check src tests` exits 0 with no violations
- [x] `pixi run ruff format --check src tests` — all files already formatted
- [x] `pixi run python -m pytest tests/ -v` — 19/19 tests pass
- [x] `pixi run ruff check --show-settings src | grep -E "target.version|line.length|select"` — confirms config is recognized

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)