### PR TITLE
feat(server): add startup banner logging with version and config summary

### DIFF
--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -27,6 +27,7 @@ class Publisher:
         self._nc: NATSClient | None = None
         self._js: JetStreamContext | None = None
         self._active_subjects: set[str] = set()
+        self._stream_names: list[str] = []
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -52,6 +53,7 @@ class Publisher:
             except Exception:
                 await jsm.add_stream(StreamConfig(name=name, subjects=subjects))
                 logger.info("Created JetStream stream: %s (%s)", name, subjects)
+            self._stream_names.append(name)
 
     async def disconnect(self) -> None:
         """Drain and close the NATS connection."""
@@ -68,6 +70,10 @@ class Publisher:
     @property
     def active_subjects(self) -> list[str]:
         return sorted(self._active_subjects)
+
+    @property
+    def stream_names(self) -> list[str]:
+        return list(self._stream_names)
 
     # ------------------------------------------------------------------
     # Publishing

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -11,6 +11,7 @@ from typing import Annotated, AsyncGenerator
 
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 
+from hermes import __version__
 from hermes.config import Settings, get_settings
 from hermes.models import WebhookPayload
 from hermes.publisher import Publisher
@@ -32,6 +33,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     except Exception as exc:  # noqa: BLE001
         logger.warning("Could not connect to NATS at %s: %s", settings.nats_url, exc)
 
+    _log_startup_banner(publisher, settings)
     app.state.publisher = publisher
     yield
     await publisher.disconnect()
@@ -109,6 +111,40 @@ async def list_subjects() -> dict[str, list[str]]:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _mask_secret(value: str, show_chars: int = 4) -> str:
+    """Mask a secret value, showing only the first ``show_chars`` characters."""
+    if not value:
+        return "(not set)"
+    if len(value) <= show_chars:
+        return "****"
+    return value[:show_chars] + "****"
+
+
+def _log_startup_banner(publisher: Publisher, settings: Settings | None = None) -> None:
+    """Log version, active configuration, and NATS connectivity on startup."""
+    if settings is None:
+        settings = get_settings()
+    logger.info("hermes version=%s", __version__)
+    logger.info(
+        "config nats_url=%s port=%s",
+        settings.nats_url,
+        settings.hermes_port,
+    )
+    logger.info(
+        "secrets webhook_secret=%s",
+        _mask_secret(settings.webhook_secret),
+    )
+    logger.info(
+        "hmac_validation=%s",
+        "enabled" if settings.webhook_secret else "disabled",
+    )
+    logger.info(
+        "nats connected=%s streams=%s",
+        publisher.is_connected,
+        publisher.stream_names,
+    )
 
 
 def _verify_signature(body: bytes, provided: str, settings: Settings) -> None:

