### PR TITLE
chore(ci): add unified required-checks workflow

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -1,0 +1,197 @@
+name: Required Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: required-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: latest
+          cache: true
+
+      - name: Lint
+        run: pixi run lint
+
+  unit-tests:
+    name: unit-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: latest
+          cache: true
+
+      - name: Unit tests (no NATS required)
+        run: pixi run pytest -m "not integration" --cov-fail-under=80
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-html
+          path: htmlcov/
+
+  integration-tests:
+    name: integration-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: latest
+          cache: true
+
+      - name: Start NATS with JetStream
+        run: |
+          docker run -d --name nats-js -p 4222:4222 nats:latest -js
+          sleep 2
+
+      - name: Integration tests
+        env:
+          TEST_NATS_URL: nats://localhost:4222
+        run: pixi run pytest -m integration -v
+
+  security/dependency-scan:
+    name: security/dependency-scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: latest
+          cache: true
+
+      - name: Dependency scan (pip-audit)
+        run: pixi run pip-audit >> $GITHUB_STEP_SUMMARY
+
+  security/secrets-scan:
+    name: security/secrets-scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          curl -sSfL \
+            https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz \
+            | tar -xz gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+
+      - name: Scan for secrets
+        run: gitleaks detect --source . --config .gitleaks.toml --verbose --exit-code=1
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: latest
+          cache: true
+
+      - name: Install build tools
+        run: pixi run pip install build hatchling
+
+      - name: Build wheel
+        run: pixi run python -m build --no-isolation
+
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: latest
+          cache: true
+
+      - name: Type check
+        run: pixi run typecheck
+
+  schema-validation:
+    name: schema-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install check-jsonschema
+        run: pip install check-jsonschema
+
+      - name: Validate workflow YAML schemas
+        run: |
+          find .github/workflows -name "*.yml" | \
+            xargs check-jsonschema \
+              --schemafile https://json.schemastore.org/github-workflow
+
+  deps/version-sync:
+    name: deps/version-sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check pyproject.toml version
+        run: |
+          python3 -c "
+          import tomllib
+          d = tomllib.load(open('pyproject.toml', 'rb'))
+          v = d['project']['version']
+          print(f'pyproject.toml version: {v}')
+          "
+
+      - name: Check version consistency (pyproject.toml vs pixi.toml)
+        run: |
+          set -e
+          PYPROJECT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          PIXI_VERSION=$(grep '^version = ' pixi.toml | sed 's/version = "\(.*\)"/\1/')
+
+          if [ "$PYPROJECT_VERSION" != "$PIXI_VERSION" ]; then
+            echo "Version mismatch: pyproject.toml ($PYPROJECT_VERSION) != pixi.toml ($PIXI_VERSION)"
+            exit 1
+          fi
+
+          echo "Version check passed: $PYPROJECT_VERSION"
+
+      - name: Check pixi.lock is not modified (uncommitted)
+        run: |
+          if git diff --name-only HEAD | grep -q pixi.lock; then
+            echo "WARN: pixi.lock has uncommitted modifications"
+            exit 1
+          else
+            echo "OK: pixi.lock is clean"
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/_required.yml` with 9 canonical job names for the org-wide `homeric-main-baseline` ruleset
- Jobs mirror actual pixi task names from `ci.yml` and `security.yml`; NATS integration tests use the same `docker run nats:latest -js` pattern as existing CI

## Jobs

| Job name | Implementation |
|---|---|
| `lint` | `pixi run lint` |
| `unit-tests` | `pixi run pytest -m "not integration"` |
| `integration-tests` | docker NATS + `pixi run pytest -m integration` |
| `security/dependency-scan` | `pixi run pip-audit` |
| `security/secrets-scan` | gitleaks v8.24.3 binary (mirrors security.yml) |
| `build` | `pixi run python -m build --no-isolation` (hatchling backend) |
| `typecheck` | `pixi run typecheck` |
| `schema-validation` | `check-jsonschema` against GitHub workflow JSON schema |
| `deps/version-sync` | pyproject.toml ↔ pixi.toml version check + pixi.lock clean check |

## Test plan

- [ ] All 9 jobs appear as status checks on this PR
- [ ] Existing required checks (`CI / Lint & Test`, `CI / Integration Tests (NATS)`, `Security Scan / Secret Scanning (gitleaks)`) still pass
- [ ] `schema-validation` validates `_required.yml` itself without error

🤖 Generated with Claude Code