### PR TITLE
security: enforce WEBHOOK_SECRET at startup — fail closed when unset

### DIFF
--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from functools import lru_cache
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_MIN_SECRET_LENGTH = 32
 
 
 class Settings(BaseSettings):
@@ -24,6 +27,15 @@ class Settings(BaseSettings):
     nats_publish_timeout: float = 5.0
     agamemnon_timeout: float = 10.0
     enable_dead_letter: bool = True
+
+    @field_validator("webhook_secret")
+    @classmethod
+    def _secret_min_length(cls, v: str) -> str:
+        if v and len(v) < _MIN_SECRET_LENGTH:
+            raise ValueError(
+                f"WEBHOOK_SECRET must be at least {_MIN_SECRET_LENGTH} characters when set"
+            )
+        return v
 
 
 @lru_cache


### PR DESCRIPTION
## Summary

- **Fail closed**: `lifespan` now raises `RuntimeError` if `WEBHOOK_SECRET` is not set, refusing to start without HMAC validation
- **Always validate**: `_verify_signature()` is called unconditionally on every webhook request (removed the opt-in `if settings.webhook_secret:` guard)
- **Minimum length**: `config.py` adds a `field_validator` that rejects secrets shorter than 32 characters, preventing weak secrets

## Changes

| File | Change |
|------|--------|
| `src/hermes/config.py` | Added `field_validator` enforcing `len(webhook_secret) >= 32` when non-empty |
| `src/hermes/server.py` | Lifespan raises `RuntimeError` on empty secret; `_verify_signature` always called |
| `tests/test_webhook.py` | Updated test secret to 32+ chars; added 5 new tests for config validation and startup rejection |

## Test plan

- [x] All 24 tests pass (`pixi run python -m pytest tests/ -v`)
- [x] Lint clean (`pixi run just lint`)
- [x] `test_short_secret_raises_validation_error` — secrets < 32 chars rejected at config load
- [x] `test_empty_secret_is_allowed_by_validator` — empty string passes validator (startup check catches it)
- [x] `test_secret_at_minimum_length_is_valid` — exactly 32 chars accepted
- [x] `test_secret_longer_than_minimum_is_valid` — longer secrets accepted
- [x] `test_startup_raises_without_secret` — app refuses to start without a secret

## OWASP

Addresses A07:2021 (Identification and Authentication Failures) and A04:2021 (Insecure Design).

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)