### PR TITLE
fix(docker): use /ready for HEALTHCHECK and fix variable expansion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ ENV HERMES_PORT=8080
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${HERMES_PORT}/health')"
+    CMD curl -f http://localhost:${HERMES_PORT:-8080}/ready || exit 1
 
 CMD ["python", "-m", "hermes.server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       nats:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/ready"]
       interval: 30s
       timeout: 5s
       start_period: 10s


### PR DESCRIPTION
Closes #80
Closes #197

Changes HEALTHCHECK to probe /ready instead of /health (/health returns 503 when NATS is disconnected, which would cause unnecessary container restarts). Fixes shell variable expansion for HERMES_PORT using shell form CMD with ${HERMES_PORT:-8080} default.