### PR TITLE
feat(config): add AGAMEMNON fields; security docs; bootstrap recipe; rotate secret

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ Unknown event types are routed to the `homeric-deadletter` NATS stream for inspe
 | WEBHOOK_SECRET        |                                | HMAC secret for webhook validation (minimum 32 characters) |
 | NATS_CONNECT_TIMEOUT  | 5.0                            | NATS connection timeout in seconds                      |
 | NATS_PUBLISH_TIMEOUT  | 5.0                            | NATS publish timeout in seconds                         |
+| AGAMEMNON_URL         |                                | Base URL of the Agamemnon coordination service          |
+| AGAMEMNON_API_KEY     |                                | API key for authenticating with Agamemnon               |
 | AGAMEMNON_TIMEOUT     | 10.0                           | Agamemnon API call timeout in seconds                   |
 | SHUTDOWN_TIMEOUT      | 10.0                           | Graceful shutdown timeout in seconds                    |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -83,6 +83,37 @@ We use the following severity levels:
 | **Medium**   | Limited impact vulnerabilities       | Standard priority  |
 | **Low**      | Minor issues, hardening              | Scheduled fix      |
 
+## Secret Rotation
+
+If a `WEBHOOK_SECRET` is compromised or needs to be rotated, follow these steps:
+
+1. **Generate a new secret**
+   ```bash
+   openssl rand -hex 32
+   ```
+
+2. **Update the deployment environment**
+   Set the new value in your deployment environment (e.g. update the `WEBHOOK_SECRET`
+   variable in your `.env` file, secrets manager, or container orchestration platform).
+
+3. **Restart the service**
+   ```bash
+   just start
+   # or, in Docker:
+   docker compose up --build -d
+   ```
+
+4. **Verify the service is healthy**
+   ```bash
+   just health
+   ```
+   The `/health` endpoint should return `{"status": "ok"}` with a 200 response.
+
+5. **Update the secret in external services**
+   Reconfigure each external service (GitHub, Slack, etc.) that sends signed webhook
+   payloads to use the new secret. Until this is done, those webhooks will be rejected
+   with a 401 Unauthorized response.
+
 ## Responsible Disclosure
 
 We follow responsible disclosure practices:

--- a/justfile
+++ b/justfile
@@ -30,10 +30,10 @@ register-webhook:
 
 # === Setup ===
 
-# One-command developer setup: copy .env, install deps
+# One-command developer setup: copy .env, install deps, regenerate lock file
 bootstrap:
     cp -n .env.example .env || true
-    pixi install
+    pixi install --frozen || pixi update
     @echo "Ready! Run 'just dev' to start."
 
 # Install pre-commit hooks into the local git repo

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -36,6 +36,8 @@ class Settings(BaseSettings):
     nats_publish_timeout: float = Field(default=5.0, gt=0)
     nats_retry_attempts: int = Field(default=3, ge=1)
     nats_retry_interval: float = Field(default=5.0, gt=0)
+    agamemnon_url: str = ""
+    agamemnon_api_key: str = ""
     agamemnon_timeout: float = Field(default=10.0, gt=0)
     shutdown_timeout: float = Field(default=10.0, gt=0)
     max_payload_bytes: int = 1_048_576


### PR DESCRIPTION
## Summary

- Add `agamemnon_url` and `agamemnon_api_key` fields to `Settings` in `config.py`
- Update `CLAUDE.md` config table with the new `AGAMEMNON_URL` and `AGAMEMNON_API_KEY` entries
- Add `pixi update` fallback to the `bootstrap` justfile recipe to keep the lock file current when `pixi.toml` changes
- Add "Secret Rotation" section to `SECURITY.md` documenting the 5-step procedure
- Confirmed the compromised secret from issue #35 audit does not appear in any source files

## Test plan

- [ ] `just lint` passes (verified locally — all checks passed)
- [ ] `just bootstrap` runs without error
- [ ] `just health` returns `{"status": "ok"}` after starting the server
- [ ] Settings instantiation includes `agamemnon_url` and `agamemnon_api_key` fields

closes #169
closes #172
closes #194
closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)