### PR TITLE
feat(packaging): multi-stage Dockerfile, docker-compose, and just recipes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
+FROM python:3.12-slim AS builder
+WORKDIR /build
+RUN pip install --no-cache-dir fastapi "uvicorn[standard]" nats-py "pydantic>=2.0" pydantic-settings httpx \
+    --target /build/deps
+
 FROM python:3.12-slim
 WORKDIR /app
-RUN pip install --no-cache-dir fastapi "uvicorn[standard]" nats-py "pydantic>=2.0" pydantic-settings httpx
+
+COPY --from=builder /build/deps /usr/local/lib/python3.12/site-packages/
 COPY src/hermes/ ./hermes/
-EXPOSE 8085
-ENV HERMES_PORT=8085
 
 RUN useradd -r -s /usr/sbin/nologin hermes
 USER hermes
+
+ENV HERMES_PORT=8080
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${HERMES_PORT}/health')"
 
 CMD ["python", "-m", "hermes.server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  nats:
+    image: nats:latest
+    command: ["--jetstream", "--store_dir", "/data"]
+    ports:
+      - "4222:4222"
+    volumes:
+      - nats-data:/data
+    healthcheck:
+      test: ["CMD", "nats-server", "--help"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  hermes:
+    build: .
+    ports:
+      - "${HERMES_PORT:-8080}:8080"
+    environment:
+      - NATS_URL=nats://nats:4222
+      - HERMES_PORT=8080
+      - WEBHOOK_SECRET=${WEBHOOK_SECRET:-}
+    depends_on:
+      nats:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+
+volumes:
+  nats-data:

--- a/justfile
+++ b/justfile
@@ -44,6 +44,29 @@ lint:
 format:
     pixi run ruff format src tests
 
+# === Docker ===
+
+# Build the Docker image
+docker-build tag="hermes:latest":
+    docker build -t {{tag}} .
+
+# Run the Docker container (requires NATS running separately)
+docker-run tag="hermes:latest":
+    docker run --rm \
+        -p {{HERMES_PORT}}:8080 \
+        -e NATS_URL={{NATS_URL}} \
+        -e HERMES_PORT=8080 \
+        -e WEBHOOK_SECRET="${WEBHOOK_SECRET:-}" \
+        {{tag}}
+
+# Start Hermes + NATS together via docker-compose
+docker-up:
+    docker compose up --build
+
+# Stop and remove docker-compose containers
+docker-down:
+    docker compose down
+
 # === NATS ===
 
 # Start NATS server (uses Odysseus config if available, otherwise embedded defaults)


### PR DESCRIPTION
## Summary

- Converts the existing Dockerfile to a **multi-stage build** (builder → runtime) to keep the final image lean
- Fixes the default port from `8085` → `8080` to match the `HERMES_PORT` default everywhere else
- Adds a `HEALTHCHECK` instruction that probes `/health` so container orchestrators can track liveness
- Adds `docker-compose.yml` for local development: Hermes + NATS JetStream sidecar, with health-gate ordering
- Adds four `just` recipes: `docker-build`, `docker-run`, `docker-up`, `docker-down`

## Test plan

- [x] All 19 existing pytest tests pass (`pixi run python -m pytest tests/ -v`)
- [ ] `just docker-build` produces a valid image
- [ ] `just docker-up` starts Hermes + NATS; `just health` returns `{"status": "ok", ...}`
- [ ] `just docker-down` tears down cleanly

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)