### PR TITLE
fix(server): 422 on unknown event types; warn on missing data fields

### DIFF
--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -30,6 +30,10 @@ AGENT_EVENTS: frozenset[str] = frozenset({"agent.created", "agent.updated", "age
 TASK_EVENTS: frozenset[str] = frozenset({"task.updated", "task.completed", "task.failed"})
 
 
+class UnknownEventTypeError(ValueError):
+    """Raised by Publisher.publish() when an event type is unrecognised and dead-lettering is disabled."""
+
+
 _DEAD_LETTER_SUBJECT_PREFIX = "hi.deadletter"
 _SLUG_MAX_LEN = 64  # Maximum characters per NATS subject slug token
 
@@ -184,7 +188,7 @@ class Publisher:
                     dead_subject,
                 )
             else:
-                logger.warning("No subject mapping for event type %r; dropping", payload.event)
+                raise UnknownEventTypeError(payload.event)
             return
 
         _RETRYABLE = (nats.errors.TimeoutError, nats.errors.NoRespondersError)
@@ -244,16 +248,28 @@ class Publisher:
         Falls back to ``unknown`` tokens when fields are missing so messages
         are never silently dropped due to incomplete payloads.
         """
-        host = _slug(data.get("hostId") or data.get("host") or "") or "unknown"
-        name = _slug(data.get("name") or "") or "unknown"
+        raw_host = data.get("hostId") or data.get("host")
+        raw_name = data.get("name")
+        if not raw_host:
+            logger.warning("agent event missing 'host' field; using 'unknown'", extra={"event": event})
+        if not raw_name:
+            logger.warning("agent event missing 'name' field; using 'unknown'", extra={"event": event})
+        host = _slug(raw_host or "unknown") or "unknown"
+        name = _slug(raw_name or "unknown") or "unknown"
         # Strip the "agent." prefix to get the bare verb (created/updated/deleted)
         verb = event.split(".", 1)[-1] if "." in event else event
         return f"hi.agents.{host}.{name}.{verb}"
 
     def _parse_task_subject(self, data: dict[str, Any], event: str) -> str:
         """Build ``hi.tasks.{team_id}.{task_id}.{event}`` from task event data."""
-        team_id = _slug(data.get("teamId") or data.get("team_id") or "") or "unknown"
-        task_id = _slug(data.get("id") or data.get("task_id") or "") or "unknown"
+        raw_team_id = data.get("teamId") or data.get("team_id")
+        raw_task_id = data.get("id") or data.get("task_id")
+        if not raw_team_id:
+            logger.warning("task event missing 'team_id' field; using 'unknown'", extra={"event": event})
+        if not raw_task_id:
+            logger.warning("task event missing 'task_id' field; using 'unknown'", extra={"event": event})
+        team_id = _slug(raw_team_id or "unknown") or "unknown"
+        task_id = _slug(raw_task_id or "unknown") or "unknown"
         verb = event.split(".", 1)[-1] if "." in event else event
         return f"hi.tasks.{team_id}.{task_id}.{verb}"
 

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -33,7 +33,7 @@ from hermes.models import (
     WebhookAcceptedResponse,
     WebhookPayload,
 )
-from hermes.publisher import AGENT_EVENTS, TASK_EVENTS, Publisher
+from hermes.publisher import AGENT_EVENTS, TASK_EVENTS, Publisher, UnknownEventTypeError
 from hermes.rate_limit import limiter, rate_limit_exceeded_handler
 from slowapi.middleware import SlowAPIMiddleware
 
@@ -337,6 +337,12 @@ async def receive_webhook(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="NATS publish timed out",
         )
+    except UnknownEventTypeError as exc:
+        WEBHOOKS_FAILED.labels(reason="unknown_event_type").inc()
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Unknown event type: {exc}",
+        ) from exc
     return WebhookAcceptedResponse(status="accepted", event=payload.event)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -298,7 +298,9 @@ class TestEdgeCases:
     async def test_unknown_event_type_not_published(
         self, nats_url: str, nats_client: nats.aio.client.Client
     ) -> None:
-        """Unknown event types with dead-letter disabled are dropped — no NATS message."""
+        """Unknown event types with dead-letter disabled raise UnknownEventTypeError — no NATS message."""
+        from hermes.publisher import UnknownEventTypeError
+
         received: list[nats.aio.msg.Msg] = []
 
         async def _cb(m: nats.aio.msg.Msg) -> None:
@@ -314,8 +316,8 @@ class TestEdgeCases:
                 data={"foo": "bar"},
                 timestamp="2026-04-22T00:00:00Z",
             )
-            await pub.publish(payload)
-            await asyncio.sleep(0.1)
+            with pytest.raises(UnknownEventTypeError):
+                await pub.publish(payload)
         finally:
             await pub.disconnect()
 

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -10,7 +10,7 @@ import pytest
 from nats.js.errors import NotFoundError
 
 from hermes.models import WebhookPayload
-from hermes.publisher import Publisher, _slug
+from hermes.publisher import Publisher, UnknownEventTypeError, _slug
 
 
 def _make_publisher() -> Publisher:
@@ -364,3 +364,29 @@ class TestPublishRetry:
                 await pub.publish(_agent_payload(), publish_retries=3, publish_retry_base_delay=0.1)
 
         assert pub._js.publish.call_count == 3
+
+
+class TestUnknownEventTypeError:
+    """Publisher raises UnknownEventTypeError for unknown events when dead-lettering is off."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_raises_when_dead_letter_disabled(self) -> None:
+        from hermes.models import WebhookPayload
+
+        pub = Publisher(enable_dead_letter=False)
+        pub._js = AsyncMock()
+
+        payload = WebhookPayload(event="foo.unknown", data={}, timestamp="2026-01-01T00:00:00Z")
+        with pytest.raises(UnknownEventTypeError):
+            await pub.publish(payload)
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_error_message_contains_event_type(self) -> None:
+        from hermes.models import WebhookPayload
+
+        pub = Publisher(enable_dead_letter=False)
+        pub._js = AsyncMock()
+
+        payload = WebhookPayload(event="foo.unknown", data={}, timestamp="2026-01-01T00:00:00Z")
+        with pytest.raises(UnknownEventTypeError, match="foo.unknown"):
+            await pub.publish(payload)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -689,3 +689,89 @@ class TestTimestampValidation:
             },
         )
         assert response.status_code in (202, 500)
