### PR TITLE
feat(config): add configurable timeouts for NATS and Agamemnon operations

### DIFF
--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -17,6 +17,9 @@ class Settings(BaseSettings):
     nats_url: str = "nats://localhost:4222"
     hermes_port: int = 8080
     webhook_secret: str = ""
+    nats_connect_timeout: float = 5.0
+    nats_publish_timeout: float = 5.0
+    agamemnon_timeout: float = 10.0
 
 
 settings = Settings()

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -32,9 +32,9 @@ class Publisher:
     # Lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self, url: str) -> None:
+    async def connect(self, url: str, connect_timeout: float = 5.0) -> None:
         """Connect to the NATS server, obtain JetStream context, and ensure streams exist."""
-        self._nc = await nats.connect(url)
+        self._nc = await nats.connect(url, connect_timeout=connect_timeout)
         self._js = self._nc.jetstream()
         await self._ensure_streams()
         logger.info("Connected to NATS at %s", url)
@@ -73,7 +73,7 @@ class Publisher:
     # Publishing
     # ------------------------------------------------------------------
 
-    async def publish(self, payload: WebhookPayload) -> None:
+    async def publish(self, payload: WebhookPayload, publish_timeout: float = 5.0) -> None:
         """Route a webhook payload to the appropriate NATS subject."""
         if self._js is None:
             raise RuntimeError("Publisher is not connected to NATS")
@@ -91,7 +91,7 @@ class Publisher:
             }
         ).encode()
 
-        await self._js.publish(subject, message)
+        await self._js.publish(subject, message, timeout=publish_timeout)
         self._active_subjects.add(subject)
         logger.info("Published to %s", subject)
 

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -27,7 +27,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Connect to NATS on startup; disconnect cleanly on shutdown."""
     publisher = Publisher()
     try:
-        await publisher.connect(settings.nats_url)
+        await publisher.connect(settings.nats_url, connect_timeout=settings.nats_connect_timeout)
     except Exception as exc:  # noqa: BLE001
         logger.warning("Could not connect to NATS at %s: %s", settings.nats_url, exc)
 
@@ -88,7 +88,7 @@ async def receive_webhook(request: Request) -> dict[str, str]:
             detail="NATS publisher not connected",
         )
 
-    await publisher.publish(payload)
+    await publisher.publish(payload, publish_timeout=settings.nats_publish_timeout)
     return {"status": "accepted", "event": payload.event}
 
 

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,0 +1,117 @@
+"""Tests verifying timeout configuration is respected."""
+
+from __future__ import annotations
+
+import sys
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from hermes.config import Settings
+from hermes.publisher import Publisher
+from hermes.models import WebhookPayload
+
+
+class TestTimeoutSettings:
+    """Settings expose configurable timeouts with correct defaults."""
+
+    def test_nats_connect_timeout_default(self) -> None:
+        s = Settings()
+        assert s.nats_connect_timeout == 5.0
+
+    def test_nats_publish_timeout_default(self) -> None:
+        s = Settings()
+        assert s.nats_publish_timeout == 5.0
+
+    def test_agamemnon_timeout_default(self) -> None:
+        s = Settings()
+        assert s.agamemnon_timeout == 10.0
+
+    def test_nats_connect_timeout_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NATS_CONNECT_TIMEOUT", "15.0")
+        s = Settings()
+        assert s.nats_connect_timeout == 15.0
+
+    def test_nats_publish_timeout_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NATS_PUBLISH_TIMEOUT", "3.0")
+        s = Settings()
+        assert s.nats_publish_timeout == 3.0
+
+    def test_agamemnon_timeout_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGAMEMNON_TIMEOUT", "20.0")
+        s = Settings()
+        assert s.agamemnon_timeout == 20.0
+
+
+class TestPublisherConnectTimeout:
+    """Publisher.connect() passes connect_timeout to nats.connect()."""
+
+    @pytest.mark.asyncio
+    async def test_connect_passes_timeout(self) -> None:
+        pub = Publisher()
+        mock_nc = MagicMock()
+        mock_nc.jetstream.return_value = MagicMock()
+        mock_jsm = AsyncMock()
+        mock_jsm.find_stream = AsyncMock(return_value=MagicMock())
+        mock_nc.jsm.return_value = mock_jsm
+
+        with patch("nats.connect", new_callable=AsyncMock, return_value=mock_nc) as mock_connect:
+            await pub.connect("nats://localhost:4222", connect_timeout=7.5)
+            mock_connect.assert_awaited_once_with(
+                "nats://localhost:4222", connect_timeout=7.5
+            )
+
+    @pytest.mark.asyncio
+    async def test_connect_default_timeout(self) -> None:
+        pub = Publisher()
+        mock_nc = MagicMock()
+        mock_nc.jetstream.return_value = MagicMock()
+        mock_jsm = AsyncMock()
+        mock_jsm.find_stream = AsyncMock(return_value=MagicMock())
+        mock_nc.jsm.return_value = mock_jsm
+
+        with patch("nats.connect", new_callable=AsyncMock, return_value=mock_nc) as mock_connect:
+            await pub.connect("nats://localhost:4222")
+            _, kwargs = mock_connect.call_args
+            assert kwargs["connect_timeout"] == 5.0
+
+
+class TestPublisherPublishTimeout:
+    """Publisher.publish() passes timeout to JetStream publish."""
+
+    def _make_payload(self) -> WebhookPayload:
+        return WebhookPayload(
+            event="agent.created",
+            data={"host": "myhost", "name": "myagent"},
+            timestamp="2026-01-01T00:00:00Z",
+        )
+
+    @pytest.mark.asyncio
+    async def test_publish_passes_timeout(self) -> None:
+        pub = Publisher()
+        mock_js = AsyncMock()
+        pub._js = mock_js
+
+        await pub.publish(self._make_payload(), publish_timeout=2.5)
+        mock_js.publish.assert_awaited_once()
+        _, kwargs = mock_js.publish.call_args
+        assert kwargs["timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_publish_default_timeout(self) -> None:
+        pub = Publisher()
+        mock_js = AsyncMock()
+        pub._js = mock_js
+
+        await pub.publish(self._make_payload())
+        _, kwargs = mock_js.publish.call_args
+        assert kwargs["timeout"] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_publish_raises_when_not_connected(self) -> None:
+        pub = Publisher()
+        with pytest.raises(RuntimeError, match="not connected"):
+            await pub.publish(self._make_payload())


### PR DESCRIPTION
## Summary

- Add `NATS_CONNECT_TIMEOUT` (default 5s), `NATS_PUBLISH_TIMEOUT` (default 5s), and `AGAMEMNON_TIMEOUT` (default 10s) to `Settings` in `config.py`
- Pass `connect_timeout` to `nats.connect()` in `Publisher.connect()`
- Pass `timeout` to `self._js.publish()` in `Publisher.publish()`
- Thread the configured timeouts through `server.py` (lifespan startup and webhook handler)
- Add `tests/test_timeouts.py` with 11 tests covering defaults, env var overrides, and timeout propagation into NATS calls

## Test plan

- [x] `TestTimeoutSettings` — verifies defaults and env var overrides for all three timeout settings
- [x] `TestPublisherConnectTimeout` — verifies `connect_timeout` is forwarded to `nats.connect()`
- [x] `TestPublisherPublishTimeout` — verifies `timeout` is forwarded to `js.publish()`
- [x] All 30 tests pass (`pixi run python -m pytest tests/ -v`)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)