### PR TITLE
refactor(config): decouple Settings singleton via FastAPI dependency injection

### DIFF
--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -19,4 +21,7 @@ class Settings(BaseSettings):
     webhook_secret: str = ""
 
 
-settings = Settings()
+@lru_cache
+def get_settings() -> Settings:
+    """Return the cached Settings instance."""
+    return Settings()

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -7,11 +7,11 @@ import hmac
 import logging
 import sys
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator
+from typing import Annotated, AsyncGenerator
 
-from fastapi import FastAPI, HTTPException, Request, status
+from fastapi import Depends, FastAPI, HTTPException, Request, status
 
-from hermes.config import settings
+from hermes.config import Settings, get_settings
 from hermes.models import WebhookPayload
 from hermes.publisher import Publisher
 
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Connect to NATS on startup; disconnect cleanly on shutdown."""
+    settings = get_settings()
     publisher = Publisher()
     try:
         await publisher.connect(settings.nats_url)
@@ -47,6 +48,12 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+
+SettingsDep = Annotated[Settings, Depends(get_settings)]
+
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -64,13 +71,13 @@ async def health() -> dict[str, object]:
 
 
 @app.post("/webhook", status_code=status.HTTP_202_ACCEPTED)
-async def receive_webhook(request: Request) -> dict[str, str]:
+async def receive_webhook(request: Request, settings: SettingsDep) -> dict[str, str]:
     """Receive an external webhook, validate its signature, and publish to NATS."""
     raw_body = await request.body()
 
     # HMAC validation (skipped when no secret is configured)
     if settings.webhook_secret:
-        _verify_signature(raw_body, request.headers.get("X-Webhook-Signature", ""))
+        _verify_signature(raw_body, request.headers.get("X-Webhook-Signature", ""), settings)
 
     try:
         payload = WebhookPayload.model_validate_json(raw_body)
@@ -104,7 +111,7 @@ async def list_subjects() -> dict[str, list[str]]:
 # ---------------------------------------------------------------------------
 
 
-def _verify_signature(body: bytes, provided: str) -> None:
+def _verify_signature(body: bytes, provided: str, settings: Settings) -> None:
     """Raise HTTP 401 if the HMAC-SHA256 signature does not match."""
     expected = hmac.new(
         settings.webhook_secret.encode(),
@@ -126,8 +133,9 @@ if __name__ == "__main__":
     import uvicorn
 
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    _settings = get_settings()
     uvicorn.run(
         "hermes.server:app",
         host="0.0.0.0",
-        port=settings.hermes_port,
+        port=_settings.hermes_port,
     )

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -26,7 +26,7 @@ def _build_client() -> TestClient:
     """Build a TestClient with a mocked Publisher and a known webhook secret."""
     from hermes.server import app
     from hermes.publisher import Publisher
-    from hermes.config import settings
+    from hermes.config import Settings, get_settings
 
     mock_publisher = MagicMock(spec=Publisher)
     mock_publisher.is_connected = True
@@ -35,8 +35,12 @@ def _build_client() -> TestClient:
 
     # Inject the mock before the test client starts
     app.state.publisher = mock_publisher
-    # Set a known secret so tests can compute valid signatures
-    settings.webhook_secret = _TEST_SECRET
+
+    # Override the settings dependency so tests never touch shared state
+    def override_get_settings() -> Settings:
+        return Settings(webhook_secret=_TEST_SECRET)
+
+    app.dependency_overrides[get_settings] = override_get_settings
     return TestClient(app, raise_server_exceptions=True)
 
 


### PR DESCRIPTION
## Summary

- Replace module-level `settings = Settings()` singleton in `config.py` with a `get_settings()` function decorated with `@lru_cache`
- Update `server.py` to inject `Settings` via `Depends(get_settings)` in the `/webhook` route handler and pass it explicitly to `_verify_signature()`
- Update `tests/test_webhook.py` to use `app.dependency_overrides[get_settings]` instead of directly mutating `settings.webhook_secret`, eliminating test pollution

## Test plan

- [ ] Run `pixi run python -m pytest tests/ -v` — all 19 tests pass
- [ ] Run with `pytest --randomly` to confirm tests pass in any order
- [ ] No module-level `Settings()` instantiation remains
- [ ] No test directly mutates a shared settings object

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)