### PR TITLE
feat(hermes): add __main__.py entry point for python -m hermes

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ default:
 
 # Start the Hermes server (production mode)
 start:
-    pixi run python -m hermes.server
+    pixi run python -m hermes
 
 # Start with hot-reload for development
 dev:

--- a/src/hermes/__main__.py
+++ b/src/hermes/__main__.py
@@ -1,0 +1,61 @@
+"""Entry point for ``python -m hermes``."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments, falling back to environment-variable defaults."""
+    from hermes.config import get_settings
+
+    settings = get_settings()
+
+    parser = argparse.ArgumentParser(
+        prog="hermes",
+        description="ProjectHermes — bridges external webhooks to NATS JetStream.",
+    )
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="Host interface to bind (default: 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=settings.hermes_port,
+        help=f"Port to listen on (default: {settings.hermes_port})",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="info",
+        choices=["debug", "info", "warning", "error", "critical"],
+        help="Logging level (default: info)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Configure logging and start the uvicorn server."""
+    import uvicorn
+
+    args = _parse_args(argv)
+
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        stream=sys.stdout,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    uvicorn.run(
+        "hermes.server:app",
+        host=args.host,
+        port=args.port,
+        log_level=args.log_level,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,75 @@
+"""Tests for src/hermes/__main__.py entry point."""
+
+from __future__ import annotations
+
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from hermes.__main__ import _parse_args, main  # noqa: E402
+
+
+class TestParseArgs:
+    def test_defaults(self) -> None:
+        args = _parse_args([])
+        assert args.host == "0.0.0.0"
+        assert args.log_level == "info"
+
+    def test_custom_host(self) -> None:
+        args = _parse_args(["--host", "127.0.0.1"])
+        assert args.host == "127.0.0.1"
+
+    def test_custom_port(self) -> None:
+        args = _parse_args(["--port", "9000"])
+        assert args.port == 9000
+
+    def test_custom_log_level(self) -> None:
+        args = _parse_args(["--log-level", "debug"])
+        assert args.log_level == "debug"
+
+    @pytest.mark.parametrize("level", ["debug", "info", "warning", "error", "critical"])
+    def test_all_log_levels_accepted(self, level: str) -> None:
+        args = _parse_args(["--log-level", level])
+        assert args.log_level == level
+
+    def test_invalid_log_level_raises(self) -> None:
+        with pytest.raises(SystemExit):
+            _parse_args(["--log-level", "verbose"])
+
+    def test_port_default_matches_settings(self) -> None:
+        from hermes.config import get_settings
+
+        args = _parse_args([])
+        assert args.port == get_settings().hermes_port
+
+
+class TestMain:
+    def test_main_calls_uvicorn_run(self) -> None:
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}):
+            main(["--port", "9090", "--host", "127.0.0.1", "--log-level", "warning"])
+
+        mock_uvicorn.run.assert_called_once_with(
+            "hermes.server:app",
+            host="127.0.0.1",
+            port=9090,
+            log_level="warning",
+        )
+
+    def test_main_default_args(self) -> None:
+        from hermes.config import get_settings
+
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}):
+            main([])
+
+        mock_uvicorn.run.assert_called_once_with(
+            "hermes.server:app",
+            host="0.0.0.0",
+            port=get_settings().hermes_port,
+            log_level="info",
+        )


### PR DESCRIPTION
## Summary

- Creates `src/hermes/__main__.py` as the conventional Python package entry point
- Moves `uvicorn.run()` and logging setup out of `server.py`'s `__main__` guard into `__main__.py`
- Adds CLI argument parsing: `--host`, `--port`, `--log-level`
- Updates `justfile` `start` recipe from `python -m hermes.server` to `python -m hermes`
- Removes `if __name__ == "__main__"` block from `server.py` so it contains only FastAPI app definition

## Test plan

- [ ] `pixi run python -m pytest tests/ -v` — 32 tests pass (13 new in `tests/test_main.py`)
- [ ] `just start` continues to work (uses `python -m hermes`)
- [ ] `server.py` contains only FastAPI app definition, no CLI logic

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)