### PR TITLE
feat(observability): add request_id to log context and error responses

### DIFF
--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -85,6 +85,7 @@ class ErrorResponse(BaseModel):
     """Standard error response body."""
 
     detail: str
+    request_id: str | None = None
 
 
 class VersionResponse(BaseModel):

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -15,6 +15,7 @@ from contextlib import asynccontextmanager
 from typing import Annotated, Any
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
+from fastapi.exception_handlers import http_exception_handler
 from fastapi.responses import JSONResponse
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -168,6 +169,21 @@ app = FastAPI(
 app.state.limiter = limiter
 app.add_exception_handler(429, rate_limit_exceeded_handler)  # type: ignore[arg-type]
 
+
+@app.exception_handler(HTTPException)
+async def _http_exception_handler_with_request_id(
+    request: Request, exc: HTTPException
+) -> JSONResponse:
+    """Augment HTTPException responses with request_id from request.state when available."""
+    request_id: str | None = getattr(request.state, "request_id", None)
+    response = await http_exception_handler(request, exc)
+    body: dict[str, object] = {"detail": exc.detail, "request_id": request_id}
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=body,
+        headers=dict(response.headers),
+    )
+
 # ---------------------------------------------------------------------------
 # Dependencies
 # ---------------------------------------------------------------------------
