### PR TITLE
fix(server): sanitize X-Request-ID; test absent signature header

### DIFF
--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import hmac
 import logging
+import re
 import signal
 import uuid
 from collections.abc import AsyncGenerator
@@ -45,6 +46,7 @@ _NATS_RETRY_ATTEMPTS = 3
 _NATS_RETRY_INTERVAL = 5
 
 _REQUEST_ID_HEADER = "X-Request-ID"
+_REQUEST_ID_RE = re.compile(r"^[a-zA-Z0-9\-_]{1,128}$")
 
 # ---------------------------------------------------------------------------
 # Application lifespan
@@ -165,7 +167,8 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
     """
 
     async def dispatch(self, request: Request, call_next: object) -> Response:
-        request_id = request.headers.get(_REQUEST_ID_HEADER) or str(uuid.uuid4())
+        raw_id = request.headers.get(_REQUEST_ID_HEADER, "")
+        request_id = raw_id if _REQUEST_ID_RE.match(raw_id) else str(uuid.uuid4())
         request.state.request_id = request_id
         response: Response = await call_next(request)  # type: ignore[operator]
         response.headers[_REQUEST_ID_HEADER] = request_id

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -203,6 +203,131 @@ class TestWebhookEndpoint:
         assert response.status_code == 401
 
 
+class TestSignatureValidation:
+    """Tests for _verify_signature behaviour (issue #156)."""
+
+    def test_missing_signature_header_returns_401_when_secret_configured(self) -> None:
+        client = _build_client()
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "localhost", "name": "bot"},
+            "timestamp": "2026-03-15T00:00:00Z",
+        }
+        response = client.post("/webhook", json=payload)
+        assert response.status_code == 401
+
+    def test_empty_signature_header_returns_401_when_secret_configured(self) -> None:
+        client = _build_client()
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "localhost", "name": "bot"},
+            "timestamp": "2026-03-15T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={"Content-Type": "application/json", "X-Webhook-Signature": ""},
+        )
+        assert response.status_code == 401
+
+
+class TestRequestIDMiddleware:
+    """Tests for X-Request-ID header sanitization (issue #229)."""
+
+    def test_valid_uuid_request_id_is_passed_through(self) -> None:
+        import uuid as uuid_mod
+
+        client = _build_client()
+        valid_id = str(uuid_mod.uuid4())
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "localhost", "name": "bot"},
+            "timestamp": "2026-03-15T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Request-ID": valid_id,
+            },
+        )
+        assert response.headers.get("X-Request-ID") == valid_id
+
+    def test_invalid_chars_in_request_id_are_replaced_with_uuid(self) -> None:
+        import uuid as uuid_mod
+
+        client = _build_client()
+        invalid_id = "bad<>id\ninjection"
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "localhost", "name": "bot"},
+            "timestamp": "2026-03-15T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Request-ID": invalid_id,
+            },
+        )
+        returned_id = response.headers.get("X-Request-ID")
+        assert returned_id != invalid_id
+        uuid_mod.UUID(returned_id)  # raises ValueError if not a valid UUID
+
+    def test_absent_request_id_header_generates_uuid(self) -> None:
+        import uuid as uuid_mod
+
+        client = _build_client()
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "localhost", "name": "bot"},
+            "timestamp": "2026-03-15T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+            },
+        )
+        returned_id = response.headers.get("X-Request-ID")
+        assert returned_id is not None
+        uuid_mod.UUID(returned_id)  # raises ValueError if not a valid UUID
+
+    def test_oversized_request_id_is_replaced_with_uuid(self) -> None:
+        import uuid as uuid_mod
+
+        client = _build_client()
+        oversized_id = "a" * 129
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "localhost", "name": "bot"},
+            "timestamp": "2026-03-15T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Request-ID": oversized_id,
+            },
+        )
+        returned_id = response.headers.get("X-Request-ID")
+        assert returned_id != oversized_id
+        uuid_mod.UUID(returned_id)  # raises ValueError if not a valid UUID
+
+
 class TestSettings:
     def test_hermes_host_defaults_to_localhost(self) -> None:
         from hermes.config import Settings


### PR DESCRIPTION
Closes #229
Closes #156

## Summary
- Adds `_REQUEST_ID_RE = re.compile(r'^[a-zA-Z0-9\-_]{1,128}$')` and updates `RequestIDMiddleware.dispatch()` to replace non-conforming `X-Request-ID` values with a fresh UUID4, preventing injection of special characters into logs and NATS payloads
- Adds `TestSignatureValidation` covering absent and empty `X-Webhook-Signature` when `webhook_secret` is configured (both return 401)
- Adds `TestRequestIDMiddleware` covering valid UUID pass-through, invalid chars replaced with UUID, absent header generates UUID, oversized value replaced with UUID

## Test plan
- [x] `pixi run pytest -m "not integration" --tb=short -q` passes (175 passed)
- [x] Valid `X-Request-ID` values are echoed back unchanged
- [x] Invalid/oversized `X-Request-ID` values are replaced with a fresh UUID in the response header
- [x] Missing `X-Webhook-Signature` returns 401 when secret is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)