### PR TITLE
feat(health): surface NATS reconnect count, last error, and retry config in /health

### DIFF
--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -66,6 +66,10 @@ class HealthResponse(BaseModel):
     inflight_requests: int = 0
     dead_letter_count: int = 0
     timeouts: TimeoutSettings | None = None
+    nats_reconnect_count: int = 0
+    nats_last_error: str = ""
+    nats_retry_attempts: int = 3
+    nats_retry_interval: float = 5.0
 
 
 class WebhookAcceptedResponse(BaseModel):

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -52,6 +52,8 @@ class Publisher:
         self._dead_letters: deque[dict[str, Any]] = deque(maxlen=1000)
         self._enable_dead_letter = enable_dead_letter
         self._connected: bool = False
+        self.reconnect_count: int = 0
+        self.last_error: str = ""
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -61,11 +63,13 @@ class Publisher:
         """Connect to the NATS server, obtain JetStream context, and ensure streams exist."""
         async def _on_disconnected() -> None:
             self._connected = False
+            self.last_error = "NATS disconnected"
             logger.warning("NATS disconnected")
 
         async def _on_reconnected() -> None:
             self._connected = True
-            logger.info("NATS reconnected")
+            self.reconnect_count += 1
+            logger.info("NATS reconnected (count=%d)", self.reconnect_count)
 
         self._nc = await nats.connect(
             url,

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -254,6 +254,10 @@ async def health(response: Response) -> HealthResponse:
             nats_publish=cfg.nats_publish_timeout,
             agamemnon=cfg.agamemnon_timeout,
         ),
+        nats_reconnect_count=publisher.reconnect_count,
+        nats_last_error=publisher.last_error,
+        nats_retry_attempts=_NATS_RETRY_ATTEMPTS,
+        nats_retry_interval=float(_NATS_RETRY_INTERVAL),
     )
 
 

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -256,8 +256,8 @@ async def health(response: Response) -> HealthResponse:
         ),
         nats_reconnect_count=publisher.reconnect_count,
         nats_last_error=publisher.last_error,
-        nats_retry_attempts=_NATS_RETRY_ATTEMPTS,
-        nats_retry_interval=float(_NATS_RETRY_INTERVAL),
+        nats_retry_attempts=cfg.nats_retry_attempts,
+        nats_retry_interval=float(cfg.nats_retry_interval),
     )
 
 

--- a/tests/test_publisher_callbacks.py
+++ b/tests/test_publisher_callbacks.py
@@ -79,6 +79,52 @@ class TestPublisherConnectionCallbacks:
         assert pub.is_connected is True
 
     @pytest.mark.asyncio
+    async def test_reconnected_cb_increments_reconnect_count(self) -> None:
+        pub = Publisher()
+        mock_nc = MagicMock()
+        mock_nc.jetstream.return_value = MagicMock()
+        jsm = AsyncMock()
+        jsm.find_stream = AsyncMock()
+        mock_nc.jsm.return_value = jsm
+
+        captured_callbacks: dict[str, object] = {}
+
+        async def fake_connect(url: str, **kwargs: object) -> MagicMock:
+            captured_callbacks.update(kwargs)
+            return mock_nc
+
+        with patch("nats.connect", side_effect=fake_connect):
+            await pub.connect("nats://localhost:4222")
+
+        assert pub.reconnect_count == 0
+        await captured_callbacks["reconnected_cb"]()  # type: ignore[operator]
+        assert pub.reconnect_count == 1
+        await captured_callbacks["reconnected_cb"]()  # type: ignore[operator]
+        assert pub.reconnect_count == 2
+
+    @pytest.mark.asyncio
+    async def test_disconnected_cb_sets_last_error(self) -> None:
+        pub = Publisher()
+        mock_nc = MagicMock()
+        mock_nc.jetstream.return_value = MagicMock()
+        jsm = AsyncMock()
+        jsm.find_stream = AsyncMock()
+        mock_nc.jsm.return_value = jsm
+
+        captured_callbacks: dict[str, object] = {}
+
+        async def fake_connect(url: str, **kwargs: object) -> MagicMock:
+            captured_callbacks.update(kwargs)
+            return mock_nc
+
+        with patch("nats.connect", side_effect=fake_connect):
+            await pub.connect("nats://localhost:4222")
+
+        assert pub.last_error == ""
+        await captured_callbacks["disconnected_cb"]()  # type: ignore[operator]
+        assert pub.last_error == "NATS disconnected"
+
+    @pytest.mark.asyncio
     async def test_disconnect_method_clears_connected_flag(self) -> None:
         pub = Publisher()
         mock_nc = MagicMock()

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -23,6 +23,8 @@ def _make_mock_publisher(*, connected: bool = True) -> MagicMock:
     mock.active_subjects = []
     mock.publish = AsyncMock()
     mock.disconnect = AsyncMock()
