### PR TITLE
feat(api): add typed OpenAPI response models and error schemas

### DIFF
--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -34,3 +34,34 @@ class TaskEvent(BaseModel):
     event: str
     status: str
     metadata: dict[str, Any] = {}
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class HealthResponse(BaseModel):
+    """Response body for GET /health."""
+
+    status: str
+    nats_connected: bool
+
+
+class WebhookAcceptedResponse(BaseModel):
+    """Response body for POST /webhook (202 Accepted)."""
+
+    status: str
+    event: str
+
+
+class SubjectsResponse(BaseModel):
+    """Response body for GET /subjects."""
+
+    subjects: list[str]
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response body."""
+
+    detail: str

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -12,7 +12,13 @@ from typing import Annotated, AsyncGenerator
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 
 from hermes.config import Settings, get_settings
-from hermes.models import WebhookPayload
+from hermes.models import (
+    ErrorResponse,
+    HealthResponse,
+    SubjectsResponse,
+    WebhookAcceptedResponse,
+    WebhookPayload,
+)
 from hermes.publisher import Publisher
 
 logger = logging.getLogger(__name__)
@@ -60,18 +66,28 @@ SettingsDep = Annotated[Settings, Depends(get_settings)]
 # ---------------------------------------------------------------------------
 
 
-@app.get("/health")
-async def health() -> dict[str, object]:
+@app.get(
+    "/health",
+    response_model=HealthResponse,
+    responses={503: {"model": ErrorResponse, "description": "NATS not reachable"}},
+)
+async def health() -> HealthResponse:
     """Return service health and NATS connection status."""
     publisher: Publisher = app.state.publisher
-    return {
-        "status": "ok",
-        "nats_connected": publisher.is_connected,
-    }
+    return HealthResponse(status="ok", nats_connected=publisher.is_connected)
 
 
-@app.post("/webhook", status_code=status.HTTP_202_ACCEPTED)
-async def receive_webhook(request: Request, settings: SettingsDep) -> dict[str, str]:
+@app.post(
+    "/webhook",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=WebhookAcceptedResponse,
+    responses={
+        401: {"model": ErrorResponse, "description": "Invalid webhook signature"},
+        422: {"model": ErrorResponse, "description": "Malformed or invalid payload"},
+        503: {"model": ErrorResponse, "description": "NATS publisher not connected"},
+    },
+)
+async def receive_webhook(request: Request, settings: SettingsDep) -> WebhookAcceptedResponse:
     """Receive an external webhook, validate its signature, and publish to NATS."""
     raw_body = await request.body()
 
@@ -96,14 +112,17 @@ async def receive_webhook(request: Request, settings: SettingsDep) -> dict[str, 
         )
 
     await publisher.publish(payload, publish_timeout=settings.nats_publish_timeout)
-    return {"status": "accepted", "event": payload.event}
+    return WebhookAcceptedResponse(status="accepted", event=payload.event)
 
 
-@app.get("/subjects")
-async def list_subjects() -> dict[str, list[str]]:
+@app.get(
+    "/subjects",
+    response_model=SubjectsResponse,
+)
+async def list_subjects() -> SubjectsResponse:
     """Return the list of NATS subjects that have been published to."""
     publisher: Publisher = app.state.publisher
-    return {"subjects": publisher.active_subjects}
+    return SubjectsResponse(subjects=publisher.active_subjects)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -13,6 +13,8 @@ from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+from hermes.models import HealthResponse, SubjectsResponse, WebhookAcceptedResponse
+
 # Fixed secret used across all webhook tests
 _TEST_SECRET = "test-webhook-secret"
 
@@ -59,6 +61,13 @@ class TestHealthEndpoint:
         client = _build_client()
         body = client.get("/health").json()
         assert "nats_connected" in body
+
+    def test_health_response_matches_model(self) -> None:
+        client = _build_client()
+        body = client.get("/health").json()
+        model = HealthResponse(**body)
+        assert model.status == "ok"
+        assert isinstance(model.nats_connected, bool)
 
 
 class TestWebhookEndpoint:
@@ -125,6 +134,27 @@ class TestWebhookEndpoint:
         body = response.json()
         assert body["event"] == "task.updated"
 
+    def test_webhook_response_matches_model(self) -> None:
+        client = _build_client()
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "localhost", "name": "bot"},
+            "timestamp": "2026-03-15T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+            },
+        )
+        assert response.status_code == 202
+        model = WebhookAcceptedResponse(**response.json())
+        assert model.status == "accepted"
+        assert model.event == "agent.created"
+
     def test_webhook_bad_signature_returns_401(self) -> None:
         client = _build_client()
         payload = {
@@ -150,3 +180,43 @@ class TestSubjectsEndpoint:
         body = client.get("/subjects").json()
         assert "subjects" in body
         assert isinstance(body["subjects"], list)
+
+    def test_subjects_response_matches_model(self) -> None:
+        client = _build_client()
+        body = client.get("/subjects").json()
+        model = SubjectsResponse(**body)
+        assert isinstance(model.subjects, list)
+
+
+class TestOpenAPISchema:
+    def test_openapi_includes_health_response_schema(self) -> None:
+        client = _build_client()
+        schema = client.get("/openapi.json").json()
+        components = schema.get("components", {}).get("schemas", {})
+        assert "HealthResponse" in components
+
+    def test_openapi_includes_webhook_accepted_response_schema(self) -> None:
+        client = _build_client()
+        schema = client.get("/openapi.json").json()
+        components = schema.get("components", {}).get("schemas", {})
+        assert "WebhookAcceptedResponse" in components
+
+    def test_openapi_includes_subjects_response_schema(self) -> None:
+        client = _build_client()
+        schema = client.get("/openapi.json").json()
+        components = schema.get("components", {}).get("schemas", {})
+        assert "SubjectsResponse" in components
+
+    def test_openapi_includes_error_response_schema(self) -> None:
+        client = _build_client()
+        schema = client.get("/openapi.json").json()
+        components = schema.get("components", {}).get("schemas", {})
+        assert "ErrorResponse" in components
+
+    def test_openapi_webhook_documents_error_responses(self) -> None:
+        client = _build_client()
+        schema = client.get("/openapi.json").json()
+        webhook_path = schema["paths"]["/webhook"]["post"]
+        response_codes = set(webhook_path["responses"].keys())
+        assert "401" in response_codes
+        assert "503" in response_codes


### PR DESCRIPTION
## Summary

- Added `HealthResponse`, `WebhookAcceptedResponse`, `SubjectsResponse`, and `ErrorResponse` Pydantic models to `src/hermes/models.py`
- Updated all three route handlers (`/health`, `/webhook`, `/subjects`) to return typed Pydantic model instances instead of raw `dict`s
- Added `response_model` and `responses` parameters to all route decorators, documenting 401, 422, and 503 error responses in the OpenAPI schema
- `/docs` now shows structured request/response schemas for all endpoints; `/openapi.json` includes all four response model schemas

## Test plan

- [x] All 27 existing + new tests pass (`pixi run python -m pytest tests/ -v`)
- [x] New `test_health_response_matches_model` validates `/health` response parses into `HealthResponse`
- [x] New `test_webhook_response_matches_model` validates `/webhook` response parses into `WebhookAcceptedResponse`
- [x] New `test_subjects_response_matches_model` validates `/subjects` response parses into `SubjectsResponse`
- [x] New `TestOpenAPISchema` class verifies all four schema components appear in `/openapi.json` and that `/webhook` documents 401 and 503 error codes

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)