### PR TITLE
test(publisher): hostId field and wildcard injection tests

### DIFF
--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -62,6 +62,28 @@ class TestAgentSubjectMapping:
         assert " " not in subject
         assert subject == "hi.agents.my-host.my-agent.created"
 
+    def test_host_id_field_used_as_host(self) -> None:
+        pub = _make_publisher()
+        payload = WebhookPayload(
+            event="agent.created",
+            data={"hostId": "myhost", "name": "bot"},
+            timestamp="2026-01-01T00:00:00Z",
+        )
+        subject = pub._resolve_subject(payload)
+        assert subject == "hi.agents.myhost.bot.created"
+
+    def test_host_id_with_wildcard_is_sanitized(self) -> None:
+        pub = _make_publisher()
+        payload = WebhookPayload(
+            event="agent.created",
+            data={"hostId": "bad*host", "name": "bot"},
+            timestamp="2026-01-01T00:00:00Z",
+        )
+        subject = pub._resolve_subject(payload)
+        assert subject is not None
+        assert "*" not in subject
+        assert ">" not in subject
+
 
 class TestTaskSubjectMapping:
     """Task event → NATS subject routing."""

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -435,6 +435,101 @@ class TestPayloadSizeLimit:
         assert tc.post("/", content=b"x" * 11).status_code == 413
 
 
+class TestWildcardInjectionSanitization:
+    """Verify that wildcard characters in webhook payloads are sanitized before publish (#152)."""
+
+    def test_wildcard_in_host_field_is_sanitized_before_publish(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+
+        published_subjects: list[str] = []
+
+        from hermes.publisher import Publisher
+        from hermes.server import app
+
+        real_publisher = Publisher()
+
+        async def _capture_publish(payload, publish_timeout=5.0, *, request_id=""):
+            subject = real_publisher._resolve_subject(payload)
+            if subject is not None:
+                published_subjects.append(subject)
+
+        mock_publisher = MagicMock(spec=Publisher)
+        mock_publisher.is_connected = True
+        mock_publisher.active_subjects = []
+        mock_publisher.publish = AsyncMock(side_effect=_capture_publish)
+
+        app.state.publisher = mock_publisher
+
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "evil*host", "name": "bot"},
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        client = TestClient(app, raise_server_exceptions=True)
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+            },
+        )
+
+        assert response.status_code == 202
+        assert len(published_subjects) == 1
+        assert "*" not in published_subjects[0]
+        assert ">" not in published_subjects[0]
+        assert "evil" in published_subjects[0]
+
+    def test_wildcard_in_name_field_is_sanitized_before_publish(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+
+        published_subjects: list[str] = []
+
+        from hermes.publisher import Publisher
+        from hermes.server import app
+
+        real_publisher = Publisher()
+
+        async def _capture_publish(payload, publish_timeout=5.0, *, request_id=""):
+            subject = real_publisher._resolve_subject(payload)
+            if subject is not None:
+                published_subjects.append(subject)
+
+        mock_publisher = MagicMock(spec=Publisher)
+        mock_publisher.is_connected = True
+        mock_publisher.active_subjects = []
+        mock_publisher.publish = AsyncMock(side_effect=_capture_publish)
+
+        app.state.publisher = mock_publisher
+
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "myhost", "name": "bad>bot"},
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        client = TestClient(app, raise_server_exceptions=True)
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+            },
+        )
+
+        assert response.status_code == 202
+        assert len(published_subjects) == 1
+        assert "*" not in published_subjects[0]
+        assert ">" not in published_subjects[0]
+
+
 class TestSubjectsEndpoint:
     def test_subjects_returns_list(self) -> None:
         client = _build_client()


### PR DESCRIPTION
Closes #203
Closes #152

Adds unit tests for `hostId` alias in agent subject parsing and verifies wildcard characters in `host`/`name` fields are sanitized before the subject is published to NATS.

## Changes

- `tests/test_publisher.py`: Two new tests in `TestAgentSubjectMapping` verifying that `hostId` produces the correct subject and that wildcards in `hostId` are sanitized
- `tests/test_webhook.py`: New `TestWildcardInjectionSanitization` class with two end-to-end tests that POST to `/webhook` with wildcard-containing fields and assert the resolved NATS subject contains no `*` or `>` characters

## Test plan
- [x] `test_host_id_field_used_as_host` — `{"hostId": "myhost", "name": "bot"}` → `hi.agents.myhost.bot.created`
- [x] `test_host_id_with_wildcard_is_sanitized` — `{"hostId": "bad*host"}` → subject with no `*` or `>`
- [x] `test_wildcard_in_host_field_is_sanitized_before_publish` — POST with `evil*host` → sanitized subject captured via mock side-effect
- [x] `test_wildcard_in_name_field_is_sanitized_before_publish` — POST with `bad>bot` → sanitized subject

🤖 Generated with [Claude Code](https://claude.com/claude-code)