### PR TITLE
fix(config): validate HERMES_HOST and warn on 0.0.0.0 bind

### DIFF
--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import re
 import ssl
 from functools import lru_cache
+from ipaddress import ip_address
 from typing import Optional
 
 from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _MIN_SECRET_LENGTH = 32
+_HOSTNAME_RE = re.compile(
+    r"^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$"
+)
 
 
 class Settings(BaseSettings):
@@ -39,6 +44,18 @@ class Settings(BaseSettings):
         if self.hermes_public_url is None:
             self.hermes_public_url = f"http://localhost:{self.hermes_port}"
         return self
+
+    @field_validator("hermes_host")
+    @classmethod
+    def _validate_host(cls, v: str) -> str:
+        try:
+            ip_address(v)
+            return v
+        except ValueError:
+            pass
+        if _HOSTNAME_RE.match(v):
+            return v
+        raise ValueError(f"HERMES_HOST must be a valid IP or hostname, got: {v!r}")
 
     @field_validator("webhook_secret")
     @classmethod

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -109,6 +109,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             "HMAC webhook validation is DISABLED — set WEBHOOK_SECRET to enable signature verification"
         )
 
+    if settings.hermes_host == "0.0.0.0":
+        logger.warning("Server binding to 0.0.0.0 exposes all network interfaces")
+
     _log_startup_banner(publisher, settings)
     app.state.publisher = publisher
     yield

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 import pytest
+from pydantic import ValidationError
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -40,6 +41,50 @@ class TestHermesHostDefault:
 
         s = Settings()
         assert s.hermes_host != "0.0.0.0"
+
+
+class TestHermesHostValidation:
+    def test_rejects_invalid_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_HOST", "not@valid!")
+        from hermes.config import Settings
+
+        with pytest.raises(ValidationError):
+            Settings()
+
+    def test_accepts_ipv4_address(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_HOST", "192.168.1.1")
+        from hermes.config import Settings
+
+        s = Settings()
+        assert s.hermes_host == "192.168.1.1"
+
+    def test_accepts_localhost(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_HOST", "localhost")
+        from hermes.config import Settings
+
+        s = Settings()
+        assert s.hermes_host == "localhost"
+
+    def test_accepts_all_interfaces(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_HOST", "0.0.0.0")
+        from hermes.config import Settings
+
+        s = Settings()
+        assert s.hermes_host == "0.0.0.0"
+
+    def test_accepts_fqdn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_HOST", "my-host.example.com")
+        from hermes.config import Settings
+
+        s = Settings()
+        assert s.hermes_host == "my-host.example.com"
+
+    def test_accepts_ipv6_address(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_HOST", "::1")
+        from hermes.config import Settings
+
+        s = Settings()
+        assert s.hermes_host == "::1"
 
 
 class TestHermesPublicUrl:

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -128,3 +128,43 @@ async def test_lifespan_error_log_includes_attempt_info(mock_publisher: MagicMoc
         # First positional arg after the format string: attempt number
         assert args[1] == i
         assert args[2] == _NATS_RETRY_ATTEMPTS
+
+
+@pytest.mark.anyio
+async def test_lifespan_warns_on_all_interfaces_bind(mock_publisher: MagicMock) -> None:
+    """A WARNING is logged when hermes_host is 0.0.0.0."""
+    from hermes.config import Settings
+    from hermes.server import lifespan, app
+
+    settings = Settings(hermes_host="0.0.0.0", _env_file=None)
+
+    with (
+        patch("hermes.server.Publisher", return_value=mock_publisher),
+        patch("hermes.server.get_settings", return_value=settings),
+        patch("hermes.server.logger") as mock_logger,
+    ):
+        async with lifespan(app):
+            pass
+
+    warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
+    assert any("0.0.0.0" in msg for msg in warning_messages)
+
+
+@pytest.mark.anyio
+async def test_lifespan_no_warn_on_loopback_bind(mock_publisher: MagicMock) -> None:
+    """No 0.0.0.0 WARNING is logged when hermes_host is 127.0.0.1."""
+    from hermes.config import Settings
+    from hermes.server import lifespan, app
+
+    settings = Settings(hermes_host="127.0.0.1", _env_file=None)
+
+    with (
+        patch("hermes.server.Publisher", return_value=mock_publisher),
+        patch("hermes.server.get_settings", return_value=settings),
+        patch("hermes.server.logger") as mock_logger,
+    ):
+        async with lifespan(app):
+            pass
+
+    warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
+    assert not any("0.0.0.0" in msg for msg in warning_messages)


### PR DESCRIPTION
Closes #133
Closes #135

Validates `HERMES_HOST` as a valid IP address or hostname at startup using `ipaddress.ip_address` for IPs and an RFC 1123 hostname regex for DNS names. Logs a WARNING when the server binds to `0.0.0.0` to make the network exposure explicit.