### PR TITLE
docs: add Security and Code of Conduct links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,11 @@ just test     # run tests
 just lint     # ruff check
 just format   # ruff format
 ```
+
+## Security
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md). Do not open public issues for security vulnerabilities.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

- Adds a **Security** section to `README.md` linking to `SECURITY.md` — gives users a clear path to the vulnerability disclosure policy
- Adds a **Code of Conduct** section to `README.md` linking to `CODE_OF_CONDUCT.md`
- `SECURITY.md` and `CODE_OF_CONDUCT.md` were already added in e913b9f; this PR completes the integration by making them discoverable from the README

Closes #39

## Test plan

- [ ] Verify `README.md` renders correctly and links resolve to the correct files
- [ ] Confirm `SECURITY.md` covers: reporting channel, response timeline, scope, supported versions
- [ ] Confirm `CODE_OF_CONDUCT.md` is Contributor Covenant v2.1
- [ ] No regressions in `just lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)