### PR TITLE
feat(subjects): expose hermes_public_url and active_subjects_max

### DIFF
--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -79,6 +79,8 @@ class SubjectsResponse(BaseModel):
     """Response body for GET /subjects."""
 
     subjects: list[str]
+    hermes_public_url: str = ""
+    active_subjects_max: int = 0
 
 
 class ErrorResponse(BaseModel):

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -116,6 +116,10 @@ class Publisher:
         return sorted(self._active_subjects)
 
     @property
+    def active_subjects_max(self) -> int:
+        return self._max_subjects
+
+    @property
     def stream_names(self) -> list[str]:
         return list(self._stream_names)
 

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -352,10 +352,14 @@ async def receive_webhook(
     response_model=SubjectsResponse,
 )
 @limiter.limit("60/minute")
-async def list_subjects(request: Request) -> SubjectsResponse:
+async def list_subjects(request: Request, settings: SettingsDep) -> SubjectsResponse:
     """Return the list of NATS subjects that have been published to."""
     publisher: Publisher = app.state.publisher
-    return SubjectsResponse(subjects=publisher.active_subjects)
+    return SubjectsResponse(
+        subjects=publisher.active_subjects,
+        hermes_public_url=settings.hermes_public_url or "",
+        active_subjects_max=publisher.active_subjects_max,
+    )
 
 
 @app.get("/metrics")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -24,6 +24,7 @@ def _build_client(*, connected: bool = True) -> TestClient:
     """Build a TestClient with a mocked Publisher and a known webhook secret."""
     from hermes.config import get_settings
     from hermes.publisher import Publisher
+    from hermes.rate_limit import limiter
     from hermes.server import app
 
     mock_publisher = MagicMock(spec=Publisher)
@@ -37,6 +38,8 @@ def _build_client(*, connected: bool = True) -> TestClient:
     app.state.publisher = mock_publisher
     # Set a known secret on the live cached Settings instance
     get_settings().webhook_secret = _TEST_SECRET
+    # Reset rate limiter so each test starts with a clean slate
+    limiter._storage.reset()  # type: ignore[attr-defined]
     return TestClient(app, raise_server_exceptions=True)
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -30,6 +30,7 @@ def _build_client(*, connected: bool = True) -> TestClient:
     mock_publisher.is_connected = connected
     mock_publisher.active_subjects = []
     mock_publisher.dead_letter_count = 0
+    mock_publisher.active_subjects_max = 1000
     mock_publisher.publish = AsyncMock()
 
     # Inject the mock before the test client starts
@@ -768,6 +769,19 @@ class TestSubjectsEndpoint:
             client.get("/subjects")
         resp = client.get("/subjects")
         assert resp.status_code == 429
+
+    def test_subjects_includes_hermes_public_url(self) -> None:
+        client = _build_client()
+        body = client.get("/subjects").json()
+        assert "hermes_public_url" in body
+        assert isinstance(body["hermes_public_url"], str)
+
+    def test_subjects_includes_active_subjects_max(self) -> None:
+        client = _build_client()
+        body = client.get("/subjects").json()
+        assert "active_subjects_max" in body
+        assert isinstance(body["active_subjects_max"], int)
+        assert body["active_subjects_max"] > 0
 
 
 class TestWWWAuthenticate:


### PR DESCRIPTION
Closes #138
Closes #105

Adds `hermes_public_url` (the configured public webhook endpoint) and `active_subjects_max` (the LRU cap) to the `GET /subjects` response.

## Changes
- `SubjectsResponse` model gains `hermes_public_url: str` and `active_subjects_max: int` fields
- `Publisher` exposes a new `active_subjects_max` property returning `_max_subjects`
- `/subjects` handler now injects both values from settings and publisher
- Two new tests verify the fields are present and correctly typed

## Test plan
- [x] `pixi run pytest -m "not integration" --tb=short -q` — 171 passed