### PR TITLE
docs(changelog): backfill Unreleased section; add pre-commit guard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,12 @@ repos:
     rev: v8.24.3
     hooks:
       - id: gitleaks
+
+  - repo: local
+    hooks:
+      - id: changelog-not-empty
+        name: CHANGELOG [Unreleased] must be populated
+        language: python
+        entry: python scripts/check-changelog.py
+        files: ^CHANGELOG\.md$
+        pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,40 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-- Add `CHANGELOG.md` following Keep a Changelog format
-- Address documentation audit findings
+### Added
+
+- Prometheus metrics endpoint (`/metrics`) with request count, latency histograms, and NATS
+  publish counters
+- Graceful shutdown sequence with configurable `SHUTDOWN_TIMEOUT` (default 10 s)
+- NATS reconnect retry loop with exponential backoff and jitter; oversized-payload logging
+- Request ID middleware: `X-Request-ID` header propagated through all log lines
+- Dead-letter queue routing for unknown event types (`homeric-deadletter` stream)
+- `MAX_PAYLOAD_BYTES` configuration variable (default 1 MiB) with startup logging
+- TLS verification guard: loud `WARNING` when `TLS_VERIFY=false` + `HERMES_HOST=0.0.0.0`
+- `schema_version` field documented in wire format reference
+- Docker publish workflow for automated image releases on version tags
+- Pre-commit CI step and version-consistency check in CI pipeline
+- `scan-secrets` just recipe using gitleaks
+- pip-audit step in CI for dependency vulnerability scanning
+- Unified `_required.yml` required-checks workflow
+
+### Changed
+
+- Default server port changed from 8080 to 8085 in Dockerfile
+- CI `typecheck` steps merged into the `lint` job to reduce workflow complexity
+- NATS connection logic extracted into `_connect_to_nats()` to reduce lifespan complexity
+- Pre-commit mypy hook added; ruff removed from pre-commit (handled by CI lint step)
+
+### Fixed
+
+- Signal handler registration guarded against non-main-thread execution (`RuntimeError` caught)
+- NATS retry loop: skip sleep after final attempt; log "giving up" on terminal failure
+- lifespan abort and degraded-mode behavior aligned across server and tests
+- mypy type errors exposed by new pre-commit mypy check
+- `pixi.toml` lock file regenerated to match pinned pixi version (v0.67.2)
+- `gitleaks-action` reverted (requires org license); pip-audit set to `continue-on-error`
+- CI: valid job IDs in `_required.yml` (no slashes in keys)
+- `prometheus_client` added to Docker image dependencies
 
 ## [0.1.0] - 2026-04-03
 

--- a/scripts/check-changelog.py
+++ b/scripts/check-changelog.py
@@ -1,0 +1,55 @@
+"""Pre-commit hook: verify the [Unreleased] section of CHANGELOG.md is populated.
+
+Exits non-zero if the [Unreleased] block contains fewer than MIN_ENTRIES non-empty,
+non-heading lines, which would indicate placeholder-only content.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+CHANGELOG = Path("CHANGELOG.md")
+MIN_ENTRIES = 3
+
+
+def count_unreleased_entries(text: str) -> int:
+    """Return the number of substantive lines in the [Unreleased] block."""
+    in_unreleased = False
+    count = 0
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == "## [Unreleased]":
+            in_unreleased = True
+            continue
+        if in_unreleased:
+            # Next versioned section ends the block
+            if stripped.startswith("## [") and stripped != "## [Unreleased]":
+                break
+            # Skip blanks and category headings (### Added, etc.)
+            if not stripped or stripped.startswith("#"):
+                continue
+            count += 1
+    return count
+
+
+def main() -> int:
+    if not CHANGELOG.exists():
+        print(f"error: {CHANGELOG} not found", file=sys.stderr)
+        return 1
+
+    text = CHANGELOG.read_text(encoding="utf-8")
+    count = count_unreleased_entries(text)
+    if count < MIN_ENTRIES:
+        print(
+            f"error: CHANGELOG.md [Unreleased] section has only {count} "
+            f"entr{'y' if count == 1 else 'ies'} (minimum {MIN_ENTRIES}).\n"
+            "Please document your changes before committing.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Backfills the `[Unreleased]` section of `CHANGELOG.md` with ~30 commits of notable changes since v0.1.0, organized into **Added / Changed / Fixed** categories per Keep a Changelog format
- Adds `scripts/check-changelog.py` — a lightweight helper that counts substantive lines in the `[Unreleased]` block and exits non-zero if fewer than 3 are present
- Adds a `changelog-not-empty` local pre-commit hook in `.pre-commit-config.yaml` that runs the script on any commit touching `CHANGELOG.md`, enforcing the CONTRIBUTING.md requirement going forward

## Test plan

- [x] `pixi run python scripts/check-changelog.py` exits 0 on the populated CHANGELOG
- [x] Script correctly returns count < MIN_ENTRIES (2) and exits 1 when given the old placeholder-only content (verified with inline test)
- [x] All 363 existing tests pass; 3 pre-existing flaky integration tests confirmed unrelated to these changes (they also fail on the clean branch)

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)