### PR TITLE
fix(publisher): prevent stream_names duplicates on reconnect

### DIFF
--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -88,7 +88,8 @@ class Publisher:
             except NotFoundError:
                 await jsm.add_stream(StreamConfig(name=name, subjects=subjects))
                 logger.info("Created JetStream stream: %s (%s)", name, subjects)
-            self._stream_names.append(name)
+            if name not in self._stream_names:
+                self._stream_names.append(name)
 
     async def disconnect(self) -> None:
         """Drain and close the NATS connection."""

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -136,6 +136,20 @@ class TestEnsureStreams:
         assert names == {"homeric-agents", "homeric-tasks", "homeric-deadletter"}
 
     @pytest.mark.asyncio
+    async def test_stream_names_no_duplicates_on_repeated_ensure(self) -> None:
+        pub = self._make_connected_publisher()
+        jsm = AsyncMock()
+        jsm.stream_info = AsyncMock(return_value=MagicMock())
+        jsm.add_stream = AsyncMock()
+        pub._nc.jsm.return_value = jsm
+
+        await pub._ensure_streams()
+        initial_count = len(pub._stream_names)
+        await pub._ensure_streams()
+
+        assert len(pub._stream_names) == initial_count
+
+    @pytest.mark.asyncio
     async def test_non_notfounderror_propagates(self) -> None:
         pub = self._make_connected_publisher()
         jsm = AsyncMock()


### PR DESCRIPTION
Closes #247

Guards the `_stream_names` append in `_ensure_streams()` to only add each stream name once, preventing duplicate accumulation across reconnects.

## Changes
- `src/hermes/publisher.py`: wrap `self._stream_names.append(name)` with a guard so each name is added at most once
- `tests/test_publisher.py`: add `test_stream_names_no_duplicates_on_repeated_ensure` that calls `_ensure_streams()` twice and asserts no duplicates

## Test plan
- [ ] `pixi run pytest -m "not integration" --tb=short -q` passes (170 passed)