+    mock.reconnect_count = 0
+    mock.last_error = ""
     return mock
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -20,7 +20,12 @@ def _sign(body: bytes) -> str:
     return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
 
 
-def _build_client(*, connected: bool = True) -> TestClient:
+def _build_client(
+    *,
+    connected: bool = True,
+    reconnect_count: int = 0,
+    last_error: str = "",
+) -> TestClient:
     """Build a TestClient with a mocked Publisher and a known webhook secret."""
     from hermes.config import get_settings
     from hermes.publisher import Publisher
@@ -31,6 +36,8 @@ def _build_client(*, connected: bool = True) -> TestClient:
     mock_publisher.active_subjects = []
     mock_publisher.dead_letter_count = 0
     mock_publisher.publish = AsyncMock()
+    mock_publisher.reconnect_count = reconnect_count
+    mock_publisher.last_error = last_error
 
     # Inject the mock before the test client starts
     app.state.publisher = mock_publisher
@@ -117,6 +124,42 @@ class TestHealthEndpoint:
         client = TestClient(app, raise_server_exceptions=True)
         body = client.get("/health").json()
         assert body["dead_letter_count"] == 7
+
+    def test_health_includes_nats_reconnect_count(self) -> None:
+        client = _build_client(reconnect_count=3)
+        body = client.get("/health").json()
+        assert "nats_reconnect_count" in body
+        assert body["nats_reconnect_count"] == 3
+
+    def test_health_reconnect_count_defaults_to_zero(self) -> None:
+        client = _build_client()
+        body = client.get("/health").json()
+        assert body["nats_reconnect_count"] == 0
+
+    def test_health_includes_nats_last_error(self) -> None:
+        client = _build_client(last_error="NATS disconnected")
+        body = client.get("/health").json()
+        assert "nats_last_error" in body
+        assert body["nats_last_error"] == "NATS disconnected"
+
+    def test_health_last_error_defaults_to_empty_string(self) -> None:
+        client = _build_client()
+        body = client.get("/health").json()
+        assert body["nats_last_error"] == ""
+
+    def test_health_includes_nats_retry_attempts(self) -> None:
+        client = _build_client()
+        body = client.get("/health").json()
+        assert "nats_retry_attempts" in body
+        assert isinstance(body["nats_retry_attempts"], int)
+        assert body["nats_retry_attempts"] == 3
+
+    def test_health_includes_nats_retry_interval(self) -> None:
+        client = _build_client()
+        body = client.get("/health").json()
+        assert "nats_retry_interval" in body
+        assert isinstance(body["nats_retry_interval"], float)
+        assert body["nats_retry_interval"] == 5.0
 
 
 class TestReadyEndpoint:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -118,6 +118,8 @@ class TestHealthEndpoint:
         mock_publisher.is_connected = True
         mock_publisher.active_subjects = []
         mock_publisher.dead_letter_count = 7
+        mock_publisher.reconnect_count = 0
+        mock_publisher.last_error = ""
         mock_publisher.publish = AsyncMock()
         app.state.publisher = mock_publisher
 


### PR DESCRIPTION
closes #81
closes #214

Add reconnect_count, last_error, nats_retry_attempts, and nats_retry_interval to /health response body.

## Changes

- `Publisher`: added `reconnect_count: int` and `last_error: str` attributes; `_on_disconnected` sets `last_error`; `_on_reconnected` increments `reconnect_count`
- `HealthResponse`: added `nats_reconnect_count`, `nats_last_error`, `nats_retry_attempts`, `nats_retry_interval` fields
- `/health` handler: populates all four new fields from the publisher and module-level retry constants
- Tests: new assertions in `TestHealthEndpoint` for all four fields; new callback tests in `test_publisher_callbacks.py` verifying reconnect count increments and last error is set on disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)