@@ -303,7 +319,9 @@ async def receive_webhook(
     try:
         payload = WebhookPayload.model_validate_json(raw_body)
     except Exception as exc:
-        logger.warning("Invalid webhook payload: %s", exc)
+        logger.warning(
+            "Invalid webhook payload: %s", exc, extra={"request_id": request_id}
+        )
         WEBHOOKS_FAILED.labels(reason="invalid_payload").inc()
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -315,9 +333,9 @@ async def receive_webhook(
     publisher: Publisher = app.state.publisher
     if not publisher.is_connected:
         logger.error(
-            "NATS not connected; cannot publish event %r (request_id=%s)",
+            "NATS not connected; cannot publish event %r",
             payload.event,
-            request_id,
+            extra={"request_id": request_id},
         )
         WEBHOOKS_FAILED.labels(reason="nats_not_connected").inc()
         raise HTTPException(
@@ -332,6 +350,11 @@ async def receive_webhook(
             request_id=request_id,
         )
     except asyncio.TimeoutError:
+        logger.error(
+            "NATS publish timed out for event %r",
+            payload.event,
+            extra={"request_id": request_id},
+        )
         WEBHOOKS_FAILED.labels(reason="publish_timeout").inc()
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/tests/test_request_id_context.py
+++ b/tests/test_request_id_context.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: MIT
+"""Tests for request_id in log context (issue #228) and error responses (issue #230)."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as hmac_mod
+import json
+import logging
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+_TEST_SECRET = "test-webhook-secret-padding-xxxxx"
+
+
+def _sign(body: bytes) -> str:
+    return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _build_client(*, connected: bool = True) -> TestClient:
+    from hermes.config import get_settings
+    from hermes.publisher import Publisher
+    from hermes.server import app
+
+    mock_publisher = MagicMock(spec=Publisher)
+    mock_publisher.is_connected = connected
+    mock_publisher.active_subjects = []
+    mock_publisher.dead_letter_count = 0
+    mock_publisher.publish = AsyncMock()
+
+    app.state.publisher = mock_publisher
+    get_settings().webhook_secret = _TEST_SECRET
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# Issue #228 — request_id in structured log extra
+# ---------------------------------------------------------------------------
+
+
+class TestRequestIdInLogContext:
+    """Verify that request_id appears in extra fields of log records."""
+
+    def test_invalid_payload_log_contains_request_id(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A 422 from invalid payload should emit a log record with request_id in extra."""
+        client = _build_client()
+        body_bytes = json.dumps({"bad": "payload"}).encode()
+        fixed_id = str(uuid.uuid4())
+
+        with caplog.at_level(logging.WARNING, logger="hermes.server"):
+            client.post(
+                "/webhook",
+                content=body_bytes,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Webhook-Signature": _sign(body_bytes),
+                    "X-Request-ID": fixed_id,
+                },
+            )
+
+        records_with_id = [
+            r for r in caplog.records if getattr(r, "request_id", None) == fixed_id
+        ]
+        assert records_with_id, (
+            f"Expected at least one log record with request_id={fixed_id!r}; "
+            f"got records: {[vars(r) for r in caplog.records]}"
+        )
+
+    def test_nats_not_connected_log_contains_request_id(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A 503 from NATS disconnected should emit a log record with request_id in extra."""
+        client = _build_client(connected=False)
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "h", "name": "n"},
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        fixed_id = str(uuid.uuid4())
+
+        with caplog.at_level(logging.ERROR, logger="hermes.server"):
+            client.post(
+                "/webhook",
+                content=body_bytes,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Webhook-Signature": _sign(body_bytes),
+                    "X-Request-ID": fixed_id,
+                },
+            )
+
+        records_with_id = [
+            r for r in caplog.records if getattr(r, "request_id", None) == fixed_id
+        ]
+        assert records_with_id, (
+            f"Expected at least one log record with request_id={fixed_id!r}; "
+            f"got records: {[vars(r) for r in caplog.records]}"
+        )
+
+    def test_publish_timeout_log_contains_request_id(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A 503 from publish timeout should emit a log record with request_id in extra."""
+        import asyncio
+
+        from hermes.config import get_settings
+        from hermes.publisher import Publisher
+        from hermes.server import app
+
+        mock_publisher = MagicMock(spec=Publisher)
+        mock_publisher.is_connected = True
+        mock_publisher.active_subjects = []
+        mock_publisher.publish = AsyncMock(side_effect=asyncio.TimeoutError())
+        app.state.publisher = mock_publisher
+        get_settings().webhook_secret = _TEST_SECRET
+
+        client = TestClient(app, raise_server_exceptions=False)
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "h", "name": "n"},
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        fixed_id = str(uuid.uuid4())
+
+        with caplog.at_level(logging.ERROR, logger="hermes.server"):
+            client.post(
+                "/webhook",
+                content=body_bytes,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Webhook-Signature": _sign(body_bytes),
+                    "X-Request-ID": fixed_id,
+                },
+            )
+
+        records_with_id = [
+            r for r in caplog.records if getattr(r, "request_id", None) == fixed_id
+        ]
+        assert records_with_id, (
+            f"Expected at least one log record with request_id={fixed_id!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #230 — request_id in error response bodies
+# ---------------------------------------------------------------------------
+
+
+class TestRequestIdInErrorResponses:
+    """Verify that request_id is included in HTTP error response bodies."""
+
+    def test_422_error_body_contains_request_id(self) -> None:
+        """Invalid payload 422 response body must include request_id."""
+        client = _build_client()
+        body_bytes = json.dumps({"bad": "payload"}).encode()
+        fixed_id = str(uuid.uuid4())
+
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Request-ID": fixed_id,
+            },
+        )
+        assert response.status_code == 422
+        data = response.json()
+        assert "request_id" in data
+        assert data["request_id"] == fixed_id
+
+    def test_401_error_body_contains_request_id(self) -> None:
+        """Bad signature 401 response body must include request_id."""
+        client = _build_client()
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "h", "name": "n"},
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        fixed_id = str(uuid.uuid4())
+
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": "bad-sig",
+                "X-Request-ID": fixed_id,
+            },
+        )
+        assert response.status_code == 401
+        data = response.json()
+        assert "request_id" in data
+        assert data["request_id"] == fixed_id
+
+    def test_503_nats_disconnected_body_contains_request_id(self) -> None:
+        """NATS disconnected 503 response body must include request_id."""
+        client = _build_client(connected=False)
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "h", "name": "n"},
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        fixed_id = str(uuid.uuid4())
+
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Request-ID": fixed_id,
+            },
+        )
+        assert response.status_code == 503
+        data = response.json()
+        assert "request_id" in data
+        assert data["request_id"] == fixed_id
+
+    def test_503_publish_timeout_body_contains_request_id(self) -> None:
+        """Publish timeout 503 response body must include request_id."""
+        import asyncio
+
+        from hermes.config import get_settings
+        from hermes.publisher import Publisher
+        from hermes.server import app
+
+        mock_publisher = MagicMock(spec=Publisher)
+        mock_publisher.is_connected = True
+        mock_publisher.active_subjects = []
+        mock_publisher.publish = AsyncMock(side_effect=asyncio.TimeoutError())
+        app.state.publisher = mock_publisher
+        get_settings().webhook_secret = _TEST_SECRET
+
+        client = TestClient(app, raise_server_exceptions=False)
+        payload = {
+            "event": "agent.created",
+            "data": {"host": "h", "name": "n"},
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+        body_bytes = json.dumps(payload).encode()
+        fixed_id = str(uuid.uuid4())
+
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Request-ID": fixed_id,
+            },
+        )
+        assert response.status_code == 503
+        data = response.json()
+        assert "request_id" in data
+        assert data["request_id"] == fixed_id
+
+    def test_error_body_contains_detail(self) -> None:
+        """Error bodies must still contain the original detail field."""
+        client = _build_client()
+        body_bytes = json.dumps({"bad": "payload"}).encode()
+
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+            },
+        )
+        assert response.status_code == 422
+        data = response.json()
+        assert "detail" in data
+        assert isinstance(data["detail"], str)
+
+    def test_generated_request_id_appears_in_error_body(self) -> None:
+        """When no X-Request-ID is sent, a generated UUID should appear in error body."""
+        client = _build_client()
+        body_bytes = json.dumps({"bad": "payload"}).encode()
+
+        response = client.post(
+            "/webhook",
+            content=body_bytes,
+            headers={
+                "Content-Type": "application/json",
+                "X-Webhook-Signature": _sign(body_bytes),
+            },
+        )
+        assert response.status_code == 422
+        data = response.json()
+        assert "request_id" in data
+        # Should be a valid UUID (auto-generated)
+        returned_id = data["request_id"]
+        assert returned_id is not None
+        uuid.UUID(returned_id)  # raises ValueError if not a valid UUID
+        # Should match the X-Request-ID response header
+        assert response.headers.get("X-Request-ID") == returned_id

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -143,9 +143,11 @@ class TestShutdownMiddleware:
 
     def test_webhook_accepted_when_not_shutting_down(self) -> None:
         import hermes.server as srv
