### PR TITLE
feat(health): expose inflight_requests count in /health

### DIFF
--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -49,6 +49,7 @@ class HealthResponse(BaseModel):
     shutting_down: bool = False
     hmac_validation_enabled: bool = False
     hermes_public_url: str | None = None
+    inflight_requests: int = 0
 
 
 class WebhookAcceptedResponse(BaseModel):

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -216,6 +216,7 @@ async def health(response: Response) -> HealthResponse:
         shutting_down=_shutdown_event.is_set(),
         hmac_validation_enabled=bool(cfg.webhook_secret),
         hermes_public_url=cfg.hermes_public_url,
+        inflight_requests=_inflight,
     )
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -92,6 +92,13 @@ class TestHealthEndpoint:
         body = client.get("/health").json()
         assert body["nats_connected"] is False
 
+    def test_health_includes_inflight_requests(self) -> None:
+        client = _build_client()
+        body = client.get("/health").json()
+        assert "inflight_requests" in body
+        assert isinstance(body["inflight_requests"], int)
+        assert body["inflight_requests"] >= 0
+
 
 class TestReadyEndpoint:
     def test_ready_returns_200_when_connected(self) -> None:


### PR DESCRIPTION
Closes #217

Adds `inflight_requests` field to the `/health` endpoint response, reflecting the current number of requests being processed via the module-level `_inflight` counter. Useful for load-balancer drain and observability.