--- a/tests/test_startup_banner.py
+++ b/tests/test_startup_banner.py
@@ -1,0 +1,183 @@
+"""Tests for the startup banner logging."""
+
+from __future__ import annotations
+
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+class TestMaskSecret:
+    def test_empty_string_returns_not_set(self) -> None:
+        from hermes.server import _mask_secret
+
+        assert _mask_secret("") == "(not set)"
+
+    def test_short_value_fully_masked(self) -> None:
+        from hermes.server import _mask_secret
+
+        assert _mask_secret("abc") == "****"
+
+    def test_exact_show_chars_fully_masked(self) -> None:
+        from hermes.server import _mask_secret
+
+        assert _mask_secret("abcd") == "****"
+
+    def test_longer_value_shows_prefix(self) -> None:
+        from hermes.server import _mask_secret
+
+        assert _mask_secret("abcdefgh") == "abcd****"
+
+    def test_zero_show_chars_fully_masks(self) -> None:
+        from hermes.server import _mask_secret
+
+        assert _mask_secret("supersecret", show_chars=0) == "****"
+
+    def test_custom_show_chars(self) -> None:
+        from hermes.server import _mask_secret
+
+        assert _mask_secret("abcdefgh", show_chars=2) == "ab****"
+
+
+class TestLogStartupBanner:
+    def _make_publisher(
+        self,
+        is_connected: bool = True,
+        stream_names: list[str] | None = None,
+    ) -> MagicMock:
+        from hermes.publisher import Publisher
+
+        mock = MagicMock(spec=Publisher)
+        mock.is_connected = is_connected
+        mock.stream_names = stream_names if stream_names is not None else ["homeric-agents", "homeric-tasks"]
+        return mock
+
+    def test_banner_logs_version(self) -> None:
+        from hermes import __version__
+        from hermes.server import _log_startup_banner
+
+        publisher = self._make_publisher()
+        with patch("hermes.server.logger") as mock_logger:
+            _log_startup_banner(publisher)
+
+        all_calls = mock_logger.info.call_args_list
+        first_call = all_calls[0]
+        assert "version=%s" in first_call.args[0]
+        assert __version__ in first_call.args[1:]
+
+    def test_banner_logs_nats_url(self) -> None:
+        from hermes.server import _log_startup_banner
+        from hermes.config import get_settings
+
+        settings = get_settings()
+        publisher = self._make_publisher()
+        with patch("hermes.server.logger") as mock_logger:
+            _log_startup_banner(publisher, settings)
+
+        all_info_args = [str(c) for c in mock_logger.info.call_args_list]
+        assert any(settings.nats_url in a for a in all_info_args)
+
+    def test_banner_logs_port(self) -> None:
+        from hermes.server import _log_startup_banner
+        from hermes.config import get_settings
+
+        settings = get_settings()
+        publisher = self._make_publisher()
+        with patch("hermes.server.logger") as mock_logger:
+            _log_startup_banner(publisher, settings)
+
+        all_info_args = [str(c) for c in mock_logger.info.call_args_list]
+        assert any(str(settings.hermes_port) in a for a in all_info_args)
+
+    def test_banner_masks_webhook_secret(self) -> None:
+        from hermes.server import _log_startup_banner
+        from hermes.config import Settings
+
+        settings = Settings(webhook_secret="abcdefgh")
+        publisher = self._make_publisher()
+        with patch("hermes.server.logger") as mock_logger:
+            _log_startup_banner(publisher, settings)
+
+        all_info_args = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("abcd****" in a for a in all_info_args)
+        assert not any("abcdefgh" in a for a in all_info_args)
+
+    def test_banner_shows_not_set_for_empty_webhook_secret(self) -> None:
+        from hermes.server import _log_startup_banner
+        from hermes.config import Settings
+
+        settings = Settings(webhook_secret="")
+        publisher = self._make_publisher()
+        with patch("hermes.server.logger") as mock_logger:
+            _log_startup_banner(publisher, settings)
+
+        all_info_args = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("(not set)" in a for a in all_info_args)
+
+    def test_banner_shows_hmac_enabled(self) -> None:
+        from hermes.server import _log_startup_banner
+        from hermes.config import Settings
+
+        settings = Settings(webhook_secret="mysecret")
+        publisher = self._make_publisher()
+        with patch("hermes.server.logger") as mock_logger:
+            _log_startup_banner(publisher, settings)
+
+        all_info_args = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("enabled" in a for a in all_info_args)
+
+    def test_banner_shows_hmac_disabled(self) -> None:
+        from hermes.server import _log_startup_banner
+        from hermes.config import Settings
+
+        settings = Settings(webhook_secret="")
+        publisher = self._make_publisher()
+        with patch("hermes.server.logger") as mock_logger:
+            _log_startup_banner(publisher, settings)
+
+        all_info_args = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("disabled" in a for a in all_info_args)
+
+    def test_banner_logs_nats_connected_true(self) -> None:
+        from hermes.server import _log_startup_banner
+
+        publisher = self._make_publisher(is_connected=True)
+        with patch("hermes.server.logger") as mock_logger:
+            _log_startup_banner(publisher)
+
+        all_info_args = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("True" in a for a in all_info_args)
+
+    def test_banner_logs_nats_connected_false(self) -> None:
+        from hermes.server import _log_startup_banner
+
+        publisher = self._make_publisher(is_connected=False)
+        with patch("hermes.server.logger") as mock_logger:
+            _log_startup_banner(publisher)
+
+        all_info_args = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("False" in a for a in all_info_args)
+
+    def test_banner_logs_stream_names(self) -> None:
+        from hermes.server import _log_startup_banner
+
+        streams = ["homeric-agents", "homeric-tasks"]
+        publisher = self._make_publisher(stream_names=streams)
+        with patch("hermes.server.logger") as mock_logger:
+            _log_startup_banner(publisher)
+
+        all_info_args = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("homeric-agents" in a for a in all_info_args)
+        assert any("homeric-tasks" in a for a in all_info_args)
+
+    def test_banner_logs_empty_streams_when_not_connected(self) -> None:
+        from hermes.server import _log_startup_banner
+
+        publisher = self._make_publisher(is_connected=False, stream_names=[])
+        with patch("hermes.server.logger") as mock_logger:
+            _log_startup_banner(publisher)
+
+        # Should still log the nats line — just with empty list
+        assert mock_logger.info.call_count >= 4


### PR DESCRIPTION
## Summary

- Adds `_mask_secret()` helper that redacts secrets — shows first 4 chars + `****`, or `(not set)` when unset
- Adds `_log_startup_banner(publisher)` that logs version, NATS URL, port, masked `WEBHOOK_SECRET`, HMAC validation status, and NATS connection/stream names using `key=value` structured format
- Calls the banner from `lifespan()` after the NATS connection attempt so operators always see the full config summary on startup (even when NATS is unavailable)
- Adds `stream_names: list[str]` property to `Publisher`, populated in `_ensure_streams()`, so the banner can report which JetStream streams are active

## Test plan

- [x] 17 new unit tests in `tests/test_startup_banner.py` covering `_mask_secret` edge cases (empty, short, exact, custom `show_chars`) and all `_log_startup_banner` log lines (version, config values, masking, HMAC status, NATS connected/disconnected, stream names)
- [x] All 36 tests pass (`pixi run python -m pytest tests/ -v`)
- [x] `pixi run lint` passes with no violations

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)