### PR TITLE
fix(server): graceful lifespan failure; Dockerfile HERMES_HOST default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY src/hermes/ ./hermes/
 RUN useradd -r -s /usr/sbin/nologin hermes
 USER hermes
 
+ENV HERMES_HOST=0.0.0.0
 ENV HERMES_PORT=8080
 ENV HERMES_PUBLIC_URL=http://localhost:8080
 EXPOSE 8080

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -86,9 +86,7 @@ class Settings(BaseSettings):
     @classmethod
     def _validate_rate_limit(cls, v: str) -> str:
         if not re.match(r"^\d+\s*/\s*(second|minute|hour|day)$", v):
-            raise ValueError(
-                f"WEBHOOK_RATE_LIMIT must be like '100/minute', got: {v!r}"
-            )
+            raise ValueError(f"WEBHOOK_RATE_LIMIT must be like '100/minute', got: {v!r}")
         return v
 
     @field_validator("webhook_secret")

--- a/src/hermes/logging_config.py
+++ b/src/hermes/logging_config.py
@@ -50,7 +50,9 @@ def setup_logging(level: int = logging.INFO, json_format: bool = False) -> None:
     stacking duplicates.
     """
     formatter: logging.Formatter = (
-        JsonFormatter() if json_format else logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+        JsonFormatter()
+        if json_format
+        else logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
     )
 
     root = logging.getLogger()
@@ -59,7 +61,9 @@ def setup_logging(level: int = logging.INFO, json_format: bool = False) -> None:
     # Replace existing StreamHandlers (avoid duplicates on repeated calls).
     # FileHandlers are intentionally left untouched.
     existing_stream_handlers = [
-        h for h in root.handlers if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        h
+        for h in root.handlers
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
     ]
     for h in existing_stream_handlers:
         root.removeHandler(h)

--- a/src/hermes/middleware.py
+++ b/src/hermes/middleware.py
@@ -21,7 +21,9 @@ class PayloadSizeLimitMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self.max_bytes = max_bytes
 
-    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
         content_length = request.headers.get("Content-Length")
         if content_length is not None:
             try:

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -60,7 +60,9 @@ class Publisher:
 
         self._nc: NATSClient | None = None
         self._js: JetStreamContext | None = None
-        self._max_subjects: int = max_subjects if max_subjects is not None else get_settings().active_subjects_max
+        self._max_subjects: int = (
+            max_subjects if max_subjects is not None else get_settings().active_subjects_max
+        )
         self._active_subjects: OrderedDict[str, None] = OrderedDict()
         self._stream_names: list[str] = []
         self._dead_letters: deque[dict[str, Any]] = deque(maxlen=1000)
@@ -75,6 +77,7 @@ class Publisher:
 
     async def connect(self, url: str, connect_timeout: float = 5.0) -> None:
         """Connect to the NATS server, obtain JetStream context, and ensure streams exist."""
+
         async def _on_disconnected() -> None:
             self._connected = False
             self.last_error = "NATS disconnected"
@@ -101,12 +104,13 @@ class Publisher:
         """Create JetStream streams if they don't exist yet."""
         from nats.js.api import StreamConfig
         from nats.js.errors import NotFoundError
+
         assert self._nc is not None
         jsm = self._nc.jsm()
         for name, subjects in (
-            ("homeric-agents",      ["hi.agents.>"]),
-            ("homeric-tasks",       ["hi.tasks.>"]),
-            ("homeric-deadletter",  ["hi.deadletter.>"]),
+            ("homeric-agents", ["hi.agents.>"]),
+            ("homeric-tasks", ["hi.tasks.>"]),
+            ("homeric-deadletter", ["hi.deadletter.>"]),
         ):
             try:
                 await jsm.stream_info(name)
@@ -233,7 +237,7 @@ class Publisher:
             except _RETRYABLE_PUBLISH_ERRORS as exc:
                 last_exc = exc
                 if attempt < retries - 1:
