### PR TITLE
fix: whitespace slug fallback and last-retry log fix

### DIFF
--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -243,16 +243,16 @@ class Publisher:
         Falls back to ``unknown`` tokens when fields are missing so messages
         are never silently dropped due to incomplete payloads.
         """
-        host = _slug(data.get("hostId") or data.get("host") or "unknown") or "unknown"
-        name = _slug(data.get("name") or "unknown") or "unknown"
+        host = _slug(data.get("hostId") or data.get("host") or "") or "unknown"
+        name = _slug(data.get("name") or "") or "unknown"
         # Strip the "agent." prefix to get the bare verb (created/updated/deleted)
         verb = event.split(".", 1)[-1] if "." in event else event
         return f"hi.agents.{host}.{name}.{verb}"
 
     def _parse_task_subject(self, data: dict[str, Any], event: str) -> str:
         """Build ``hi.tasks.{team_id}.{task_id}.{event}`` from task event data."""
-        team_id = _slug(data.get("teamId") or data.get("team_id") or "unknown") or "unknown"
-        task_id = _slug(data.get("id") or data.get("task_id") or "unknown") or "unknown"
+        team_id = _slug(data.get("teamId") or data.get("team_id") or "") or "unknown"
+        task_id = _slug(data.get("id") or data.get("task_id") or "") or "unknown"
         verb = event.split(".", 1)[-1] if "." in event else event
         return f"hi.tasks.{team_id}.{task_id}.{verb}"
 
@@ -269,6 +269,7 @@ def _slug(value: str) -> str:
     """
     return (
         str(value)
+        .strip()
         .replace(" ", "-")
         .replace(".", "-")
         .replace("*", "")

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -82,16 +82,25 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             break
         except Exception as exc:  # noqa: BLE001
             last_exc = exc
-            logger.error(
-                "NATS connect attempt %d/%d failed (%s: %s); retrying in %ds",
-                attempt,
-                settings.nats_retry_attempts,
-                type(exc).__name__,
-                exc,
-                settings.nats_retry_interval,
-            )
-            if attempt < settings.nats_retry_attempts:
+            will_retry = attempt < settings.nats_retry_attempts
+            if will_retry:
+                logger.error(
+                    "NATS connect attempt %d/%d failed (%s: %s); retrying in %ds",
+                    attempt,
+                    settings.nats_retry_attempts,
+                    type(exc).__name__,
+                    exc,
+                    settings.nats_retry_interval,
+                )
                 await asyncio.sleep(settings.nats_retry_interval)
+            else:
+                logger.error(
+                    "NATS connect attempt %d/%d failed (%s: %s); giving up",
+                    attempt,
+                    settings.nats_retry_attempts,
+                    type(exc).__name__,
+                    exc,
+                )
 
     if last_exc is not None:
         logger.critical(

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -166,3 +166,25 @@ async def test_lifespan_no_warn_on_loopback_bind(mock_publisher: MagicMock) -> N
 
     warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
     assert not any("0.0.0.0" in msg for msg in warning_messages)
+
+
+@pytest.mark.anyio
+async def test_last_retry_logs_giving_up_not_retrying(mock_publisher: MagicMock) -> None:
+    """The final attempt logs 'giving up', not 'retrying in Xs'."""
+    from hermes.server import lifespan, app
+
+    mock_publisher.connect.side_effect = RuntimeError("boom")
+
+    with (
+        patch("hermes.server.Publisher", return_value=mock_publisher),
+        patch("hermes.server.asyncio.sleep", new_callable=AsyncMock),
+        patch("hermes.server.logger") as mock_logger,
+        pytest.raises(RuntimeError),
+    ):
+        async with lifespan(app):
+            pass
+
+    last_error_call = mock_logger.error.call_args_list[-1]
+    last_format_string: str = last_error_call.args[0]
+    assert "retrying" not in last_format_string.lower()
+    assert "giving up" in last_format_string.lower()

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -85,6 +85,16 @@ class TestAgentSubjectMapping:
         assert "*" not in subject
         assert ">" not in subject
 
+    def test_whitespace_only_host_falls_back_to_unknown(self) -> None:
+        pub = _make_publisher()
+        subject = pub._parse_agent_subject({"host": "   ", "name": "bot"}, "agent.created")
+        assert subject == "hi.agents.unknown.bot.created"
+
+    def test_whitespace_only_name_falls_back_to_unknown(self) -> None:
+        pub = _make_publisher()
+        subject = pub._parse_agent_subject({"host": "myhost", "name": "   "}, "agent.created")
+        assert subject == "hi.agents.myhost.unknown.created"
+
 
 class TestTaskSubjectMapping:
     """Task event → NATS subject routing."""
@@ -184,6 +194,9 @@ class TestEnsureStreams:
 
 class TestSlugSanitisation:
     """Unit tests for the _slug() helper covering wildcard sanitisation."""
+
+    def test_whitespace_only_returns_empty_string(self) -> None:
+        assert _slug("   ") == ""
 
     def test_wildcard_star_is_removed(self) -> None:
         assert "*" not in _slug("test*")


### PR DESCRIPTION
Closes #151
Closes #148

## Changes

- **#151**: `_slug()` now calls `.strip()` before replacing spaces, so whitespace-only inputs (e.g. `"   "`) produce `""` rather than `"---"`. Subject builders in `_parse_agent_subject` and `_parse_task_subject` use `or "unknown"` after `_slug()` so the empty result correctly falls back to `"unknown"`.

- **#148**: Retry logging in the lifespan NATS connection loop now conditionally logs. Non-final attempts log `"retrying in %ds"` as before; the final attempt logs `"giving up"` instead, eliminating the misleading "retrying" message when there is no next attempt.

## Test plan
- `test_whitespace_only_returns_empty_string` — `_slug("   ")` returns `""`
- `test_whitespace_only_host_falls_back_to_unknown` — whitespace host produces `hi.agents.unknown...`
- `test_whitespace_only_name_falls_back_to_unknown` — whitespace name produces `hi.agents.*.unknown.*`
- `test_last_retry_logs_giving_up_not_retrying` — last error log contains "giving up", not "retrying"
- All 173 non-integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)