### PR TITLE
security: gate /subjects endpoint behind admin API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ NATS_URL=nats://localhost:4222
 HERMES_HOST=127.0.0.1
 HERMES_PORT=8080
 WEBHOOK_SECRET=
+# API key to access /subjects (leave empty to disable the endpoint entirely)
+ADMIN_API_KEY=


### PR DESCRIPTION
## Summary

- Added `ADMIN_API_KEY` config setting (defaults to empty — endpoint disabled by default)
- New `_require_admin_key` FastAPI dependency gates `GET /subjects`:
  - Returns **404** when `ADMIN_API_KEY` is unset (endpoint effectively hidden)
  - Returns **401** for missing or incorrect `Authorization: Bearer <key>` header
  - Uses `hmac.compare_digest` for timing-safe key comparison
- Wired dependency into `/subjects` route via `dependencies=[Depends(_require_admin_key)]`
- Updated `.env.example` with the new variable
- Added 3 new tests covering all auth failure cases

## Test plan

- [x] All 22 tests pass (`pixi run python -m pytest tests/ -v`)
- [x] `test_subjects_returns_list` — valid key → 200
- [x] `test_subjects_without_auth_returns_401` — no header → 401
- [x] `test_subjects_wrong_key_returns_401` — bad key → 401
- [x] `test_subjects_disabled_when_no_key_returns_404` — key unset → 404

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)