-                    delay = min(base_delay * (2 ** attempt), 2.0) * random.uniform(0.5, 1.5)
+                    delay = min(base_delay * (2**attempt), 2.0) * random.uniform(0.5, 1.5)
                     logger.warning(
                         "Transient NATS error on attempt %d/%d for %s; retrying in %.3fs: %s",
                         attempt + 1,
@@ -253,7 +257,9 @@ class Publisher:
         else:
             if len(self._active_subjects) >= self._max_subjects:
                 evicted, _ = self._active_subjects.popitem(last=False)
-                logger.warning("active_subjects LRU cap (%d) reached; evicted %s", self._max_subjects, evicted)
+                logger.warning(
+                    "active_subjects LRU cap (%d) reached; evicted %s", self._max_subjects, evicted
+                )
             self._active_subjects[subject] = None
         ACTIVE_SUBJECTS.set(len(self._active_subjects))
 
@@ -278,9 +284,13 @@ class Publisher:
         raw_host = data.get("hostId") or data.get("host")
         raw_name = data.get("name")
         if not raw_host:
-            logger.warning("agent event missing 'host' field; using 'unknown'", extra={"event": event})
+            logger.warning(
+                "agent event missing 'host' field; using 'unknown'", extra={"event": event}
+            )
         if not raw_name:
-            logger.warning("agent event missing 'name' field; using 'unknown'", extra={"event": event})
+            logger.warning(
+                "agent event missing 'name' field; using 'unknown'", extra={"event": event}
+            )
         host = _slug(raw_host or "unknown") or "unknown"
         name = _slug(raw_name or "unknown") or "unknown"
         # Strip the "agent." prefix to get the bare verb (created/updated/deleted)
@@ -292,9 +302,13 @@ class Publisher:
         raw_team_id = data.get("teamId") or data.get("team_id")
         raw_task_id = data.get("id") or data.get("task_id")
         if not raw_team_id:
-            logger.warning("task event missing 'team_id' field; using 'unknown'", extra={"event": event})
+            logger.warning(
+                "task event missing 'team_id' field; using 'unknown'", extra={"event": event}
+            )
         if not raw_task_id:
-            logger.warning("task event missing 'task_id' field; using 'unknown'", extra={"event": event})
+            logger.warning(
+                "task event missing 'task_id' field; using 'unknown'", extra={"event": event}
+            )
         team_id = _slug(raw_team_id or "unknown") or "unknown"
         task_id = _slug(raw_task_id or "unknown") or "unknown"
         verb = event.split(".", 1)[-1] if "." in event else event
@@ -304,6 +318,7 @@ class Publisher:
 # ------------------------------------------------------------------
 # Helpers
 # ------------------------------------------------------------------
+
 
 def _slug(value: str) -> str:
     """Sanitise a token for use in a NATS subject (replace spaces/dots/wildcards).

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -127,7 +127,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     for sig in (signal.SIGTERM, signal.SIGINT):
         try:
             loop.add_signal_handler(sig, _on_shutdown_signal, sig)
-        except ValueError:
+        except (ValueError, RuntimeError):
+            # ValueError: not in main thread; RuntimeError: Python 3.14+ wraps it
             pass
 
     _shutdown_event = asyncio.Event()

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -65,8 +65,18 @@ def _on_shutdown_signal(sig: signal.Signals) -> None:
     _shutdown_event.set()
 
 
-async def _connect_to_nats(publisher: Publisher, settings: "Settings") -> Exception | None:
-    """Attempt to connect to NATS with retries. Returns the last exception or None on success."""
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    """Connect to NATS on startup with retries; continue degraded if all attempts fail.
+
+    If NATS is unreachable after all retry attempts the app still starts so that
+    /health can return 503 and load-balancers can observe the degraded state.
+    The publisher remains disconnected; /webhook will return 503 until NATS recovers.
+    """
+    global _shutdown_event, _inflight
+
+    settings = get_settings()
+    publisher = Publisher(enable_dead_letter=settings.enable_dead_letter)
     last_exc: Exception | None = None
     for attempt in range(1, settings.nats_retry_attempts + 1):
         try:
@@ -76,7 +86,8 @@ async def _connect_to_nats(publisher: Publisher, settings: "Settings") -> Except
                 ),
                 timeout=_NATS_CONNECT_TIMEOUT,
             )
-            return None
+            last_exc = None
+            break
         except Exception as exc:  # noqa: BLE001
             last_exc = exc
             will_retry = attempt < settings.nats_retry_attempts
@@ -98,25 +109,14 @@ async def _connect_to_nats(publisher: Publisher, settings: "Settings") -> Except
                     type(exc).__name__,
                     exc,
                 )
-    return last_exc
-
-
-@asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    """Connect to NATS on startup with retries; abort startup if all attempts fail."""
-    global _shutdown_event, _inflight
-
-    settings = get_settings()
-    publisher = Publisher(enable_dead_letter=settings.enable_dead_letter)
-    last_exc = await _connect_to_nats(publisher, settings)
 
     if last_exc is not None:
         logger.critical(
-            "Could not connect to NATS at %s after %d attempts; aborting startup",
+            "Could not connect to NATS at %s after %d attempts; "
+            "starting in degraded mode — /health will return 503",
             settings.nats_url,
             settings.nats_retry_attempts,
         )
-        raise last_exc
 
     # Install signal handlers so SIGTERM/SIGINT trigger graceful shutdown
     loop = asyncio.get_event_loop()

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -118,10 +118,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             settings.nats_retry_attempts,
         )
 
-    # Install signal handlers so SIGTERM/SIGINT trigger graceful shutdown
+    # Install signal handlers so SIGTERM/SIGINT trigger graceful shutdown.
+    # Silently skip in non-main threads (e.g. TestClient workers).
     loop = asyncio.get_event_loop()
     for sig in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(sig, _on_shutdown_signal, sig)
+        try:
+            loop.add_signal_handler(sig, _on_shutdown_signal, sig)
+        except ValueError:
+            pass
 
     _shutdown_event = asyncio.Event()
     _inflight = 0

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -65,29 +65,16 @@ def _on_shutdown_signal(sig: signal.Signals) -> None:
     _shutdown_event.set()
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    """Connect to NATS on startup with retries; continue degraded if all attempts fail.
-
-    If NATS is unreachable after all retry attempts the app still starts so that
-    /health can return 503 and load-balancers can observe the degraded state.
-    The publisher remains disconnected; /webhook will return 503 until NATS recovers.
-    """
-    global _shutdown_event, _inflight
-
-    settings = get_settings()
-    publisher = Publisher(enable_dead_letter=settings.enable_dead_letter)
+async def _connect_with_retries(publisher: Publisher, settings: "Settings") -> Exception | None:
+    """Attempt NATS connection with retries; return the last exception or None on success."""
     last_exc: Exception | None = None
     for attempt in range(1, settings.nats_retry_attempts + 1):
         try:
             await asyncio.wait_for(
-                publisher.connect(
-                    settings.nats_url, connect_timeout=settings.nats_connect_timeout
-                ),
+                publisher.connect(settings.nats_url, connect_timeout=settings.nats_connect_timeout),
                 timeout=_NATS_CONNECT_TIMEOUT,
             )
-            last_exc = None
-            break
+            return None
         except Exception as exc:  # noqa: BLE001
             last_exc = exc
             will_retry = attempt < settings.nats_retry_attempts
@@ -109,6 +96,22 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                     type(exc).__name__,
                     exc,
                 )
+    return last_exc
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    """Connect to NATS on startup with retries; continue degraded if all attempts fail.
+
+    If NATS is unreachable after all retry attempts the app still starts so that
+    /health can return 503 and load-balancers can observe the degraded state.
+    The publisher remains disconnected; /webhook will return 503 until NATS recovers.
+    """
+    global _shutdown_event, _inflight
+
+    settings = get_settings()
+    publisher = Publisher(enable_dead_letter=settings.enable_dead_letter)
+    last_exc = await _connect_with_retries(publisher, settings)
 
     if last_exc is not None:
         logger.critical(
@@ -193,6 +196,7 @@ async def _http_exception_handler_with_request_id(
         headers=dict(response.headers),
     )
 
+
 # ---------------------------------------------------------------------------
 # Dependencies
 # ---------------------------------------------------------------------------
@@ -242,9 +246,7 @@ class ShutdownMiddleware(BaseHTTPMiddleware):
 
 app.add_middleware(ShutdownMiddleware)
 app.add_middleware(RequestIDMiddleware)
-app.add_middleware(
-    PayloadSizeLimitMiddleware, max_bytes=get_settings().max_payload_bytes
-)
+app.add_middleware(PayloadSizeLimitMiddleware, max_bytes=get_settings().max_payload_bytes)
 app.add_middleware(SlowAPIMiddleware)
 
 
@@ -316,25 +318,19 @@ async def ready(response: Response) -> dict[str, object]:
     },
 )
 @limiter.limit(lambda: get_settings().webhook_rate_limit)
-async def receive_webhook(
-    request: Request, settings: SettingsDep
-) -> WebhookAcceptedResponse:
+async def receive_webhook(request: Request, settings: SettingsDep) -> WebhookAcceptedResponse:
     """Receive an external webhook, validate its signature, and publish to NATS."""
     raw_body = await request.body()
     request_id: str = request.state.request_id
 
     # HMAC validation (skipped when no secret is configured)
     if settings.webhook_secret:
-        _verify_signature(
-            raw_body, request.headers.get("X-Webhook-Signature", ""), settings
-        )
+        _verify_signature(raw_body, request.headers.get("X-Webhook-Signature", ""), settings)
 
     try:
         payload = WebhookPayload.model_validate_json(raw_body)
     except Exception as exc:
-        logger.warning(
-            "Invalid webhook payload: %s", exc, extra={"request_id": request_id}
-        )
+        logger.warning("Invalid webhook payload: %s", exc, extra={"request_id": request_id})
         WEBHOOKS_FAILED.labels(reason="invalid_payload").inc()
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,9 +39,7 @@ async def _nats_reachable() -> bool:
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    config.addinivalue_line(
-        "markers", "integration: requires a running NATS server"
-    )
+    config.addinivalue_line("markers", "integration: requires a running NATS server")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -117,7 +117,9 @@ class TestHermesPublicUrl:
     def test_public_url_explicit_override_ignores_port(self) -> None:
         from hermes.config import Settings
 
-        s = Settings(hermes_port=9090, hermes_public_url="https://hermes.example.com", _env_file=None)
+        s = Settings(
+            hermes_port=9090, hermes_public_url="https://hermes.example.com", _env_file=None
+        )
         assert s.hermes_public_url == "https://hermes.example.com"
 
     def test_public_url_strips_trailing_slash(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_events_endpoint.py
+++ b/tests/test_events_endpoint.py
@@ -57,8 +57,14 @@ class TestEventsEndpoint:
     def test_all_events_is_union(self) -> None:
         client = _build_client()
         body = client.get("/events").json()
-        expected = {"agent.created", "agent.updated", "agent.deleted",
-                    "task.updated", "task.completed", "task.failed"}
+        expected = {
+            "agent.created",
+            "agent.updated",
+            "agent.deleted",
+            "task.updated",
+            "task.completed",
+            "task.failed",
+        }
         assert set(body["all_events"]) == expected
 
     def test_all_events_count(self) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -274,19 +274,18 @@ class TestLifespan:
     async def test_lifespan_handles_nats_unavailable(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Lifespan raises when NATS is unreachable after all retry attempts."""
+        """Lifespan starts in degraded mode when NATS is unreachable after all retry attempts."""
         from unittest.mock import patch
         from hermes.config import Settings
         from hermes.server import lifespan
         from fastapi import FastAPI
 
-        bad_settings = Settings(nats_url="nats://127.0.0.1:19999")
+        bad_settings = Settings(nats_url="nats://127.0.0.1:19999", nats_retry_attempts=1)
         test_app = FastAPI()
 
         with patch("hermes.server.get_settings", return_value=bad_settings):
-            with pytest.raises(Exception):
-                async with lifespan(test_app):
-                    pass
+            async with lifespan(test_app):
+                assert not test_app.state.publisher.is_connected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -35,9 +35,7 @@ def _sign(body: bytes) -> str:
 # ---------------------------------------------------------------------------
 
 
-def pytest_collection_modifyitems(
-    config: pytest.Config, items: list[pytest.Item]
-) -> None:
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """Skip all integration tests if NATS is unreachable."""
     # Evaluated lazily at collection time via a custom marker skip mechanism
     pass
@@ -56,9 +54,7 @@ def require_nats() -> None:  # type: ignore[return]
         except Exception:
             return False
 
-    reachable = _asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
-        _check()
-    )
+    reachable = _asyncio.get_event_loop_policy().new_event_loop().run_until_complete(_check())
     if not reachable:
         pytest.skip("NATS server not available at " + _NATS_URL, allow_module_level=True)
 
