### PR TITLE
fix(tests): remove sys.path hacks and fix settings mutation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import nats
 import pytest
 import pytest_asyncio
 
+from hermes.config import get_settings
 from hermes.models import WebhookPayload
 from hermes.publisher import Publisher
 
@@ -30,6 +31,14 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers", "integration: requires a running NATS server"
     )
+
+
+@pytest.fixture(autouse=True)
+def reset_settings() -> None:
+    """Clear the get_settings LRU cache before each test so mutations don't leak."""
+    get_settings.cache_clear()
+    yield  # type: ignore[misc]
+    get_settings.cache_clear()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 
 class TestHermesHostDefault:

--- a/tests/test_events_endpoint.py
+++ b/tests/test_events_endpoint.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-import sys
-import os
 from unittest.mock import AsyncMock, MagicMock
 
 from fastapi.testclient import TestClient
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 
 def _build_client() -> TestClient:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,7 +23,7 @@ from hermes.publisher import Publisher
 pytestmark = pytest.mark.integration
 
 _NATS_URL = os.environ.get("TEST_NATS_URL", "nats://localhost:4222")
-_TEST_SECRET = "integration-test-secret"
+_TEST_SECRET = "integration-test-secret-for-hermes-webhook"
 
 
 def _sign(body: bytes) -> str:
@@ -170,14 +170,13 @@ class TestPublisherIntegration:
 
 class TestWebhookIntegration:
     async def test_webhook_to_nats_end_to_end(
-        self, nats_url: str, nats_client: nats.aio.client.Client
+        self, monkeypatch: pytest.MonkeyPatch, nats_url: str, nats_client: nats.aio.client.Client
     ) -> None:
         """POST /webhook with a valid payload results in a NATS message being delivered."""
-        from hermes.config import settings
         from hermes.server import app
 
-        settings.webhook_secret = _TEST_SECRET
-        settings.nats_url = nats_url
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("NATS_URL", nats_url)
 
         received: list[nats.aio.msg.Msg] = []
 
@@ -219,12 +218,13 @@ class TestWebhookIntegration:
             await sub.unsubscribe()
             await pub.disconnect()
 
