### PR TITLE
feat(health): expose dead-letter count and timeouts in /health

### DIFF
--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -31,6 +31,14 @@ class WebhookPayload(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class TimeoutSettings(BaseModel):
+    """Timeout values (seconds) surfaced in /health for observability."""
+
+    nats_connect: float
+    nats_publish: float
+    agamemnon: float
+
+
 class HealthResponse(BaseModel):
     """Response body for GET /health."""
 
@@ -40,6 +48,8 @@ class HealthResponse(BaseModel):
     hmac_validation_enabled: bool = False
     hermes_public_url: str | None = None
     inflight_requests: int = 0
+    dead_letter_count: int = 0
+    timeouts: TimeoutSettings | None = None
 
 
 class WebhookAcceptedResponse(BaseModel):

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -117,6 +117,10 @@ class Publisher:
     def dead_letters(self) -> list[dict[str, Any]]:
         return list(self._dead_letters)
 
+    @property
+    def dead_letter_count(self) -> int:
+        return len(self._dead_letters)
+
     # ------------------------------------------------------------------
     # Publishing
     # ------------------------------------------------------------------

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -27,6 +27,7 @@ from hermes.models import (
     ErrorResponse,
     HealthResponse,
     SubjectsResponse,
+    TimeoutSettings,
     VersionResponse,
     WebhookAcceptedResponse,
     WebhookPayload,
@@ -238,6 +239,12 @@ async def health(response: Response) -> HealthResponse:
         hmac_validation_enabled=bool(cfg.webhook_secret),
         hermes_public_url=cfg.hermes_public_url,
         inflight_requests=_inflight,
+        dead_letter_count=publisher.dead_letter_count,
+        timeouts=TimeoutSettings(
+            nats_connect=cfg.nats_connect_timeout,
+            nats_publish=cfg.nats_publish_timeout,
+            agamemnon=cfg.agamemnon_timeout,
+        ),
     )
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -27,6 +27,7 @@ def _build_client(*, connected: bool = True) -> TestClient:
     mock_publisher = MagicMock(spec=Publisher)
     mock_publisher.is_connected = connected
     mock_publisher.active_subjects = []
+    mock_publisher.dead_letter_count = 0
     mock_publisher.publish = AsyncMock()
 
     # Inject the mock before the test client starts
@@ -83,6 +84,35 @@ class TestHealthEndpoint:
         assert "inflight_requests" in body
         assert isinstance(body["inflight_requests"], int)
         assert body["inflight_requests"] >= 0
+
+    def test_health_includes_timeout_fields(self) -> None:
+        client = _build_client()
+        body = client.get("/health").json()
+        assert "timeouts" in body
+        assert body["timeouts"]["nats_connect"] > 0
+        assert body["timeouts"]["nats_publish"] > 0
+        assert body["timeouts"]["agamemnon"] > 0
+
+    def test_health_includes_dead_letter_count(self) -> None:
+        client = _build_client()
+        body = client.get("/health").json()
+        assert "dead_letter_count" in body
+        assert isinstance(body["dead_letter_count"], int)
+
+    def test_health_dead_letter_count_reflects_publisher(self) -> None:
+        from hermes.publisher import Publisher
+        from hermes.server import app
+
+        mock_publisher = MagicMock(spec=Publisher)
+        mock_publisher.is_connected = True
+        mock_publisher.active_subjects = []
+        mock_publisher.dead_letter_count = 7
+        mock_publisher.publish = AsyncMock()
+        app.state.publisher = mock_publisher
+
+        client = TestClient(app, raise_server_exceptions=True)
+        body = client.get("/health").json()
+        assert body["dead_letter_count"] == 7
 
 
 class TestReadyEndpoint:


### PR DESCRIPTION
Closes #254
Closes #239

Adds `dead_letter_count` (messages routed to homeric-deadletter stream) and `timeouts` (nats_connect, nats_publish, agamemnon) to the /health endpoint response.

## Summary
- `TimeoutSettings` model added to `models.py` with `nats_connect`, `nats_publish`, `agamemnon` float fields
- `HealthResponse` extended with `dead_letter_count: int = 0` and `timeouts: TimeoutSettings | None = None`
- `Publisher.dead_letter_count` property exposes the in-memory dead-letter deque length
- `/health` handler populates both new fields from the publisher and settings
- 3 new tests cover timeout fields, dead_letter_count presence, and count reflection

## Test plan
- [x] `pixi run pytest -m "not integration" --tb=short -q` — 172 passed
- [x] Existing health tests pass unchanged
- [x] `test_health_includes_timeout_fields` — all three timeout subfields > 0
- [x] `test_health_includes_dead_letter_count` — field present and is int
- [x] `test_health_dead_letter_count_reflects_publisher` — count mirrors publisher state

🤖 Generated with [Claude Code](https://claude.com/claude-code)