### PR TITLE
fix: remove pixi.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ build/
 __pycache__/
 *.pyc
 .pixi/
-pixi.lock


### PR DESCRIPTION
## Summary

- Removes `pixi.lock` from `.gitignore` so it is no longer contradictorily ignored while also being tracked by git
- Lock files should be committed to enable reproducible builds and ensure dependency updates are visible in PRs

## Problem

`pixi.lock` was listed in `.gitignore` but also committed to the repo (force-added at some point). This caused:
1. Git to track the file (so it appears in diffs when dependencies change)
2. `.gitignore` to signal to developers it shouldn't be committed
3. New contributors seeing no `git status` changes to the lock file even after dependency updates

## Test plan

- [ ] Verify `pixi.lock` no longer appears in `.gitignore`
- [ ] Confirm `git status` correctly shows changes to `pixi.lock` after any `pixi add` / `pixi update`
- [ ] Existing CI passes (no code changes)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)