### PR TITLE
feat(types): add PEP 561 py.typed marker and mypy strict configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Lint
         run: pixi run lint
 
+      - name: Type check
+        run: pixi run typecheck
+
       - name: Unit tests (no NATS required)
         run: pixi run pytest -m "not integration"
 

--- a/justfile
+++ b/justfile
@@ -57,6 +57,10 @@ lint:
 format:
     pixi run ruff format src tests
 
+# Run mypy type checker
+typecheck:
+    pixi run mypy --strict src/hermes/
+
 # === Docker ===
 
 # Build the Docker image

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,6 +29,7 @@ mypy = "*"
 default = { features = ["dev"], solve-group = "default" }
 
 [tasks]
-start = "just start"
-test  = "just test"
-lint  = "just lint"
+start     = "just start"
+test      = "just test"
+lint      = "just lint"
+typecheck = "just typecheck"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,17 @@ exclude_lines = [
     "class .*\\bProtocol\\):",
     "@(abc\\.)?abstractmethod",
 ]
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_unused_configs = true
+show_error_codes = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = ["nats.*", "nats.aio.*", "nats.js.*"]
+ignore_missing_imports = true

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -44,6 +44,7 @@ class Publisher:
         """Create JetStream streams if they don't exist yet."""
         from nats.js.api import StreamConfig
         from nats.js.errors import NotFoundError
+        assert self._nc is not None
         jsm = self._nc.jsm()
         for name, subjects in (
             ("homeric-agents", ["hi.agents.>"]),

--- a/tests/test_py_typed.py
+++ b/tests/test_py_typed.py
@@ -1,0 +1,29 @@
+"""Verify that the PEP 561 py.typed marker is present in the hermes package."""
+
+from __future__ import annotations
+
+import importlib.resources
+from pathlib import Path
+
+
+def test_py_typed_marker_exists_in_source() -> None:
+    """py.typed must exist alongside the package source files."""
+    import hermes
+
+    pkg_dir = Path(hermes.__file__).parent  # type: ignore[arg-type]
+    assert (pkg_dir / "py.typed").exists(), "py.typed marker missing from hermes package"
+
+
+def test_py_typed_marker_is_empty() -> None:
+    """PEP 561 requires py.typed to be an empty file (zero bytes)."""
+    import hermes
+
+    pkg_dir = Path(hermes.__file__).parent  # type: ignore[arg-type]
+    marker = pkg_dir / "py.typed"
+    assert marker.stat().st_size == 0, "py.typed must be empty (zero bytes)"
+
+
+def test_py_typed_accessible_via_importlib_resources() -> None:
+    """py.typed must be accessible as a package resource (i.e. it's included)."""
+    ref = importlib.resources.files("hermes").joinpath("py.typed")
+    assert ref.is_file(), "py.typed is not accessible as a package resource"


### PR DESCRIPTION
## Summary

- Creates empty `src/hermes/py.typed` so downstream packages (Argus, Keystone, Telemachy) can use Hermes type annotations with mypy/pyright without `--ignore-missing-imports`
- Adds `[tool.mypy]` strict configuration to `pyproject.toml` (python_version=3.10, strict=true, nats stubs overrides)
- Fixes two mypy strict errors in `publisher.py` (null-guard assertion in `_ensure_streams` and `attr-defined` suppression for nats `JetStreamManager`)
- Adds `typecheck` recipe to `justfile` and `pixi.toml`
- Adds "Type check" CI step between Lint and Test
- Adds `tests/test_py_typed.py` verifying marker exists, is empty, and is accessible via `importlib.resources`

## Test plan

- [x] `pixi run mypy --strict src/hermes/` exits 0 (verified locally)
- [x] `pixi run python -m pytest tests/ -v` — 22 tests pass including 3 new py.typed tests
- [x] `py.typed` marker exists at `src/hermes/py.typed` (zero bytes)
- [x] CI "Type check" step added and will run on every push/PR

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)