### PR TITLE
chore: add session artifact paths to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ build/
 .ruff_cache/
 .pytest_cache/
 .pixi/
+
+# Session artifacts
+.worktrees/
+.issue_implementer/
+.coverage
+htmlcov/


### PR DESCRIPTION
## Summary
- Add `.worktrees/`, `.issue_implementer/`, `.coverage`, `htmlcov/` to `.gitignore`

These paths are created by the auto-impl swarm sessions and should never be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)