### PR TITLE
feat(planning): add issue/PR templates, branching strategy, and v0.2.0 milestone

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior in ProjectHermes
+labels: [bug]
+---
+
+## Description
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen. -->
+
+## Actual Behavior
+
+<!-- What actually happened. Include any error messages or stack traces. -->
+
+## Environment
+
+- **OS**: <!-- e.g. Ubuntu 22.04, macOS 14 -->
+- **Python version**: <!-- `python --version` -->
+- **NATS server version**: <!-- `nats-server --version` -->
+- **Hermes version**: <!-- `pixi run python -c "import hermes; print(hermes.__version__)"` -->
+
+## Diagnostics
+
+<details>
+<summary>Health check output</summary>
+
+```text
+<!-- paste output of: just health -->
+```
+
+</details>
+
+<details>
+<summary>Relevant logs</summary>
+
+```text
+<!-- paste relevant log lines here -->
+```
+
+</details>
+
+## Additional Context
+
+<!-- Anything else that might help diagnose the issue. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/HomericIntelligence/ProjectHermes/security/advisories/new
+    about: Please report security vulnerabilities via GitHub Security Advisories, not public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement for ProjectHermes
+labels: [enhancement]
+---
+
+## Problem Statement
+
+<!-- Describe the problem this feature would solve. What are you trying to do that you cannot do today? -->
+
+## Proposed Solution
+
+<!-- Describe the solution you have in mind. Be as specific as possible. -->
+
+## Alternatives Considered
+
+<!-- What other approaches did you consider? Why did you choose this one? -->
+
+## Architecture Impact
+
+<!-- If this touches the webhook → NATS pipeline, describe how it fits:
+     - Does it add a new subject pattern (hi.agents.* or hi.tasks.*)?
+     - Does it require a new NATS stream or consumer?
+     - Does it affect the HMAC validation or payload parsing boundary?
+-->
+
+## Additional Context
+
+<!-- Screenshots, links to related issues, prior art, etc. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- 1-3 bullet points describing what this PR does and why. -->
+
+-
+
+## Test Plan
+
+<!-- How was this tested? Which cases were covered? -->
+
+- [ ] `just test` passes locally
+- [ ] Tested manually with `just dev` + `just health`
+
+## Checklist
+
+- [ ] Tests pass (`just test`)
+- [ ] Lint clean (`just lint`)
+- [ ] Types checked (all new functions have type hints)
+- [ ] Documentation updated (if user-facing change)
+- [ ] No secrets or credentials committed
+
+## Related Issues
+
+<!-- Link issues this PR resolves. -->
+
+Closes #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   lint-and-test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,11 +76,11 @@ Before starting work:
 
 ### 2. Branch Naming Convention
 
-Create a feature branch from `main`:
+Create a feature branch from `master`:
 
 ```bash
-git checkout main
-git pull origin main
+git checkout master
+git pull origin master
 git checkout -b <issue-number>-<short-description>
 
 # Examples:
@@ -181,7 +181,7 @@ just register-webhook
 ### Before You Start
 
 1. Ensure an issue exists for your work
-2. Create a branch from `main` using the naming convention
+2. Create a branch from `master` using the naming convention
 3. Implement your changes
 4. Run `just test` and `just lint` to verify
 
@@ -198,9 +198,22 @@ gh pr create --title "[Type] Brief description" --body "Closes #<issue-number>"
 - PR title should be clear and descriptive
 - Tests and linting must pass
 
-### Never Push Directly to Main
+### Branching Strategy
 
-The `main` branch is protected. All changes must go through pull requests.
+| Branch type | Naming convention | Base branch | Notes |
+|-------------|-------------------|-------------|-------|
+| Default | `master` | — | Protected; never push directly |
+| Feature / fix | `<issue>-<slug>` | `master` | e.g. `44-planning-templates` |
+| Release | `release/v<x.y.z>` | `master` | Created from `master` before tagging |
+
+**Merge strategy:**
+
+- Single-concern PRs: squash-and-merge
+- Multi-commit story-arc PRs: rebase-and-merge
+
+### Never Push Directly to Master
+
+The `master` branch is protected. All changes must go through pull requests.
 
 ## Code Review
 


### PR DESCRIPTION
## Summary

- Add GitHub issue templates (bug report, feature request) and a PR template with checklist
- Document the branching strategy in CONTRIBUTING.md (master default, `<issue>-<slug>` feature branches)
- Fix CI workflow: trigger on `master` not `main` (CI was silently never firing on pushes)
- Create v0.2.0 milestone and assign 8 critical/major issues to it

## Test Plan

- [ ] Verified templates render with correct YAML frontmatter
- [ ] Confirmed `just lint` passes (Python-only linter — no regressions)
- [ ] CI branch fix verified by reading current default branch (`master`)
- [ ] Milestone created via `gh api` and confirmed via list; 8 issues assigned

## Checklist

- [x] Tests pass (`just test` — no Python changes)
- [x] Lint clean (`just lint`)
- [x] Documentation updated (CONTRIBUTING.md branching strategy)
- [x] No secrets or credentials committed

## Related Issues

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)