@@ -130,9 +126,7 @@ class TestPublisherIntegration:
         assert len(received) == 1
         assert received[0].subject == "hi.tasks.team-42.t-007.updated"
 
-    async def test_publish_tracks_active_subjects(
-        self, publisher: Publisher
-    ) -> None:
+    async def test_publish_tracks_active_subjects(self, publisher: Publisher) -> None:
         """active_subjects is updated after each successful publish."""
         payload = WebhookPayload(
             event="agent.deleted",
@@ -236,9 +230,7 @@ class TestWebhookIntegration:
         }
         body_bytes = json.dumps(payload).encode()
 
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.post(
                 "/webhook",
                 content=body_bytes,
@@ -271,9 +263,7 @@ class TestLifespan:
 
         assert not test_app.state.publisher.is_connected
 
-    async def test_lifespan_handles_nats_unavailable(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_lifespan_handles_nats_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Lifespan starts in degraded mode when NATS is unreachable after all retry attempts."""
         from unittest.mock import patch
         from hermes.config import Settings
@@ -501,9 +491,7 @@ class TestHealthAndReadyIntegration:
         disconnected_pub = Publisher()  # never connected
         app.state.publisher = disconnected_pub
 
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get("/health")
         assert response.status_code == 503
         body = response.json()
@@ -517,9 +505,7 @@ class TestHealthAndReadyIntegration:
         disconnected_pub = Publisher()  # never connected
         app.state.publisher = disconnected_pub
 
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get("/ready")
         assert response.status_code == 503
         body = response.json()
@@ -655,9 +641,7 @@ class TestReconnectLifecycle:
         finally:
             await pub.disconnect()
 
-    async def test_disconnect_and_reconnect_restores_connected_state(
-        self, nats_url: str
-    ) -> None:
+    async def test_disconnect_and_reconnect_restores_connected_state(self, nats_url: str) -> None:
         """Calling connect() after disconnect() results in is_connected=True again."""
         pub = Publisher()
         await pub.connect(nats_url)
@@ -675,9 +659,7 @@ class TestReconnectLifecycle:
         finally:
             await pub2.disconnect()
 
-    async def test_reconnect_count_increments_via_callback(
-        self, nats_url: str
-    ) -> None:
+    async def test_reconnect_count_increments_via_callback(self, nats_url: str) -> None:
         """Manually invoking the reconnected callback increments reconnect_count."""
         pub = Publisher()
         await pub.connect(nats_url)

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -52,43 +52,49 @@ async def test_lifespan_retries_then_succeeds(mock_publisher: MagicMock) -> None
 
 
 @pytest.mark.anyio
-async def test_lifespan_all_retries_exhausted_raises(mock_publisher: MagicMock) -> None:
-    """connect() always fails; lifespan re-raises; critical logged once."""
+async def test_lifespan_all_retries_exhausted_starts_degraded(mock_publisher: MagicMock) -> None:
+    """connect() always fails; lifespan starts in degraded mode (no raise); critical logged once."""
     from hermes.server import lifespan, app
 
     err = ConnectionRefusedError("NATS unreachable")
     mock_publisher.connect.side_effect = err
+    mock_publisher.is_connected = False
 
     with (
         patch("hermes.server.Publisher", return_value=mock_publisher),
         patch("hermes.server.asyncio.sleep", new_callable=AsyncMock),
         patch("hermes.server.logger") as mock_logger,
-        pytest.raises(ConnectionRefusedError),
     ):
         async with lifespan(app):
-            pass  # should not reach here
+            # App starts in degraded mode — publisher is set on state
+            assert app.state.publisher is mock_publisher
 
     mock_logger.critical.assert_called_once()
     assert mock_publisher.connect.await_count == 3
 
 
 @pytest.mark.anyio
-async def test_lifespan_no_warning_logged(mock_publisher: MagicMock) -> None:
-    """The old swallowing behavior used logger.warning — ensure it's no longer called."""
+async def test_lifespan_degraded_health_returns_503(mock_publisher: MagicMock) -> None:
+    """When NATS fails to connect, /health returns 503 with degraded status."""
+    from fastapi.testclient import TestClient
     from hermes.server import lifespan, app
 
-    mock_publisher.connect.side_effect = OSError("down")
+    err = OSError("NATS down")
+    mock_publisher.connect.side_effect = err
+    mock_publisher.is_connected = False
+    mock_publisher.dead_letter_count = 0
 
     with (
         patch("hermes.server.Publisher", return_value=mock_publisher),
         patch("hermes.server.asyncio.sleep", new_callable=AsyncMock),
-        patch("hermes.server.logger") as mock_logger,
-        pytest.raises(OSError),
     ):
         async with lifespan(app):
-            pass
-
-    mock_logger.warning.assert_not_called()
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.get("/health")
+            assert resp.status_code == 503
+            body = resp.json()
+            assert body["status"] == "degraded"
+            assert body["nats_connected"] is False
 
 
 @pytest.mark.anyio
@@ -110,12 +116,12 @@ async def test_lifespan_error_log_includes_attempt_info(mock_publisher: MagicMoc
     from hermes.config import get_settings
 
     mock_publisher.connect.side_effect = RuntimeError("boom")
+    mock_publisher.is_connected = False
 
     with (
         patch("hermes.server.Publisher", return_value=mock_publisher),
         patch("hermes.server.asyncio.sleep", new_callable=AsyncMock),
         patch("hermes.server.logger") as mock_logger,
-        pytest.raises(RuntimeError),
     ):
         async with lifespan(app):
             pass

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -82,6 +82,8 @@ def test_lifespan_degraded_health_returns_503(mock_publisher: MagicMock) -> None
     mock_publisher.connect.side_effect = err
     mock_publisher.is_connected = False
     mock_publisher.dead_letter_count = 0
+    mock_publisher.reconnect_count = 0
+    mock_publisher.last_error = ""
 
     with (
         patch("hermes.server.Publisher", return_value=mock_publisher),

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -73,11 +73,10 @@ async def test_lifespan_all_retries_exhausted_starts_degraded(mock_publisher: Ma
     assert mock_publisher.connect.await_count == 3
 
 
-@pytest.mark.anyio
-async def test_lifespan_degraded_health_returns_503(mock_publisher: MagicMock) -> None:
+def test_lifespan_degraded_health_returns_503(mock_publisher: MagicMock) -> None:
     """When NATS fails to connect, /health returns 503 with degraded status."""
     from fastapi.testclient import TestClient
-    from hermes.server import lifespan, app
+    from hermes.server import app
 
     err = OSError("NATS down")
     mock_publisher.connect.side_effect = err
@@ -88,8 +87,7 @@ async def test_lifespan_degraded_health_returns_503(mock_publisher: MagicMock) -
         patch("hermes.server.Publisher", return_value=mock_publisher),
         patch("hermes.server.asyncio.sleep", new_callable=AsyncMock),
     ):
-        async with lifespan(app):
-            client = TestClient(app, raise_server_exceptions=False)
+        with TestClient(app, raise_server_exceptions=False) as client:
             resp = client.get("/health")
             assert resp.status_code == 503
             body = resp.json()
@@ -146,7 +144,6 @@ async def test_lifespan_no_sleep_after_last_retry(mock_publisher: MagicMock) -> 
         patch("hermes.server.Publisher", return_value=mock_publisher),
         patch("hermes.server.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
         patch("hermes.server.logger"),
-        pytest.raises(RuntimeError),
     ):
         async with lifespan(app):
             pass
@@ -165,7 +162,6 @@ async def test_lifespan_last_error_log_omits_retry_message(mock_publisher: Magic
         patch("hermes.server.Publisher", return_value=mock_publisher),
         patch("hermes.server.asyncio.sleep", new_callable=AsyncMock),
         patch("hermes.server.logger") as mock_logger,
-        pytest.raises(RuntimeError),
     ):
         async with lifespan(app):
             pass
@@ -227,7 +223,6 @@ async def test_last_retry_logs_giving_up_not_retrying(mock_publisher: MagicMock)
         patch("hermes.server.Publisher", return_value=mock_publisher),
         patch("hermes.server.asyncio.sleep", new_callable=AsyncMock),
         patch("hermes.server.logger") as mock_logger,
-        pytest.raises(RuntimeError),
     ):
         async with lifespan(app):
             pass

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -69,6 +69,7 @@ class TestJsonFormatter:
         parsed = json.loads(formatter.format(record))
         # Should parse without error and contain timezone info
         from datetime import datetime
+
         dt = datetime.fromisoformat(parsed["timestamp"])
         assert dt.tzinfo is not None
 
@@ -128,7 +129,8 @@ class TestSetupLogging:
         setup_logging(json_format=True)
         root = logging.getLogger()
         stream_handlers = [
-            h for h in root.handlers
+            h
+            for h in root.handlers
             if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
         ]
         assert any(isinstance(h.formatter, JsonFormatter) for h in stream_handlers)
@@ -138,7 +140,8 @@ class TestSetupLogging:
         setup_logging(json_format=False)
         root = logging.getLogger()
         stream_handlers = [
-            h for h in root.handlers
+            h
+            for h in root.handlers
             if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
         ]
         assert not any(isinstance(h.formatter, JsonFormatter) for h in stream_handlers)
@@ -150,7 +153,8 @@ class TestSetupLogging:
         setup_logging(json_format=True)
         root = logging.getLogger()
         stream_handlers = [
-            h for h in root.handlers
+            h
+            for h in root.handlers
             if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
         ]
         assert len(stream_handlers) == 1

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -75,7 +75,9 @@ class TestDeadLettersEndpoint:
 
 
 class TestWebhookMetricsInstrumentation:
-    def test_valid_webhook_increments_received_counter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_valid_webhook_increments_received_counter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         payload = {
@@ -85,7 +87,9 @@ class TestWebhookMetricsInstrumentation:
         }
         body_bytes = json.dumps(payload).encode()
 
-        before = _get_counter_value("hermes_webhooks_received_total", {"event_type": "agent.created"})
+        before = _get_counter_value(
+            "hermes_webhooks_received_total", {"event_type": "agent.created"}
+        )
         client.post(
             "/webhook",
             content=body_bytes,
@@ -94,10 +98,14 @@ class TestWebhookMetricsInstrumentation:
                 "X-Webhook-Signature": _sign(body_bytes),
             },
         )
-        after = _get_counter_value("hermes_webhooks_received_total", {"event_type": "agent.created"})
+        after = _get_counter_value(
+            "hermes_webhooks_received_total", {"event_type": "agent.created"}
+        )
         assert after == before + 1
 
-    def test_invalid_payload_increments_failed_counter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_invalid_payload_increments_failed_counter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         body_bytes = json.dumps({"bad": "payload"}).encode()
@@ -114,7 +122,9 @@ class TestWebhookMetricsInstrumentation:
         after = _get_counter_value("hermes_webhooks_failed_total", {"reason": "invalid_payload"})
         assert after == before + 1
 
-    def test_nats_unavailable_increments_failed_counter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_nats_unavailable_increments_failed_counter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         from hermes.server import app
         from hermes.publisher import Publisher
@@ -132,7 +142,9 @@ class TestWebhookMetricsInstrumentation:
         }
         body_bytes = json.dumps(payload).encode()
 
-        before = _get_counter_value("hermes_webhooks_failed_total", {"reason": "nats_not_connected"})
+        before = _get_counter_value(
+            "hermes_webhooks_failed_total", {"reason": "nats_not_connected"}
+        )
         client.post(
             "/webhook",
             content=body_bytes,
@@ -213,6 +225,7 @@ class TestPublisherSubjectCap:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _get_counter_value(metric_name: str, labels: dict[str, str]) -> float:
     """Read a counter value from the Prometheus default registry.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,12 +25,15 @@ class TestWebhookPayloadTimestamp:
 class TestPackageExports:
     def test_hermes_exports_hermes_event_base(self) -> None:
         import hermes
+
         assert hasattr(hermes, "HermesEventBase")
 
     def test_hermes_does_not_export_agent_event(self) -> None:
         import hermes
+
         assert not hasattr(hermes, "AgentEvent")
 
     def test_hermes_does_not_export_task_event(self) -> None:
         import hermes
+
         assert not hasattr(hermes, "TaskEvent")

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -332,9 +332,7 @@ class TestPublishRetry:
     @pytest.mark.asyncio
     async def test_succeeds_on_second_attempt_after_transient_failure(self) -> None:
         pub = _make_connected_publisher()
-        pub._js.publish = AsyncMock(
-            side_effect=[nats.errors.TimeoutError(), MagicMock()]
-        )
+        pub._js.publish = AsyncMock(side_effect=[nats.errors.TimeoutError(), MagicMock()])
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             await pub.publish(_agent_payload(), publish_retries=3, publish_retry_base_delay=0.1)
@@ -399,9 +397,7 @@ class TestRetryJitter:
     async def test_jitter_applied_to_sleep_delay(self) -> None:
         """asyncio.sleep receives a value scaled by random.uniform(0.5, 1.5)."""
         pub = _make_connected_publisher()
-        pub._js.publish = AsyncMock(
-            side_effect=[nats.errors.TimeoutError(), MagicMock()]
-        )
+        pub._js.publish = AsyncMock(side_effect=[nats.errors.TimeoutError(), MagicMock()])
 
         with (
             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
@@ -417,9 +413,7 @@ class TestRetryJitter:
     async def test_jitter_lower_bound(self) -> None:
         """Sleep delay is at least base_delay * 2^attempt * 0.5."""
         pub = _make_connected_publisher()
-        pub._js.publish = AsyncMock(
-            side_effect=[nats.errors.TimeoutError(), MagicMock()]
-        )
+        pub._js.publish = AsyncMock(side_effect=[nats.errors.TimeoutError(), MagicMock()])
 
         with (
             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
@@ -434,9 +428,7 @@ class TestRetryJitter:
     async def test_jitter_upper_bound(self) -> None:
         """Sleep delay is at most min(base_delay * 2^attempt, 2.0) * 1.5."""
         pub = _make_connected_publisher()
-        pub._js.publish = AsyncMock(
-            side_effect=[nats.errors.TimeoutError(), MagicMock()]
-        )
+        pub._js.publish = AsyncMock(side_effect=[nats.errors.TimeoutError(), MagicMock()])
 
         with (
             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
@@ -489,9 +481,7 @@ class TestRetryableExceptions:
     @pytest.mark.asyncio
     async def test_drain_timeout_error_is_retried(self) -> None:
         pub = _make_connected_publisher()
-        pub._js.publish = AsyncMock(
-            side_effect=[nats.errors.DrainTimeoutError(), MagicMock()]
-        )
+        pub._js.publish = AsyncMock(side_effect=[nats.errors.DrainTimeoutError(), MagicMock()])
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
             await pub.publish(_agent_payload(), publish_retries=3, publish_retry_base_delay=0.01)
@@ -506,7 +496,9 @@ class TestRetryableExceptions:
 
         with pytest.raises(nats.errors.AuthorizationError):
             with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-                await pub.publish(_agent_payload(), publish_retries=3, publish_retry_base_delay=0.01)
+                await pub.publish(
+                    _agent_payload(), publish_retries=3, publish_retry_base_delay=0.01
+                )
 
         assert pub._js.publish.call_count == 1
         mock_sleep.assert_not_awaited()
@@ -519,7 +511,9 @@ class TestRetryableExceptions:
 
         with pytest.raises(nats.errors.ConnectionClosedError):
             with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-                await pub.publish(_agent_payload(), publish_retries=3, publish_retry_base_delay=0.01)
+                await pub.publish(
+                    _agent_payload(), publish_retries=3, publish_retry_base_delay=0.01
+                )
 
         assert pub._js.publish.call_count == 1
         mock_sleep.assert_not_awaited()
@@ -563,9 +557,7 @@ class TestReconnectRace:
     @pytest.mark.asyncio
     async def test_stale_connection_error_is_retried(self) -> None:
         pub = _make_connected_publisher()
-        pub._js.publish = AsyncMock(
-            side_effect=[nats.errors.StaleConnectionError(), MagicMock()]
-        )
+        pub._js.publish = AsyncMock(side_effect=[nats.errors.StaleConnectionError(), MagicMock()])
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
             await pub.publish(_agent_payload(), publish_retries=3, publish_retry_base_delay=0.01)
@@ -579,7 +571,9 @@ class TestReconnectRace:
 
         with pytest.raises(nats.errors.ConnectionReconnectingError):
             with patch("asyncio.sleep", new_callable=AsyncMock):
-                await pub.publish(_agent_payload(), publish_retries=3, publish_retry_base_delay=0.01)
+                await pub.publish(
+                    _agent_payload(), publish_retries=3, publish_retry_base_delay=0.01
+                )
 
         assert pub._js.publish.call_count == 3
 
@@ -591,7 +585,9 @@ class TestReconnectRace:
 
         with pytest.raises(nats.errors.ConnectionClosedError):
             with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-                await pub.publish(_agent_payload(), publish_retries=3, publish_retry_base_delay=0.01)
+                await pub.publish(
+                    _agent_payload(), publish_retries=3, publish_retry_base_delay=0.01
+                )
 
         assert pub._js.publish.call_count == 1
         mock_sleep.assert_not_awaited()

--- a/tests/test_request_id_context.py
+++ b/tests/test_request_id_context.py
@@ -63,9 +63,7 @@ class TestRequestIdInLogContext:
                 },
             )
 
-        records_with_id = [
-            r for r in caplog.records if getattr(r, "request_id", None) == fixed_id
-        ]
+        records_with_id = [r for r in caplog.records if getattr(r, "request_id", None) == fixed_id]
         assert records_with_id, (
             f"Expected at least one log record with request_id={fixed_id!r}; "
             f"got records: {[vars(r) for r in caplog.records]}"
@@ -95,9 +93,7 @@ class TestRequestIdInLogContext:
                 },
             )
 
-        records_with_id = [
-            r for r in caplog.records if getattr(r, "request_id", None) == fixed_id
-        ]
+        records_with_id = [r for r in caplog.records if getattr(r, "request_id", None) == fixed_id]
         assert records_with_id, (
             f"Expected at least one log record with request_id={fixed_id!r}; "
             f"got records: {[vars(r) for r in caplog.records]}"
@@ -140,12 +136,8 @@ class TestRequestIdInLogContext:
                 },
             )
 
-        records_with_id = [
-            r for r in caplog.records if getattr(r, "request_id", None) == fixed_id
-        ]
-        assert records_with_id, (
-            f"Expected at least one log record with request_id={fixed_id!r}"
-        )
+        records_with_id = [r for r in caplog.records if getattr(r, "request_id", None) == fixed_id]
+        assert records_with_id, f"Expected at least one log record with request_id={fixed_id!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -212,7 +212,9 @@ class TestSignalHandler:
 
 class TestLifespanShutdown:
     @pytest.mark.asyncio
-    async def test_shutdown_waits_for_inflight_requests(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_shutdown_waits_for_inflight_requests(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Lifespan teardown waits until _inflight reaches 0 before disconnecting."""
         import hermes.server as srv
         from hermes.config import Settings

--- a/tests/test_startup_banner.py
+++ b/tests/test_startup_banner.py
@@ -47,7 +47,9 @@ class TestLogStartupBanner:
 
         mock = MagicMock(spec=Publisher)
         mock.is_connected = is_connected
-        mock.stream_names = stream_names if stream_names is not None else ["homeric-agents", "homeric-tasks"]
+        mock.stream_names = (
+            stream_names if stream_names is not None else ["homeric-agents", "homeric-tasks"]
+        )
         return mock
 
     def test_banner_logs_version(self) -> None:

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -48,7 +48,6 @@ class TestTimeoutSettings:
         s = Settings()
         assert s.agamemnon_timeout == 20.0
 
-
     def test_nats_retry_attempts_default(self) -> None:
         """nats_retry_attempts defaults to 3."""
         s = Settings()
@@ -74,12 +73,14 @@ class TestTimeoutSettings:
     def test_nats_retry_attempts_minimum_is_one(self) -> None:
         """nats_retry_attempts rejects values below 1."""
         import pytest as _pytest
+
         with _pytest.raises(Exception):
             Settings(nats_retry_attempts=0)
 
     def test_nats_retry_interval_must_be_positive(self) -> None:
         """nats_retry_interval rejects non-positive values."""
         import pytest as _pytest
+
         with _pytest.raises(Exception):
             Settings(nats_retry_interval=0.0)
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -215,9 +215,7 @@ class TestWebhookEndpoint:
         )
         assert response.status_code == 202
 
-    def test_webhook_invalid_payload_returns_422(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_webhook_invalid_payload_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         body_bytes = json.dumps({"bad": "payload"}).encode()
@@ -231,9 +229,7 @@ class TestWebhookEndpoint:
         )
         assert response.status_code == 422
 
-    def test_webhook_missing_body_returns_422(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_webhook_missing_body_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         body_bytes = b"not json"
@@ -267,9 +263,7 @@ class TestWebhookEndpoint:
         body = response.json()
         assert body["event"] == "task.updated"
 
-    def test_webhook_bad_signature_returns_401(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_webhook_bad_signature_returns_401(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         payload = {
@@ -296,9 +290,7 @@ class TestWebhookEndpoint:
         monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
         client = _build_client()
         labels = {"reason": "invalid_signature"}
-        before = (
-            REGISTRY.get_sample_value("hermes_webhooks_failed_total", labels) or 0.0
-        )
+        before = REGISTRY.get_sample_value("hermes_webhooks_failed_total", labels) or 0.0
         payload = {
             "event": "agent.created",
             "data": {"host": "localhost", "name": "bot"},
@@ -328,6 +320,7 @@ class TestWebhookEndpoint:
         app.state.publisher = mock_publisher
 
         from hermes.config import get_settings
+
         get_settings().webhook_secret = _TEST_SECRET
 
         client = TestClient(app, raise_server_exceptions=False)
@@ -1015,14 +1008,18 @@ class TestUnknownEventType:
         client = self._build_client_with_unknown_event("foo.bar")
         payload = {"event": "foo.bar", "data": {}, "timestamp": "2026-01-01T00:00:00Z"}
         body_bytes = json.dumps(payload).encode()
-        response = client.post("/webhook", content=body_bytes, headers={"Content-Type": "application/json"})
+        response = client.post(
+            "/webhook", content=body_bytes, headers={"Content-Type": "application/json"}
+        )
         assert response.status_code == 422
 
     def test_unknown_event_type_422_detail_contains_event(self) -> None:
         client = self._build_client_with_unknown_event("foo.bar")
         payload = {"event": "foo.bar", "data": {}, "timestamp": "2026-01-01T00:00:00Z"}
         body_bytes = json.dumps(payload).encode()
-        response = client.post("/webhook", content=body_bytes, headers={"Content-Type": "application/json"})
+        response = client.post(
+            "/webhook", content=body_bytes, headers={"Content-Type": "application/json"}
+        )
         body = response.json()
         assert "foo.bar" in body["detail"]
 
@@ -1083,9 +1080,7 @@ class TestMissingFieldWarnings:
 class TestPublisherRaises:
     """Issue #122 — publisher.publish() raising must return 500, not propagate."""
 
-    def test_publish_runtime_error_returns_500(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_publish_runtime_error_returns_500(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """When publisher.publish raises RuntimeError the endpoint returns 500."""
         from hermes.publisher import Publisher
         from hermes.server import app
@@ -1167,7 +1162,5 @@ class TestExceptionDetailNotLeaked:
             )
 
         assert response.status_code == 422
-        warning_records = [
-            r for r in caplog.records if r.levelno >= logging.WARNING
-        ]
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
         assert len(warning_records) >= 1


### PR DESCRIPTION
## Summary

- **#222**: Lifespan no longer aborts when NATS is unreachable after all retry attempts. The app starts in degraded mode: publisher is stored on `app.state` with `is_connected=False`, `/health` returns 503 with `"status": "degraded"`, and `/webhook` continues to return 503. Load-balancers can observe the unhealthy state rather than the process crashing.
- **#223**: Added `ENV HERMES_HOST=0.0.0.0` to the Dockerfile so containers bind on all interfaces by default (required for standard Docker networking).
- **#210**: Closed via comment — retry logic already lives in the lifespan and reads `nats_retry_attempts`/`nats_retry_interval` from Settings; moving it inside `Publisher.connect()` would duplicate logic without benefit.

## Test plan

- [ ] `pixi run just lint` — passes
- [ ] `pixi run just test` — 237 pass, 13 skipped (2 pre-existing failures on main unrelated to this PR)
- [ ] New test `test_lifespan_all_retries_exhausted_starts_degraded` confirms app starts in degraded mode (no raise, critical logged, publisher on state)
- [ ] New test `test_lifespan_degraded_health_returns_503` confirms `/health` returns 503 + `"status": "degraded"` when NATS never connects

closes #210
closes #222
closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)