### PR TITLE
fix(security): redact exception details from webhook error response

### DIFF
--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -82,9 +82,10 @@ async def receive_webhook(request: Request, settings: SettingsDep) -> dict[str, 
     try:
         payload = WebhookPayload.model_validate_json(raw_body)
     except Exception as exc:
+        logger.warning("Invalid webhook payload: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Invalid payload: {exc}",
+            detail="Invalid payload format",
         ) from exc
 
     publisher: Publisher = app.state.publisher

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -144,6 +144,37 @@ class TestWebhookEndpoint:
         assert response.status_code == 401
 
 
+    def test_webhook_invalid_payload_does_not_leak_exception_details(self) -> None:
+        client = _build_client()
+        body_bytes = json.dumps({"bad": "payload"}).encode()
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+            },
+        )
+        detail = response.json().get("detail", "")
+        assert detail == "Invalid payload format"
+        assert "validation" not in detail.lower()
+        assert "field" not in detail.lower()
+
+    def test_webhook_malformed_json_does_not_leak_exception_details(self) -> None:
+        client = _build_client()
+        body_bytes = b"{not valid json}"
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+            },
+        )
+        detail = response.json().get("detail", "")
+        assert detail == "Invalid payload format"
+
+
 class TestSubjectsEndpoint:
     def test_subjects_returns_list(self) -> None:
         client = _build_client()


### PR DESCRIPTION
## Summary

- Replace `f"Invalid payload: {exc}"` with the generic string `"Invalid payload format"` in `server.py:77-81`
- Log the full exception server-side via `logger.warning` so nothing is silently swallowed
- Add two new tests asserting the response detail is exactly `"Invalid payload format"` and contains no Pydantic field/validation internals

## OWASP

Fixes **A04:2021 — Insecure Design** (verbose error messages that disclose internal model structure to callers).

## Test plan

- [x] All 21 existing tests still pass
- [x] `test_webhook_invalid_payload_does_not_leak_exception_details` — asserts generic message on bad JSON object
- [x] `test_webhook_malformed_json_does_not_leak_exception_details` — asserts generic message on malformed JSON

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)