### PR TITLE
docs: document endpoints, timeouts, TLS, subject constraints, dead-letter stream, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,9 @@ NATS JetStream (via ProjectKeystone)
     │
     ├──► Argus      (observability)
     ├──► Agamemnon  (coordination)
-    └──► Telemachy  (workflow engine)
+    ├──► Telemachy  (workflow engine)
+    │
+    └──► homeric-deadletter (unknown event types)
 ```
 
 **Subject schema:**
@@ -35,14 +37,21 @@ NATS JetStream (via ProjectKeystone)
 sanitised and truncated to **64 characters** (`_SLUG_MAX_LEN = 64` in `publisher.py`).
 Values that exceed 64 characters are silently truncated before routing.
 
+Unknown event types are routed to the `homeric-deadletter` NATS stream for inspection and replay.
+
 ## Configuration
 
-| Variable          | Default                        | Description                                             |
-|-------------------|--------------------------------|---------------------------------------------------------|
-| NATS_URL          | nats://localhost:4222          | NATS server URL                                         |
-| HERMES_PORT       | 8080                           | Port Hermes listens on                                  |
-| HERMES_PUBLIC_URL | http://localhost:{HERMES_PORT} | Externally-reachable base URL for the /webhook endpoint |
-| WEBHOOK_SECRET    |                                | HMAC secret for webhook validation                      |
+| Variable              | Default                        | Description                                             |
+|-----------------------|--------------------------------|---------------------------------------------------------|
+| NATS_URL              | nats://localhost:4222          | NATS server URL                                         |
+| HERMES_HOST           | 127.0.0.1                     | Host/IP the server binds to                             |
+| HERMES_PORT           | 8080                           | Port Hermes listens on                                  |
+| HERMES_PUBLIC_URL     | http://localhost:{HERMES_PORT} | Externally-reachable base URL for the /webhook endpoint |
+| WEBHOOK_SECRET        |                                | HMAC secret for webhook validation                      |
+| NATS_CONNECT_TIMEOUT  | 5.0                            | NATS connection timeout in seconds                      |
+| NATS_PUBLISH_TIMEOUT  | 5.0                            | NATS publish timeout in seconds                         |
+| AGAMEMNON_TIMEOUT     | 10.0                           | Agamemnon API call timeout in seconds                   |
+| SHUTDOWN_TIMEOUT      | 10.0                           | Graceful shutdown timeout in seconds                    |
 
 Configure external services to POST to `http://<hermes-host>:<HERMES_PORT>/webhook`.
 
@@ -66,4 +75,6 @@ just lint       # ruff check src tests
 just format     # ruff format src tests
 just health     # curl /health endpoint
 just nats-start # start NATS server
+
+python -m hermes # alternative to 'just start' — runs the server directly
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Unknown event types are routed to the `homeric-deadletter` NATS stream for inspe
 | HERMES_HOST           | 127.0.0.1                     | Host/IP the server binds to                             |
 | HERMES_PORT           | 8080                           | Port Hermes listens on                                  |
 | HERMES_PUBLIC_URL     | http://localhost:{HERMES_PORT} | Externally-reachable base URL for the /webhook endpoint |
-| WEBHOOK_SECRET        |                                | HMAC secret for webhook validation                      |
+| WEBHOOK_SECRET        |                                | HMAC secret for webhook validation (minimum 32 characters) |
 | NATS_CONNECT_TIMEOUT  | 5.0                            | NATS connection timeout in seconds                      |
 | NATS_PUBLISH_TIMEOUT  | 5.0                            | NATS publish timeout in seconds                         |
 | AGAMEMNON_TIMEOUT     | 10.0                           | Agamemnon API call timeout in seconds                   |
