### PR TITLE
feat(api): expose get_settings; test /events endpoint; add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@
 - [ ] Lint clean (`just lint`)
 - [ ] Types checked (all new functions have type hints)
 - [ ] Documentation updated (if user-facing change)
+- [ ] Updated CHANGELOG.md
 - [ ] No secrets or credentials committed
 
 ## Related Issues

--- a/src/hermes/__init__.py
+++ b/src/hermes/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
+from hermes.config import get_settings
 from hermes.models import HermesEventBase
 
 try:
@@ -9,4 +10,4 @@ try:
 except PackageNotFoundError:
     __version__ = "unknown"
 
-__all__ = ["HermesEventBase", "__version__"]
+__all__ = ["HermesEventBase", "__version__", "get_settings"]

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -810,6 +810,58 @@ class TestVersionEndpoint:
         assert len(data["version"]) > 0
 
 
+class TestEventsEndpoint:
+    """Tests for GET /events — validates response against AGENT_EVENTS and TASK_EVENTS (#127)."""
+
+    def test_events_returns_200(self) -> None:
+        client = _build_client()
+        resp = client.get("/events")
+        assert resp.status_code == 200
+
+    def test_events_response_has_agent_events_key(self) -> None:
+        client = _build_client()
+        body = client.get("/events").json()
+        assert "agent_events" in body
+
+    def test_events_response_has_task_events_key(self) -> None:
+        client = _build_client()
+        body = client.get("/events").json()
+        assert "task_events" in body
+
+    def test_events_response_has_all_events_key(self) -> None:
+        client = _build_client()
+        body = client.get("/events").json()
+        assert "all_events" in body
+
+    def test_events_agent_events_matches_publisher_constant(self) -> None:
+        from hermes.publisher import AGENT_EVENTS
+
+        client = _build_client()
+        body = client.get("/events").json()
+        assert set(body["agent_events"]) == AGENT_EVENTS
+
+    def test_events_task_events_matches_publisher_constant(self) -> None:
+        from hermes.publisher import TASK_EVENTS
+
+        client = _build_client()
+        body = client.get("/events").json()
+        assert set(body["task_events"]) == TASK_EVENTS
+
+    def test_events_all_events_is_union_of_agent_and_task(self) -> None:
+        from hermes.publisher import AGENT_EVENTS, TASK_EVENTS
+
+        client = _build_client()
+        body = client.get("/events").json()
+        assert set(body["all_events"]) == AGENT_EVENTS | TASK_EVENTS
+
+    def test_events_lists_are_sorted(self) -> None:
+        client = _build_client()
+        body = client.get("/events").json()
+        assert body["agent_events"] == sorted(body["agent_events"])
+        assert body["task_events"] == sorted(body["task_events"])
+        assert body["all_events"] == sorted(body["all_events"])
+
+
 class TestTimestampValidation:
     def test_webhook_naive_timestamp_rejected(self) -> None:
         client = _build_client()


### PR DESCRIPTION
## Summary

- Expose `get_settings` in the `hermes` package public API (`__init__.py` and `__all__`)
- Add `TestEventsEndpoint` tests in `test_webhook.py` that validate `GET /events` response against `AGENT_EVENTS` and `TASK_EVENTS` constants from `publisher.py`
- Add `- [ ] Updated CHANGELOG.md` checklist item to `.github/pull_request_template.md`

## Test Plan

- [x] `just test` passes locally (292 passed, 13 skipped; 2 pre-existing failures in `TestUnknownEventType` on `main`)
- [x] `just lint` passes locally

closes #127
closes #205
closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)