### PR TITLE
feat(__main__): add --reload flag for development hot-reload

### DIFF
--- a/src/hermes/__main__.py
+++ b/src/hermes/__main__.py
@@ -34,6 +34,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         choices=["debug", "info", "warning", "error", "critical"],
         help="Logging level (default: info)",
     )
+    parser.add_argument(
+        "--reload",
+        action="store_true",
+        help="Enable hot-reload (development mode)",
+    )
     return parser.parse_args(argv)
 
 
@@ -54,6 +59,7 @@ def main(argv: list[str] | None = None) -> None:
         host=args.host,
         port=args.port,
         log_level=args.log_level,
+        reload=args.reload,
     )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,6 +18,11 @@ class TestParseArgs:
         args = _parse_args([])
         assert args.host == "0.0.0.0"
         assert args.log_level == "info"
+        assert args.reload is False
+
+    def test_reload_flag(self) -> None:
+        args = _parse_args(["--reload"])
+        assert args.reload is True
 
     def test_custom_host(self) -> None:
         args = _parse_args(["--host", "127.0.0.1"])
@@ -58,6 +63,7 @@ class TestMain:
             host="127.0.0.1",
             port=9090,
             log_level="warning",
+            reload=False,
         )
 
     def test_main_default_args(self) -> None:
@@ -72,4 +78,26 @@ class TestMain:
             host="0.0.0.0",
             port=get_settings().hermes_port,
             log_level="info",
+            reload=False,
         )
+
+    def test_main_reload_flag(self) -> None:
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}):
+            main(["--reload"])
+
+        mock_uvicorn.run.assert_called_once_with(
+            "hermes.server:app",
+            host="0.0.0.0",
+            port=mock_uvicorn.run.call_args[1]["port"],
+            log_level="info",
+            reload=True,
+        )
+
+    def test_main_no_reload_flag(self) -> None:
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}):
+            main([])
+
+        _, kwargs = mock_uvicorn.run.call_args
+        assert kwargs.get("reload") is False


### PR DESCRIPTION
Closes #251

Adds `--reload` CLI flag to `python -m hermes` so developers can start in hot-reload mode without using `just dev`. Equivalent to the uvicorn `--reload` option.