### PR TITLE
fix(tests): use env vars to configure get_settings in rate_limit tests

### DIFF
--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -6,13 +6,10 @@ import asyncio
 import hashlib
 import hmac as hmac_mod
 import json
-import os
-import sys
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 _TEST_SECRET = "test-webhook-secret-padding-xxxxx"
 _VALID_PAYLOAD = {
@@ -26,25 +23,63 @@ def _sign(body: bytes) -> str:
     return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
 
 
-def _build_client(rate_limit: str = "5/minute") -> TestClient:
-    """Build a TestClient with mocked Publisher and configurable rate limit."""
+@contextmanager
+def _rate_limit_client(rate_limit: str = "5/minute"):
+    """Context manager providing a TestClient with mocked Publisher and configurable rate limit."""
+    import os
     from hermes.server import app
     from hermes.publisher import Publisher
-    from hermes.config import settings
+    from hermes.config import get_settings
+    from hermes.rate_limit import limiter
 
     mock_publisher = MagicMock(spec=Publisher)
     mock_publisher.is_connected = True
     mock_publisher.active_subjects = []
+    mock_publisher.active_subjects_max = 1000
+    mock_publisher.dead_letter_count = 0
     mock_publisher.publish = AsyncMock()
 
     app.state.publisher = mock_publisher
-    settings.webhook_secret = _TEST_SECRET
-    settings.webhook_rate_limit = rate_limit
-
-    # Reset the limiter storage between tests so counts don't bleed across
-    from hermes.rate_limit import limiter
     limiter._storage.reset()  # type: ignore[attr-defined]
 
+    env_overrides = {
+        "WEBHOOK_SECRET": _TEST_SECRET,
+        "WEBHOOK_RATE_LIMIT": rate_limit,
+    }
+    old_env = {k: os.environ.get(k) for k in env_overrides}
+    os.environ.update(env_overrides)
+    get_settings.cache_clear()
+    try:
+        yield TestClient(app, raise_server_exceptions=False)
+    finally:
+        get_settings.cache_clear()
+        for k, v in old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _build_client(rate_limit: str = "5/minute") -> TestClient:
+    import os
+    from hermes.server import app
+    from hermes.publisher import Publisher
+    from hermes.config import get_settings
+    from hermes.rate_limit import limiter
+
+    mock_publisher = MagicMock(spec=Publisher)
+    mock_publisher.is_connected = True
+    mock_publisher.active_subjects = []
+    mock_publisher.active_subjects_max = 1000
+    mock_publisher.dead_letter_count = 0
+    mock_publisher.publish = AsyncMock()
+
+    app.state.publisher = mock_publisher
+    limiter._storage.reset()  # type: ignore[attr-defined]
+
+    os.environ["WEBHOOK_SECRET"] = _TEST_SECRET
+    os.environ["WEBHOOK_RATE_LIMIT"] = rate_limit
+    get_settings.cache_clear()
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -62,38 +97,38 @@ def _post_webhook(client: TestClient, payload: dict | None = None) -> object:
 
 class TestRateLimitEnforcement:
     def test_requests_within_limit_return_202(self) -> None:
-        client = _build_client(rate_limit="5/minute")
-        for _ in range(5):
-            response = _post_webhook(client)
-            assert response.status_code == 202
+        with _rate_limit_client(rate_limit="5/minute") as client:
+            for _ in range(5):
+                response = _post_webhook(client)
+                assert response.status_code == 202
 
     def test_request_exceeding_limit_returns_429(self) -> None:
-        client = _build_client(rate_limit="3/minute")
-        for _ in range(3):
-            _post_webhook(client)
-        response = _post_webhook(client)
+        with _rate_limit_client(rate_limit="3/minute") as client:
+            for _ in range(3):
+                _post_webhook(client)
+            response = _post_webhook(client)
         assert response.status_code == 429
 
     def test_429_response_has_retry_after_header(self) -> None:
-        client = _build_client(rate_limit="2/minute")
-        _post_webhook(client)
-        _post_webhook(client)
-        response = _post_webhook(client)
+        with _rate_limit_client(rate_limit="2/minute") as client:
+            _post_webhook(client)
+            _post_webhook(client)
+            response = _post_webhook(client)
         assert response.status_code == 429
         assert "retry-after" in response.headers
 
     def test_429_response_body_contains_detail(self) -> None:
-        client = _build_client(rate_limit="1/minute")
-        _post_webhook(client)
-        response = _post_webhook(client)
+        with _rate_limit_client(rate_limit="1/minute") as client:
+            _post_webhook(client)
+            response = _post_webhook(client)
         assert response.status_code == 429
         body = response.json()
         assert "detail" in body
 
     def test_retry_after_header_is_numeric(self) -> None:
-        client = _build_client(rate_limit="1/minute")
-        _post_webhook(client)
-        response = _post_webhook(client)
+        with _rate_limit_client(rate_limit="1/minute") as client:
+            _post_webhook(client)
+            response = _post_webhook(client)
         assert response.status_code == 429
         retry_after = response.headers["retry-after"]
         assert retry_after.isdigit() or retry_after.lstrip("-").isdigit()
@@ -101,9 +136,10 @@ class TestRateLimitEnforcement:
 
 class TestNatsPublishTimeout:
     def test_slow_publish_returns_503(self) -> None:
+        import os
         from hermes.server import app
         from hermes.publisher import Publisher
-        from hermes.config import settings
+        from hermes.config import get_settings
         from hermes.rate_limit import limiter
 
         async def _slow_publish(*_args: object, **_kwargs: object) -> None:
@@ -112,17 +148,31 @@ class TestNatsPublishTimeout:
         mock_publisher = MagicMock(spec=Publisher)
         mock_publisher.is_connected = True
         mock_publisher.active_subjects = []
+        mock_publisher.active_subjects_max = 1000
+        mock_publisher.dead_letter_count = 0
         mock_publisher.publish = _slow_publish
 
         app.state.publisher = mock_publisher
-        settings.webhook_secret = _TEST_SECRET
-        settings.webhook_rate_limit = "100/minute"
-
         limiter._storage.reset()  # type: ignore[attr-defined]
 
-        with patch("hermes.server.asyncio.wait_for", side_effect=asyncio.TimeoutError):
-            client = TestClient(app, raise_server_exceptions=False)
-            response = _post_webhook(client)
+        env_overrides = {
+            "WEBHOOK_SECRET": _TEST_SECRET,
+            "WEBHOOK_RATE_LIMIT": "100/minute",
+        }
+        old_env = {k: os.environ.get(k) for k in env_overrides}
+        os.environ.update(env_overrides)
+        get_settings.cache_clear()
+        try:
+            with patch("hermes.server.asyncio.wait_for", side_effect=asyncio.TimeoutError):
+                client = TestClient(app, raise_server_exceptions=False)
+                response = _post_webhook(client)
+        finally:
+            get_settings.cache_clear()
+            for k, v in old_env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
 
         assert response.status_code == 503
         assert "timed out" in response.json()["detail"]

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -199,9 +199,10 @@ class TestWebhookEndpoint:
         )
         assert response.status_code == 401
 
