### PR TITLE
feat(config): add configurable HERMES_HOST bind address

### DIFF
--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -203,6 +203,14 @@ class TestWebhookEndpoint:
         assert response.status_code == 401
 
 
+class TestSettings:
+    def test_hermes_host_defaults_to_localhost(self) -> None:
+        from hermes.config import Settings
+
+        s = Settings()
+        assert s.hermes_host == "127.0.0.1"
+
+
 class TestSubjectsEndpoint:
     def test_subjects_returns_list(self) -> None:
         client = _build_client()


### PR DESCRIPTION
## Summary

- Adds `hermes_host: str = Field(default="127.0.0.1")` to `Settings` in `config.py`, eliminating the hardcoded `0.0.0.0`
- Updates `uvicorn.run()` in `server.py` to use `settings.hermes_host`
- Documents `HERMES_HOST` in `.env.example` with a comment on when to override (Docker deployments)
- Adds `TestSettings::test_hermes_host_defaults_to_localhost` to verify the secure default

## Test plan

- [x] `pixi run python -m pytest tests/ -v` — all 20 tests pass
- [x] `pixi run ruff check src tests` — no lint errors
- [x] Default bind address is `127.0.0.1` (localhost-only) unless `HERMES_HOST` env var is set
- [x] Setting `HERMES_HOST=0.0.0.0` restores the previous all-interface binding behavior

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)