### PR TITLE
fix(config): validate and strip trailing slash from HERMES_PUBLIC_URL

### DIFF
--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -34,6 +34,18 @@ class Settings(BaseSettings):
     log_json: bool = False
     active_subjects_max: int = 1000
 
+    @field_validator("hermes_public_url", mode="before")
+    @classmethod
+    def _validate_and_normalize_public_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        from urllib.parse import urlparse
+
+        parsed = urlparse(v)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(f"HERMES_PUBLIC_URL must be http or https, got: {v!r}")
+        return v.rstrip("/")
+
     @model_validator(mode="after")
     def _set_public_url_default(self) -> "Settings":
         if self.hermes_public_url is None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,3 +66,26 @@ class TestHermesPublicUrl:
 
         s = Settings(hermes_port=9090, hermes_public_url="https://hermes.example.com", _env_file=None)
         assert s.hermes_public_url == "https://hermes.example.com"
+
+    def test_public_url_strips_trailing_slash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_PUBLIC_URL", "http://example.com/")
+        from hermes.config import Settings
+
+        s = Settings()
+        assert not s.hermes_public_url.endswith("/")
+        assert s.hermes_public_url == "http://example.com"
+
+    def test_public_url_rejects_invalid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_PUBLIC_URL", "not-a-url")
+        from hermes.config import Settings
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Settings()
+
+    def test_public_url_accepts_with_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_PUBLIC_URL", "https://example.com/webhooks")
+        from hermes.config import Settings
+
+        s = Settings()
+        assert s.hermes_public_url == "https://example.com/webhooks"


### PR DESCRIPTION
Closes #103
Closes #104

Validates HERMES_PUBLIC_URL is a well-formed http/https URL at startup and strips any trailing slash for consistent downstream use.