+
+
+class TestUnknownEventType:
+    """Tests for #125: unknown event types return 422 when dead-lettering is disabled."""
+
+    def _build_client_with_unknown_event(self, event: str) -> TestClient:
+        from hermes.publisher import UnknownEventTypeError, Publisher
+        from hermes.server import app
+        from hermes.config import settings
+
+        mock_publisher = MagicMock(spec=Publisher)
+        mock_publisher.is_connected = True
+        mock_publisher.active_subjects = []
+        mock_publisher.publish = AsyncMock(side_effect=UnknownEventTypeError(event))
+
+        app.state.publisher = mock_publisher
+        settings.webhook_secret = ""
+        return TestClient(app, raise_server_exceptions=True)
+
+    def test_unknown_event_type_raises_422(self) -> None:
+        client = self._build_client_with_unknown_event("foo.bar")
+        payload = {"event": "foo.bar", "data": {}, "timestamp": "2026-01-01T00:00:00Z"}
+        body_bytes = json.dumps(payload).encode()
+        response = client.post("/webhook", content=body_bytes, headers={"Content-Type": "application/json"})
+        assert response.status_code == 422
+
+    def test_unknown_event_type_422_detail_contains_event(self) -> None:
+        client = self._build_client_with_unknown_event("foo.bar")
+        payload = {"event": "foo.bar", "data": {}, "timestamp": "2026-01-01T00:00:00Z"}
+        body_bytes = json.dumps(payload).encode()
+        response = client.post("/webhook", content=body_bytes, headers={"Content-Type": "application/json"})
+        body = response.json()
+        assert "foo.bar" in body["detail"]
+
+
+class TestMissingFieldWarnings:
+    """Tests for #98: warnings logged when agent/task data fields are missing."""
+
+    def test_missing_host_field_logs_warning(self) -> None:
+        from unittest.mock import patch
+        from hermes.publisher import Publisher
+
+        with patch("hermes.publisher.logger") as mock_log:
+            pub = Publisher()
+            pub._parse_agent_subject({"name": "bot"}, "agent.created")
+            warned_messages = [str(call.args) for call in mock_log.warning.call_args_list]
+            assert any("host" in msg for msg in warned_messages)
+
+    def test_missing_name_field_logs_warning(self) -> None:
+        from unittest.mock import patch
+        from hermes.publisher import Publisher
+
+        with patch("hermes.publisher.logger") as mock_log:
+            pub = Publisher()
+            pub._parse_agent_subject({"host": "myhost"}, "agent.created")
+            warned_messages = [str(call.args) for call in mock_log.warning.call_args_list]
+            assert any("name" in msg for msg in warned_messages)
+
+    def test_missing_team_id_field_logs_warning(self) -> None:
+        from unittest.mock import patch
+        from hermes.publisher import Publisher
+
+        with patch("hermes.publisher.logger") as mock_log:
+            pub = Publisher()
+            pub._parse_task_subject({"task_id": "t-1"}, "task.updated")
+            warned_messages = [str(call.args) for call in mock_log.warning.call_args_list]
+            assert any("team_id" in msg for msg in warned_messages)
+
+    def test_missing_task_id_field_logs_warning(self) -> None:
+        from unittest.mock import patch
+        from hermes.publisher import Publisher
+
+        with patch("hermes.publisher.logger") as mock_log:
+            pub = Publisher()
+            pub._parse_task_subject({"team_id": "alpha"}, "task.updated")
+            warned_messages = [str(call.args) for call in mock_log.warning.call_args_list]
+            assert any("task_id" in msg for msg in warned_messages)
+
+    def test_present_host_and_name_no_warning(self) -> None:
+        from unittest.mock import patch
+        from hermes.publisher import Publisher
+
+        with patch("hermes.publisher.logger") as mock_log:
+            pub = Publisher()
+            pub._parse_agent_subject({"host": "myhost", "name": "bot"}, "agent.created")
+            assert not mock_log.warning.called


### PR DESCRIPTION
Closes #125
Closes #98

Returns 422 Unprocessable Entity when an event type is unrecognised and dead-lettering is disabled (raises UnknownEventTypeError). Logs structured warnings when required agent/task data fields (host, name, team_id, task_id) fall back to "unknown".