### PR TITLE
security: harden secret hygiene with gitleaks scanning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Copy to .env and fill in values. NEVER commit .env to version control.
+# After copying: chmod 600 .env
 NATS_URL=nats://localhost:4222
 HERMES_PORT=8080
 WEBHOOK_SECRET=

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,31 @@
+name: Security Scan
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly on Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+jobs:
+  secret-scan:
+    name: Secret Scanning (gitleaks)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          curl -sSfL \
+            https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz \
+            | tar -xz gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+
+      - name: Scan for secrets
+        run: gitleaks detect --source . --config .gitleaks.toml --verbose --exit-code=1

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,21 @@
+# Environment / secrets — NEVER commit these
 .env
+.env.local
+.env.*.local
+*.key
+*.pem
+credentials.json
+secrets/
+
+# Python
 __pycache__/
 *.py[cod]
 *.egg-info/
 dist/
 build/
+
+# Tools / caches
 .mypy_cache/
 .ruff_cache/
 .pytest_cache/
-.pixi/
-
-__pycache__/
-*.pyc
 .pixi/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+title = "ProjectHermes gitleaks config"
+
+[allowlist]
+  description = "Test fixtures use placeholder secrets — not real credentials"
+  paths = [
+    '''tests/.*''',
+    '''.env\.example''',
+  ]

--- a/justfile
+++ b/justfile
@@ -67,6 +67,12 @@ docker-up:
 docker-down:
     docker compose down
 
+# === Security ===
+
+# Scan repository for leaked secrets (requires gitleaks installed)
+scan-secrets:
+    gitleaks detect --source . --config .gitleaks.toml --verbose
+
 # === NATS ===
 
 # Start NATS server (uses Odysseus config if available, otherwise embedded defaults)


### PR DESCRIPTION
## Summary

- Expanded `.gitignore` to cover additional secret file patterns (`.env.local`, `*.key`, `*.pem`, `credentials.json`, `secrets/`) and removed duplicate entries
- Added `.gitleaks.toml` with an allowlist for test fixture secrets to suppress false positives
- Added `.github/workflows/security.yml`: gitleaks secret scanning on every PR, weekly schedule (Mon 08:00 UTC), and `workflow_dispatch` — uses `fetch-depth: 0` to scan full git history
- Added `just scan-secrets` recipe for local secret scanning
- Annotated `.env.example` with a `NEVER commit .env` warning and `chmod 600` reminder

**Note:** Investigation confirmed `.env` was never committed to git history (`git log --all -- .env` returns empty). The hardening here is preventative, not remedial.

## Test plan

- [x] All 19 existing tests pass (`pixi run pytest`)
- [x] Linting passes (`pixi run ruff check src tests`)
- [x] `.env` confirmed absent from `git ls-files`
- [x] `.gitleaks.toml` allowlist covers `tests/` and `.env.example` to avoid false positives from test fixture secrets

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)