### PR TITLE
fix(docker): add prometheus_client and fix default port to 8085

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim AS builder
 WORKDIR /build
-RUN pip install --no-cache-dir fastapi "uvicorn[standard]" nats-py "pydantic>=2.0" pydantic-settings httpx \
+RUN pip install --no-cache-dir fastapi "uvicorn[standard]" nats-py "pydantic>=2.0" pydantic-settings httpx prometheus_client \
     --target /build/deps
 
 FROM python:3.12-slim
@@ -13,11 +13,11 @@ RUN useradd -r -s /usr/sbin/nologin hermes
 USER hermes
 
 ENV HERMES_HOST=0.0.0.0
-ENV HERMES_PORT=8080
-ENV HERMES_PUBLIC_URL=http://localhost:8080
-EXPOSE 8080
+ENV HERMES_PORT=8085
+ENV HERMES_PUBLIC_URL=http://localhost:8085
+EXPOSE 8085
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:${HERMES_PORT:-8080}/ready || exit 1
+    CMD curl -f http://localhost:${HERMES_PORT:-8085}/ready || exit 1
 
 CMD ["python", "-m", "hermes.server"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -92,6 +92,7 @@ class TestPublisherIntegration:
             received.append(m)
 
         sub = await nats_client.subscribe("hi.agents.>", cb=_cb)
+        await nats_client.flush()  # ensure server has ack'd the subscription before we publish
 
         payload = WebhookPayload(
             event="agent.created",
@@ -117,6 +118,7 @@ class TestPublisherIntegration:
             received.append(m)
 
         sub = await nats_client.subscribe("hi.tasks.>", cb=_cb)
+        await nats_client.flush()  # ensure server has ack'd the subscription before we publish
 
         payload = WebhookPayload(
             event="task.updated",


### PR DESCRIPTION
## Summary
- Add `prometheus_client` to pip install — missing dep caused Hermes to crash on startup
- Fix `HERMES_PORT` default from 8080 to 8085 — was conflicting with Agamemnon

Found during mesh bringup on titan, aeolus, apollo (all three independently hit the same issue).

## Test plan
- [ ] Docker build succeeds
- [ ] Hermes starts without import errors
- [ ] Health endpoint responds on port 8085

🤖 Generated with Claude Code