+        from hermes.config import get_settings
 
         srv._shutdown_event = asyncio.Event()
-        # webhook_secret="" is the default; no env override needed
+        # Disable HMAC validation so the test works regardless of .env contents
+        get_settings().webhook_secret = ""
         client = _build_client()
         response = client.post(
             "/webhook",

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -278,8 +278,8 @@ class TestWebhookEndpoint:
         mock_publisher.publish = AsyncMock(side_effect=asyncio.TimeoutError())
         app.state.publisher = mock_publisher
 
-        from hermes.config import settings
-        settings.webhook_secret = _TEST_SECRET
+        from hermes.config import get_settings
+        get_settings().webhook_secret = _TEST_SECRET
 
         client = TestClient(app, raise_server_exceptions=False)
         payload = {


### PR DESCRIPTION
closes #228
closes #230

Add request_id to structured log extra fields and include it in HTTP error response bodies.

## Changes

### Issue #228 — Structured log context for request_id
- Added `extra={"request_id": request_id}` to all `logger.*` calls inside `receive_webhook` that previously lacked it:
  - Invalid payload warning (422 path)
  - NATS-not-connected error (503 path) — also moved request_id from the message string to `extra`
  - Publish timeout error (503 path) — added a new `logger.error` call before the raise

### Issue #230 — request_id in error response bodies
- Added `request_id: str | None = None` to `ErrorResponse` model in `models.py`
- Registered a custom `@app.exception_handler(HTTPException)` in `server.py` that reads `request.state.request_id` and includes it in every error response body, preserving all existing headers (e.g. `WWW-Authenticate`)

### Bug fixes (pre-existing)
- Fixed `test_webhook_publish_timeout_returns_503` and `test_webhook_accepted_when_not_shutting_down` which mutated the module-level `settings` singleton instead of the `get_settings()` lru_cache return value, causing them to fail when a `.env` file is present with `WEBHOOK_SECRET`

## Test plan
- [x] `pixi run just test` — 258 passed, 13 skipped (NATS integration), coverage 97%
- [x] `pixi run just lint` — all checks passed
- [x] New `tests/test_request_id_context.py` with 9 tests covering both issues:
  - Log records contain `request_id` in `extra` for all error paths
  - Error response bodies include `request_id` matching the `X-Request-ID` header for 401, 422, 503 paths
  - Auto-generated request_id (no header sent) is a valid UUID and matches response header

🤖 Generated with [Claude Code](https://claude.com/claude-code)