-    async def test_webhook_nats_disconnected_returns_503(self) -> None:
+    async def test_webhook_nats_disconnected_returns_503(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """POST /webhook returns 503 when the publisher is not connected."""
-        from hermes.config import settings
         from hermes.server import app
 
-        settings.webhook_secret = _TEST_SECRET
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
 
         disconnected = Publisher()  # never connected
         app.state.publisher = disconnected
@@ -256,13 +256,14 @@ class TestWebhookIntegration:
 
 
 class TestLifespan:
-    async def test_lifespan_connects_publisher(self, nats_url: str) -> None:
+    async def test_lifespan_connects_publisher(
+        self, monkeypatch: pytest.MonkeyPatch, nats_url: str
+    ) -> None:
         """The lifespan context manager connects the publisher on startup."""
-        from hermes.config import settings
         from hermes.server import lifespan
         from fastapi import FastAPI
 
-        settings.nats_url = nats_url
+        monkeypatch.setenv("NATS_URL", nats_url)
         test_app = FastAPI()
 
         async with lifespan(test_app):
@@ -270,13 +271,14 @@ class TestLifespan:
 
         assert not test_app.state.publisher.is_connected
 
-    async def test_lifespan_handles_nats_unavailable(self) -> None:
+    async def test_lifespan_handles_nats_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Lifespan raises when NATS is unreachable after all retry attempts."""
-        from hermes.config import settings
         from hermes.server import lifespan
         from fastapi import FastAPI
 
-        settings.nats_url = "nats://127.0.0.1:19999"  # nothing listening here
+        monkeypatch.setenv("NATS_URL", "nats://127.0.0.1:19999")  # nothing listening here
         test_app = FastAPI()
 
         with pytest.raises(Exception):

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 
 @pytest.fixture()

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -4,10 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
-import os
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from hermes.logging_config import JsonFormatter, setup_logging
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-import sys
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from hermes.__main__ import _parse_args, main  # noqa: E402
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,16 +5,12 @@ from __future__ import annotations
 import hashlib
 import hmac as hmac_mod
 import json
-import os
-import sys
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-
-_TEST_SECRET = "test-webhook-secret"
+_TEST_SECRET = "test-webhook-secret-padding-xxxxx"
 
 
 def _sign(body: bytes) -> str:
@@ -24,7 +20,6 @@ def _sign(body: bytes) -> str:
 def _build_client(dead_letters: list | None = None) -> TestClient:
     from hermes.server import app
     from hermes.publisher import Publisher
-    from hermes.config import settings
 
     mock_publisher = MagicMock(spec=Publisher)
     mock_publisher.is_connected = True
@@ -33,7 +28,6 @@ def _build_client(dead_letters: list | None = None) -> TestClient:
     mock_publisher.dead_letters = dead_letters if dead_letters is not None else []
 
     app.state.publisher = mock_publisher
-    settings.webhook_secret = _TEST_SECRET
     return TestClient(app, raise_server_exceptions=True)
 
 
@@ -81,7 +75,8 @@ class TestDeadLettersEndpoint:
 
 
 class TestWebhookMetricsInstrumentation:
-    def test_valid_webhook_increments_received_counter(self) -> None:
+    def test_valid_webhook_increments_received_counter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",
@@ -102,7 +97,8 @@ class TestWebhookMetricsInstrumentation:
         after = _get_counter_value("hermes_webhooks_received_total", {"event_type": "agent.created"})
         assert after == before + 1
 
-    def test_invalid_payload_increments_failed_counter(self) -> None:
+    def test_invalid_payload_increments_failed_counter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         body_bytes = json.dumps({"bad": "payload"}).encode()
 
@@ -118,16 +114,15 @@ class TestWebhookMetricsInstrumentation:
         after = _get_counter_value("hermes_webhooks_failed_total", {"reason": "invalid_payload"})
         assert after == before + 1
 
-    def test_nats_unavailable_increments_failed_counter(self) -> None:
+    def test_nats_unavailable_increments_failed_counter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         from hermes.server import app
         from hermes.publisher import Publisher
-        from hermes.config import settings
 
         mock_publisher = MagicMock(spec=Publisher)
         mock_publisher.is_connected = False
         mock_publisher.dead_letters = []
         app.state.publisher = mock_publisher
-        settings.webhook_secret = _TEST_SECRET
         client = TestClient(app, raise_server_exceptions=False)
 
         payload = {

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -2,14 +2,9 @@
 
 from __future__ import annotations
 
-import sys
-import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
-# Ensure src is on the path when running directly
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from nats.js.errors import NotFoundError
 

--- a/tests/test_publisher_callbacks.py
+++ b/tests/test_publisher_callbacks.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-import sys
-import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from hermes.publisher import Publisher
 

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -4,14 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import signal
-import sys
-import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 
 # ---------------------------------------------------------------------------
@@ -131,9 +127,7 @@ class TestShutdownMiddleware:
         srv._shutdown_event = asyncio.Event()
         srv._shutdown_event.set()
         try:
-            from hermes.config import settings
-
-            settings.webhook_secret = ""
+            # webhook_secret="" is the default; no env override needed
             client = _build_client()
             response = client.post(
                 "/webhook",
@@ -151,9 +145,7 @@ class TestShutdownMiddleware:
         import hermes.server as srv
 
         srv._shutdown_event = asyncio.Event()
-        from hermes.config import settings
-
-        settings.webhook_secret = ""
+        # webhook_secret="" is the default; no env override needed
         client = _build_client()
         response = client.post(
             "/webhook",
@@ -216,12 +208,13 @@ class TestSignalHandler:
 
 class TestLifespanShutdown:
     @pytest.mark.asyncio
-    async def test_shutdown_waits_for_inflight_requests(self) -> None:
+    async def test_shutdown_waits_for_inflight_requests(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Lifespan teardown waits until _inflight reaches 0 before disconnecting."""
         import hermes.server as srv
-        from hermes.config import settings
+        from hermes.config import Settings
 
-        settings.shutdown_timeout = 2.0
+        monkeypatch.setenv("SHUTDOWN_TIMEOUT", "2.0")
+        timeout = Settings().shutdown_timeout
 
         mock_pub = _make_mock_publisher()
 
@@ -246,7 +239,7 @@ class TestLifespanShutdown:
         mock_pub.disconnect = _tracked_disconnect
 
         # Run the post-yield shutdown logic directly
-        deadline = settings.shutdown_timeout
+        deadline = timeout
         poll_interval = 0.05
         elapsed = 0.0
         while elapsed < deadline:
@@ -264,12 +257,13 @@ class TestLifespanShutdown:
         assert disconnect_called_at_inflight == [0]
 
     @pytest.mark.asyncio
-    async def test_shutdown_proceeds_after_timeout(self) -> None:
+    async def test_shutdown_proceeds_after_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Lifespan teardown proceeds with disconnect even if inflight never clears."""
         import hermes.server as srv
-        from hermes.config import settings
+        from hermes.config import Settings
 
-        settings.shutdown_timeout = 0.3  # very short
+        monkeypatch.setenv("SHUTDOWN_TIMEOUT", "0.3")
+        timeout = Settings().shutdown_timeout
 
         srv._shutdown_event = asyncio.Event()
         srv._inflight = 5  # stuck requests
@@ -281,7 +275,7 @@ class TestLifespanShutdown:
             disconnect_called = True
 
         # Run the shutdown polling loop
-        deadline = settings.shutdown_timeout
+        deadline = timeout
         poll_interval = 0.05
         elapsed = 0.0
         while elapsed < deadline:
@@ -299,6 +293,5 @@ class TestLifespanShutdown:
         async with srv._inflight_lock:
             assert srv._inflight == 5
 
-        # Reset
+        # Reset inflight for subsequent tests
         srv._inflight = 0
-        settings.shutdown_timeout = 10.0

--- a/tests/test_startup_banner.py
+++ b/tests/test_startup_banner.py
@@ -2,11 +2,7 @@
 
 from __future__ import annotations
 
-import sys
-import os
 from unittest.mock import MagicMock, patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 
 class TestMaskSecret:

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-import os
-import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from hermes.config import Settings
 from hermes.models import WebhookPayload

--- a/tests/test_tls_config.py
+++ b/tests/test_tls_config.py
@@ -3,10 +3,6 @@
 from __future__ import annotations
 
 import ssl
-import sys
-import os
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 
 class TestBuildSslContext:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
-import sys
-import os
 from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 
 def test_hermes_version_is_a_string() -> None:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -5,13 +5,10 @@ from __future__ import annotations
 import hashlib
 import hmac as hmac_mod
 import json
-import sys
-import os
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 # Fixed secret used across all webhook tests
 _TEST_SECRET = "test-webhook-secret-padding-xxxxx"
@@ -22,36 +19,24 @@ def _sign(body: bytes) -> str:
     return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
 
 
-def _build_client() -> TestClient:
-    """Build a TestClient with a mocked Publisher and a known webhook secret."""
-    from hermes.config import settings
+def _build_client(*, connected: bool = True) -> TestClient:
+    """Build a TestClient with a mocked Publisher."""
     from hermes.publisher import Publisher
     from hermes.server import app
 
     mock_publisher = MagicMock(spec=Publisher)
-    mock_publisher.is_connected = True
+    mock_publisher.is_connected = connected
     mock_publisher.active_subjects = []
     mock_publisher.publish = AsyncMock()
 
     # Inject the mock before the test client starts
     app.state.publisher = mock_publisher
-    # Set a known secret so tests can compute valid signatures
-    settings.webhook_secret = _TEST_SECRET
     return TestClient(app, raise_server_exceptions=True)
 
 
 def _build_client_disconnected() -> TestClient:
     """Build a TestClient where the Publisher reports NATS as disconnected."""
-    from hermes.server import app
-    from hermes.publisher import Publisher
-
-    mock_publisher = MagicMock(spec=Publisher)
-    mock_publisher.is_connected = False
-    mock_publisher.active_subjects = []
-    mock_publisher.publish = AsyncMock()
-
-    app.state.publisher = mock_publisher
-    return TestClient(app, raise_server_exceptions=True)
+    return _build_client(connected=False)
 
 
 class TestHealthEndpoint:
@@ -121,7 +106,8 @@ class TestReadyEndpoint:
 
 
 class TestWebhookEndpoint:
-    def test_valid_payload_returns_202(self) -> None:
+    def test_valid_payload_returns_202(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",
@@ -139,7 +125,8 @@ class TestWebhookEndpoint:
         )
         assert response.status_code == 202
 
-    def test_webhook_invalid_payload_returns_422(self) -> None:
+    def test_webhook_invalid_payload_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         body_bytes = json.dumps({"bad": "payload"}).encode()
         response = client.post(
@@ -152,7 +139,8 @@ class TestWebhookEndpoint:
         )
         assert response.status_code == 422
 
-    def test_webhook_missing_body_returns_422(self) -> None:
+    def test_webhook_missing_body_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         body_bytes = b"not json"
         response = client.post(
@@ -165,7 +153,8 @@ class TestWebhookEndpoint:
         )
         assert response.status_code == 422
 
-    def test_webhook_returns_event_name(self) -> None:
+    def test_webhook_returns_event_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "task.updated",
@@ -184,7 +173,8 @@ class TestWebhookEndpoint:
         body = response.json()
         assert body["event"] == "task.updated"
 
-    def test_webhook_bad_signature_returns_401(self) -> None:
+    def test_webhook_bad_signature_returns_401(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",


### PR DESCRIPTION
Closes #19
Closes #20

## Summary
- Removes `sys.path.insert` hacks from all 14 test files — the package is installed via pixi so path manipulation is unnecessary
- Adds a `reset_settings` autouse fixture to `conftest.py` that clears the `get_settings` LRU cache before and after each test, preventing settings mutations from leaking between tests
- Converts direct settings mutation (`settings.webhook_secret = ...`, `settings.shutdown_timeout = ...`) in `test_webhook.py`, `test_metrics.py`, and `test_shutdown.py` to use `monkeypatch.setenv` with a fresh `Settings()` instance

## Test plan
- [x] `pixi run pytest -m "not integration" --tb=short -q` passes: 169 passed, 0 failed
- [x] No `sys.path.insert` or `sys.path.append` in any test file
- [x] No direct mutation of module-level `settings` singleton in non-integration tests
- [x] Only test files modified — no source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)