### PR TITLE
feat(observability): structured HMAC log field and invalid-sig metric

### DIFF
--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -106,7 +106,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     if not settings.webhook_secret:
         logger.warning(
-            "HMAC webhook validation is DISABLED — set WEBHOOK_SECRET to enable signature verification"
+            "HMAC webhook validation is DISABLED — set WEBHOOK_SECRET to enable signature verification",
+            extra={"hmac_enabled": False},
         )
 
     _log_startup_banner(publisher, settings)
@@ -360,6 +361,7 @@ def _verify_signature(body: bytes, provided: str, settings: Settings) -> None:
         hashlib.sha256,
     ).hexdigest()
     if not hmac.compare_digest(expected, provided):
+        WEBHOOKS_FAILED.labels(reason="invalid_signature").inc()
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid webhook signature",

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -202,6 +202,30 @@ class TestWebhookEndpoint:
         )
         assert response.status_code == 401
 
+    def test_invalid_signature_increments_failed_counter(self) -> None:
+        from prometheus_client import REGISTRY
+
+        client = _build_client()
+        labels = {"reason": "invalid_signature"}
+        before = REGISTRY.get_sample_value("hermes_webhooks_failed_total", labels) or 0.0
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "localhost", "name": "bot"},
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": "sha256=wrong",
+            },
+        )
+        assert response.status_code == 401
+        after = REGISTRY.get_sample_value("hermes_webhooks_failed_total", labels) or 0.0
+        assert after > before
+
 
 class TestSettings:
     def test_hermes_host_defaults_to_localhost(self) -> None:


### PR DESCRIPTION
Closes #67
Closes #109

Adds `hmac_enabled=False` structured field to the HMAC-disabled startup warning for JSON log parsing. Increments `WEBHOOKS_FAILED` counter with `reason=invalid_signature` when HMAC validation rejects a request.