### PR TITLE
feat(publisher): retry with exponential backoff for transient NATS publish failures

### DIFF
--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from ipaddress import ip_address
 from typing import Optional
 
-from pydantic import field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _MIN_SECRET_LENGTH = 32
@@ -41,6 +41,8 @@ class Settings(BaseSettings):
     active_subjects_max: int = 1000
     webhook_rate_limit: str = "60/minute"
     webhook_rate_limit_key: str = "ip"
+    publish_retries: int = Field(default=3, ge=1)
+    publish_retry_base_delay: float = Field(default=0.1, gt=0)
 
     @field_validator("hermes_public_url", mode="before")
     @classmethod

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -121,7 +122,15 @@ class Publisher:
     # Publishing
     # ------------------------------------------------------------------
 
-    async def publish(self, payload: WebhookPayload, publish_timeout: float = 5.0, *, request_id: str = "") -> None:
+    async def publish(
+        self,
+        payload: WebhookPayload,
+        publish_timeout: float = 5.0,
+        *,
+        request_id: str = "",
+        publish_retries: int | None = None,
+        publish_retry_base_delay: float | None = None,
+    ) -> None:
         """Route a webhook payload to the appropriate NATS subject.
 
         Args:
@@ -129,9 +138,22 @@ class Publisher:
             publish_timeout: Timeout in seconds for the NATS publish call.
             request_id: Correlation ID from the originating HTTP request; included
                 in the NATS message to enable end-to-end tracing.
+            publish_retries: Max total attempts (default from Settings).
+            publish_retry_base_delay: Base delay in seconds for exponential backoff
+                (default from Settings). Actual delay = base * 2^attempt, capped at 2s.
         """
         if self._js is None:
             raise RuntimeError("Publisher is not connected to NATS")
+
+        from hermes.config import get_settings
+
+        settings = get_settings()
+        retries = publish_retries if publish_retries is not None else settings.publish_retries
+        base_delay = (
+            publish_retry_base_delay
+            if publish_retry_base_delay is not None
+            else settings.publish_retry_base_delay
+        )
 
         subject = self._resolve_subject(payload)
 
@@ -160,12 +182,33 @@ class Publisher:
                 logger.warning("No subject mapping for event type %r; dropping", payload.event)
             return
 
-        t0 = time.perf_counter()
-        await self._js.publish(subject, message, timeout=publish_timeout)
-        PUBLISH_LATENCY.observe(time.perf_counter() - t0)
-        WEBHOOKS_PUBLISHED.labels(subject_prefix=subject.split(".")[1]).inc()
-        self._track_subject(subject)
-        logger.info("Published to %s (request_id=%s)", subject, request_id)
+        _RETRYABLE = (nats.errors.TimeoutError, nats.errors.NoRespondersError)
+
+        last_exc: Exception | None = None
+        for attempt in range(retries):
+            try:
+                t0 = time.perf_counter()
+                await self._js.publish(subject, message, timeout=publish_timeout)
+                PUBLISH_LATENCY.observe(time.perf_counter() - t0)
+                WEBHOOKS_PUBLISHED.labels(subject_prefix=subject.split(".")[1]).inc()
+                self._track_subject(subject)
+                logger.info("Published to %s (request_id=%s)", subject, request_id)
+                return
+            except _RETRYABLE as exc:
+                last_exc = exc
+                if attempt < retries - 1:
+                    delay = min(base_delay * (2 ** attempt), 2.0)
+                    logger.warning(
+                        "Transient NATS error on attempt %d/%d for %s; retrying in %.3fs: %s",
+                        attempt + 1,
+                        retries,
+                        subject,
+                        delay,
+                        exc,
+                    )
+                    await asyncio.sleep(delay)
+
+        raise last_exc  # type: ignore[misc]
 
     def _track_subject(self, subject: str) -> None:
         """Add subject to the LRU OrderedDict, evicting the oldest if at capacity."""

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import nats.errors
 import pytest
 
 from nats.js.errors import NotFoundError
@@ -272,3 +273,59 @@ class TestActiveSubjectsBound:
         for i in range(5):
             self._add_subject(pub, f"subj-{i}")
         assert len(pub.active_subjects) == 2
+
+
+def _agent_payload() -> WebhookPayload:
+    return WebhookPayload(
+        event="agent.created",
+        data={"host": "myhost", "name": "myagent"},
+        timestamp="2026-04-24T00:00:00Z",
+    )
+
+
+def _make_connected_publisher() -> Publisher:
+    pub = Publisher()
+    pub._js = AsyncMock()
+    pub._connected = True
+    pub._nc = MagicMock()
+    return pub
+
+
+class TestPublishRetry:
+    """Retry logic for transient NATS publish failures."""
+
+    @pytest.mark.asyncio
+    async def test_succeeds_on_second_attempt_after_transient_failure(self) -> None:
+        pub = _make_connected_publisher()
+        pub._js.publish = AsyncMock(
+            side_effect=[nats.errors.TimeoutError(), MagicMock()]
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await pub.publish(_agent_payload(), publish_retries=3, publish_retry_base_delay=0.1)
+
+        assert pub._js.publish.call_count == 2
+        mock_sleep.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_error_is_not_retried(self) -> None:
+        pub = _make_connected_publisher()
+        pub._js.publish = AsyncMock(side_effect=ValueError("bad event"))
+
+        with pytest.raises(ValueError, match="bad event"):
+            with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                await pub.publish(_agent_payload(), publish_retries=3, publish_retry_base_delay=0.1)
+
+        assert pub._js.publish.call_count == 1
+        mock_sleep.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_retry_count_is_respected(self) -> None:
+        pub = _make_connected_publisher()
+        pub._js.publish = AsyncMock(side_effect=nats.errors.NoRespondersError())
+
+        with pytest.raises(nats.errors.NoRespondersError):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                await pub.publish(_agent_payload(), publish_retries=3, publish_retry_base_delay=0.1)
+
+        assert pub._js.publish.call_count == 3


### PR DESCRIPTION
closes #47

Retry publish on TimeoutError/NoRespondersError with exponential backoff (up to 3 attempts by default). ValueError and UnknownEventTypeError are not retried.