-    def test_invalid_signature_increments_failed_counter(self) -> None:
+    def test_invalid_signature_increments_failed_counter(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from prometheus_client import REGISTRY
 
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         labels = {"reason": "invalid_signature"}
         before = REGISTRY.get_sample_value("hermes_webhooks_failed_total", labels) or 0.0
@@ -227,7 +228,8 @@ class TestWebhookEndpoint:
 class TestSignatureValidation:
     """Tests for _verify_signature behaviour (issue #156)."""
 
-    def test_missing_signature_header_returns_401_when_secret_configured(self) -> None:
+    def test_missing_signature_header_returns_401_when_secret_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",
@@ -237,7 +239,8 @@ class TestSignatureValidation:
         response = client.post("/webhook", json=payload)
         assert response.status_code == 401
 
-    def test_empty_signature_header_returns_401_when_secret_configured(self) -> None:
+    def test_empty_signature_header_returns_401_when_secret_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",


### PR DESCRIPTION
## Summary
- Replaces direct `settings.webhook_secret = ...` mutation (broken after the lru_cache-clearing autouse fixture merged) with env var overrides that prime the cache correctly
- `SettingsDep = Depends(get_settings)` holds a direct reference to the original lru_cache function object, so patching `hermes.server.get_settings` was insufficient — setting env vars and calling `get_settings.cache_clear()` is the correct approach
- All 6 rate-limit tests now pass; fixes cascading CI failures on PRs #283 and #284

## Test plan
- [x] `pixi run pytest tests/test_rate_limit.py -v --no-cov` → 6 passed
- [x] `pixi run just lint` → clean

closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)