### PR TITLE
feat(server): add GET /version endpoint

### DIFF
--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -68,3 +68,9 @@ class ErrorResponse(BaseModel):
     """Standard error response body."""
 
     detail: str
+
+
+class VersionResponse(BaseModel):
+    """Response body for GET /version."""
+
+    version: str

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -25,6 +25,7 @@ from hermes.models import (
     ErrorResponse,
     HealthResponse,
     SubjectsResponse,
+    VersionResponse,
     WebhookAcceptedResponse,
     WebhookPayload,
 )
@@ -217,6 +218,12 @@ async def health(response: Response) -> HealthResponse:
         hmac_validation_enabled=bool(cfg.webhook_secret),
         hermes_public_url=cfg.hermes_public_url,
     )
+
+
+@app.get("/version", response_model=VersionResponse)
+async def get_version() -> VersionResponse:
+    """Return the installed package version."""
+    return VersionResponse(version=__version__)
 
 
 @app.get("/ready", responses={503: {"model": ErrorResponse, "description": "NATS not connected"}})

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -217,3 +217,17 @@ class TestSubjectsEndpoint:
         body = client.get("/subjects").json()
         assert "subjects" in body
         assert isinstance(body["subjects"], list)
+
+
+class TestVersionEndpoint:
+    def test_version_returns_200(self) -> None:
+        client = _build_client()
+        resp = client.get("/version")
+        assert resp.status_code == 200
+
+    def test_version_body_has_version_key(self) -> None:
+        client = _build_client()
+        data = client.get("/version").json()
+        assert "version" in data
+        assert isinstance(data["version"], str)
+        assert len(data["version"]) > 0


### PR DESCRIPTION
## Summary
- Adds `GET /version` endpoint returning `{"version": "<semver>"}` with status 200
- Version sourced from `hermes.__version__` (already backed by `importlib.metadata`)
- Adds `VersionResponse` Pydantic model to `models.py`
- Two new tests in `TestVersionEndpoint` covering status code and response shape

## Test plan
- [x] `pixi run pytest -m "not integration" --tb=short -q` — 171 passed, 98% coverage

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)