### PR TITLE
feat(security): rate-limit /subjects and WWW-Authenticate on 401

### DIFF
--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -331,7 +331,8 @@ async def receive_webhook(
     "/subjects",
     response_model=SubjectsResponse,
 )
-async def list_subjects() -> SubjectsResponse:
+@limiter.limit("60/minute")
+async def list_subjects(request: Request) -> SubjectsResponse:
     """Return the list of NATS subjects that have been published to."""
     publisher: Publisher = app.state.publisher
     return SubjectsResponse(subjects=publisher.active_subjects)
@@ -414,6 +415,7 @@ def _verify_signature(body: bytes, provided: str, settings: Settings) -> None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid webhook signature",
+            headers={"WWW-Authenticate": 'Bearer realm="hermes"'},
         )
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -442,6 +442,42 @@ class TestSubjectsEndpoint:
         assert "subjects" in body
         assert isinstance(body["subjects"], list)
 
+    def test_subjects_rate_limit_returns_429_when_limit_exceeded(self) -> None:
+        from hermes.rate_limit import limiter
+
+        limiter._storage.reset()  # type: ignore[attr-defined]
+        client = _build_client()
+        for _ in range(60):
+            client.get("/subjects")
+        resp = client.get("/subjects")
+        assert resp.status_code == 429
+
+
+class TestWWWAuthenticate:
+    def test_bad_signature_401_has_www_authenticate_header(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        client = _build_client()
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "localhost", "name": "bot"},
+            "timestamp": "2026-03-15T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        resp = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": "sha256=bad",
+            },
+        )
+        assert resp.status_code == 401
+        headers_lower = {k.lower(): v for k, v in resp.headers.items()}
+        assert "www-authenticate" in headers_lower
+        assert headers_lower["www-authenticate"] == 'Bearer realm="hermes"'
+
 
 class TestVersionEndpoint:
     def test_version_returns_200(self) -> None:


### PR DESCRIPTION
Closes #165
Closes #167

Applies slowapi rate limiting (60/minute) to GET /subjects. Adds `WWW-Authenticate: Bearer realm="hermes"` to 401 responses from HMAC validation failures per RFC 7235.

## Changes
- `GET /subjects` is now decorated with `@limiter.limit("60/minute")` and accepts `request: Request` as required by slowapi
- `_verify_signature` now includes `WWW-Authenticate: Bearer realm="hermes"` in the HTTPException headers on 401
- Tests: `TestSubjectsEndpoint.test_subjects_rate_limit_returns_429_when_limit_exceeded` verifies the rate limit is enforced
- Tests: `TestWWWAuthenticate.test_bad_signature_401_has_www_authenticate_header` verifies the header is present on 401 responses

## Test plan
- [x] `pixi run pytest -m "not integration" --tb=short -q` passes (7 pre-existing failures unaffected)
- [x] `pixi run ruff check src/hermes/server.py tests/test_webhook.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)