### PR TITLE
fix(publisher): guard empty _slug() output with 'unknown' fallback

### DIFF
--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -194,16 +194,16 @@ class Publisher:
         Falls back to ``unknown`` tokens when fields are missing so messages
         are never silently dropped due to incomplete payloads.
         """
-        host = _slug(data.get("hostId") or data.get("host") or "unknown")
-        name = _slug(data.get("name") or "unknown")
+        host = _slug(data.get("hostId") or data.get("host") or "unknown") or "unknown"
+        name = _slug(data.get("name") or "unknown") or "unknown"
         # Strip the "agent." prefix to get the bare verb (created/updated/deleted)
         verb = event.split(".", 1)[-1] if "." in event else event
         return f"hi.agents.{host}.{name}.{verb}"
 
     def _parse_task_subject(self, data: dict[str, Any], event: str) -> str:
         """Build ``hi.tasks.{team_id}.{task_id}.{event}`` from task event data."""
-        team_id = _slug(data.get("teamId") or data.get("team_id") or "unknown")
-        task_id = _slug(data.get("id") or data.get("task_id") or "unknown")
+        team_id = _slug(data.get("teamId") or data.get("team_id") or "unknown") or "unknown"
+        task_id = _slug(data.get("id") or data.get("task_id") or "unknown") or "unknown"
         verb = event.split(".", 1)[-1] if "." in event else event
         return f"hi.tasks.{team_id}.{task_id}.{verb}"
 

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from nats.js.errors import NotFoundError
 
+from hermes.models import WebhookPayload
 from hermes.publisher import Publisher, _slug
 
 
@@ -181,6 +182,32 @@ class TestSlugSanitisation:
         )
         assert ">" not in subject
         assert subject == "hi.agents.myhost.all.created"
+
+    def test_all_wildcards_fall_back_to_unknown(self) -> None:
+        pub = _make_publisher()
+        payload = WebhookPayload(
+            event="agent.created",
+            data={"host": "***", "name": ">>>"},
+            timestamp="2026-04-23T00:00:00Z",
+        )
+        subject = pub._resolve_subject(payload)
+        assert subject is not None
+        parts = subject.split(".")
+        assert all(p for p in parts), f"Empty token in subject: {subject}"
+        assert "unknown" in subject
+
+    def test_all_wildcards_task_falls_back_to_unknown(self) -> None:
+        pub = _make_publisher()
+        payload = WebhookPayload(
+            event="task.updated",
+            data={"team_id": "***", "task_id": ">>>"},
+            timestamp="2026-04-23T00:00:00Z",
+        )
+        subject = pub._resolve_subject(payload)
+        assert subject is not None
+        parts = subject.split(".")
+        assert all(p for p in parts), f"Empty token in subject: {subject}"
+        assert "unknown" in subject
 
 
 class TestActiveSubjectsBound:


### PR DESCRIPTION
Closes #85

When `_slug()` strips all characters from a subject token (e.g. all-wildcard input like `"***"` or `">>>"`) it returns an empty string, producing invalid NATS subjects with empty tokens like `hi.agents.h1..deleted`.

## Changes
- Added `or "unknown"` guard after each `_slug()` call in `_parse_agent_subject` (host, name) and `_parse_task_subject` (team_id, task_id)
- Added two unit tests: one for agent subjects and one for task subjects with all-wildcard inputs, asserting no empty tokens and presence of `"unknown"` fallback