### PR TITLE
fix(ci): --no-cov for integration job; fix HMAC tests missing env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,4 +67,4 @@ jobs:
       - name: Integration tests
         env:
           TEST_NATS_URL: nats://localhost:4222
-        run: pixi run pytest -m integration -v
+        run: pixi run pytest -m integration -v --no-cov

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -199,9 +199,10 @@ class TestWebhookEndpoint:
         )
         assert response.status_code == 401
 
-    def test_invalid_signature_increments_failed_counter(self) -> None:
+    def test_invalid_signature_increments_failed_counter(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from prometheus_client import REGISTRY
 
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         labels = {"reason": "invalid_signature"}
         before = REGISTRY.get_sample_value("hermes_webhooks_failed_total", labels) or 0.0
@@ -227,7 +228,8 @@ class TestWebhookEndpoint:
 class TestSignatureValidation:
     """Tests for _verify_signature behaviour (issue #156)."""
 
-    def test_missing_signature_header_returns_401_when_secret_configured(self) -> None:
+    def test_missing_signature_header_returns_401_when_secret_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",
@@ -237,7 +239,8 @@ class TestSignatureValidation:
         response = client.post("/webhook", json=payload)
         assert response.status_code == 401
 
-    def test_empty_signature_header_returns_401_when_secret_configured(self) -> None:
+    def test_empty_signature_header_returns_401_when_secret_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",


### PR DESCRIPTION
## Summary
- Integration test CI job runs only ~13 tests covering 79% — below the 80% `fail_under` threshold in `addopts`. Passes `--no-cov` to avoid enforcing unit-test coverage thresholds on an integration-only run.
- Three tests (`test_invalid_signature_increments_failed_counter`, `test_missing_signature_header_returns_401_when_secret_configured`, `test_empty_signature_header_returns_401_when_secret_configured`) called `_build_client()` expecting 401 but never set `WEBHOOK_SECRET` in the environment — they pass locally via `.env` file but fail in CI. Fixed with `monkeypatch.setenv`.

## Test plan
- [x] `WEBHOOK_SECRET="" pixi run pytest tests/test_webhook.py --no-cov` → 33 passed
- [x] `pixi run just lint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)