### PR TITLE
test: add publisher raise→500, HERMES_HOST env, log detail tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -82,6 +82,19 @@ class TestHermesHostValidation:
         assert s.hermes_host == "::1"
 
 
+class TestGetSettingsEnvOverride:
+    """Issue #136 — get_settings() must reflect HERMES_HOST env-var override."""
+
+    def test_get_settings_reflects_hermes_host_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """monkeypatch HERMES_HOST and verify get_settings() picks it up."""
+        monkeypatch.setenv("HERMES_HOST", "127.0.0.1")
+        from hermes.config import get_settings
+
+        assert get_settings().hermes_host == "127.0.0.1"
+
+
 class TestHermesPublicUrl:
     def test_public_url_defaults_to_localhost_port(self) -> None:
         from hermes.config import Settings

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -932,3 +932,96 @@ class TestMissingFieldWarnings:
             pub = Publisher()
             pub._parse_agent_subject({"host": "myhost", "name": "bot"}, "agent.created")
             assert not mock_log.warning.called
+
+
+class TestPublisherRaises:
+    """Issue #122 — publisher.publish() raising must return 500, not propagate."""
+
+    def test_publish_runtime_error_returns_500(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When publisher.publish raises RuntimeError the endpoint returns 500."""
+        from hermes.publisher import Publisher
+        from hermes.server import app
+
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+
+        mock_publisher = MagicMock(spec=Publisher)
+        mock_publisher.is_connected = True
+        mock_publisher.active_subjects = []
+        mock_publisher.publish = AsyncMock(side_effect=RuntimeError("NATS exploded"))
+
+        app.state.publisher = mock_publisher
+        client = TestClient(app, raise_server_exceptions=False)
+
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "localhost", "name": "bot"},
+            "timestamp": "2026-03-15T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+            },
+        )
+        assert response.status_code == 500
+
+
+class TestExceptionDetailNotLeaked:
+    """Issue #158 — internal exception detail must not appear in response body."""
+
+    def test_invalid_payload_response_has_no_traceback(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """422 response body must only contain 'detail', no stack trace or internal info."""
+        import logging
+
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        client = _build_client()
+        body_bytes = json.dumps({"bad": "payload"}).encode()
+
+        with caplog.at_level(logging.WARNING):
+            response = client.post(
+                "/webhook",
+                content=body_bytes,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Webhook-Signature": _sign(body_bytes),
+                },
+            )
+
+        assert response.status_code == 422
+        body_text = response.text
+        assert "Traceback" not in body_text
+        assert "File " not in body_text
+        assert "detail" in response.json()
+
+    def test_invalid_payload_emits_warning_log(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A WARNING-level log must be emitted when the webhook payload is invalid."""
+        import logging
+
+        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        client = _build_client()
+        body_bytes = json.dumps({"bad": "payload"}).encode()
+
+        with caplog.at_level(logging.WARNING, logger="hermes"):
+            response = client.post(
+                "/webhook",
+                content=body_bytes,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Webhook-Signature": _sign(body_bytes),
+                },
+            )
+
+        assert response.status_code == 422
+        warning_records = [
+            r for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert len(warning_records) >= 1


### PR DESCRIPTION
closes #122
closes #136
closes #158

## Summary
- Add test that `publisher.publish()` raising `RuntimeError` returns a 500 response (using `raise_server_exceptions=False`)
- Add test that `get_settings()` reflects `HERMES_HOST` env-var override via `monkeypatch.setenv`
- Add tests that invalid webhook payload 422 response body contains no stack trace and a WARNING log is emitted

## Test plan
- [ ] `pixi run just test` passes (217 tests pass, 1 pre-existing failure in test_shutdown.py unrelated to this PR)
- [ ] `pixi run just lint` passes
- [ ] Coverage remains at 98%

🤖 Generated with [Claude Code](https://claude.com/claude-code)