@@ -63,6 +63,7 @@ Configure external services to POST to `http://<hermes-host>:<HERMES_PORT>/webho
 4. **Async throughout** — FastAPI + nats-py are both async; never block the event loop.
 5. **Config via environment** — All tunables come from env vars / `.env`; no hard-coded URLs.
 6. **Pin dependency versions** — use `">=X.Y,<NEXT_MAJOR"` ranges in `pixi.toml`; never use `"*"`. Lower bound at the minor version level of the minimum supported version, upper bound at the next major to prevent breaking changes.
+7. **Subject sanitization** — NATS subject tokens are sanitized via `_slug()`: spaces become hyphens, dots become hyphens, and wildcards (`*` and `>`) are stripped entirely. Tokens are lowercased and subject strings are typically capped at 64 characters.
 
 ## Common Commands
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ hi.tasks.{team_id}.{task_id}.{event}
 
 Example: `hi.tasks.team-alpha.task-42.updated`
 
+## Endpoints
+
+Hermes exposes several endpoints for webhooks, health checks, and observability:
+
+| Endpoint         | Method | Description                                                                         | Status Code |
+|------------------|--------|-------------------------------------------------------------------------------------| ----------- |
+| `/webhook`       | POST   | Accept and validate incoming webhooks; publishes to NATS                            | 200 / 401 / 422 |
+| `/health`        | GET    | Service health check; returns NATS connection status                                | 200 / 503   |
+| `/ready`         | GET    | Readiness probe for orchestrators (Kubernetes, Docker Compose)                      | 200 / 503   |
+| `/metrics`       | GET    | Prometheus metrics (counter, gauge, histogram)                                      | 200         |
+| `/subjects`      | GET    | List all NATS subjects published to in this session                                 | 200         |
+| `/events`        | GET    | Canonical list of supported webhook event types (agent_events, task_events)         | 200         |
+| `/dead-letters`  | GET    | View in-memory dead-letter queue of unroutable events                               | 200         |
+
+### Health Checks
+
+- **`/health`** returns `200 OK` when NATS is connected, `503 Service Unavailable` when disconnected. Use this for liveness probes and metrics scraping (e.g., Prometheus).
+- **`/ready`** returns `200 OK` when ready to accept webhooks (NATS connected), `503 Service Unavailable` otherwise. Use for Kubernetes readiness probes.
+
 ## Configuration
 
 Copy `.env.example` to `.env` and fill in values:
@@ -116,6 +135,27 @@ If connection issues occur, check:
 2. Network connectivity and firewall rules
 3. TLS configuration if using `tls://` scheme
 4. Application logs for specific error messages
+
+## TLS Configuration
+
+For production deployments, Hermes can be configured to use TLS for NATS connections. Set the following environment variables:
+
+| Variable       | Description                                                            |
+|----------------|------------------------------------------------------------------------|
+| TLS_CA_BUNDLE  | Path to CA certificate bundle file (for server certificate validation) |
+| TLS_CERT_FILE  | Path to client certificate file (for mTLS)                            |
+| TLS_KEY_FILE   | Path to client private key file (for mTLS)                            |
+| TLS_VERIFY     | Enable/disable hostname verification (default: true)                  |
+
+Example with mTLS (mutual TLS):
+
+```bash
+export NATS_URL=tls://nats.example.com:4222
+export TLS_CERT_FILE=/etc/hermes/certs/client-cert.pem
+export TLS_KEY_FILE=/etc/hermes/certs/client-key.pem
+export TLS_CA_BUNDLE=/etc/hermes/certs/ca-bundle.crt
+just start
+```
 
 ## Development
 


### PR DESCRIPTION
Closes #83
Closes #86
Closes #134
Closes #155
Closes #186
Closes #218
Closes #234
Closes #242
Closes #252
Closes #253

Documents /health and /ready semantics, NATS subject sanitization constraints, WEBHOOK_SECRET minimum length, TLS configuration, all timeout env vars, HERMES_HOST, `python -m hermes` usage, dead-letter stream architecture, and adds Dependabot config for automated pip version bumps.