### PR TITLE
docs: add committed OpenAPI spec and Hermes-specific ADRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,32 @@ Hermes exposes several endpoints for webhooks, health checks, and observability:
 - **`/ready`** returns `200 OK` when ready to accept webhooks (NATS connected),
   `503 Service Unavailable` otherwise. Use for Kubernetes readiness probes.
 
+## API Documentation
+
+The committed OpenAPI 3.x specification is at [`openapi.json`](openapi.json) in the repository
+root. It is generated from the live FastAPI app and kept in sync with each release.
+
+To regenerate it locally:
+
+```bash
+just export-openapi
+```
+
+FastAPI also serves interactive docs at runtime:
+
+- Swagger UI: `http://localhost:<HERMES_PORT>/docs`
+- ReDoc: `http://localhost:<HERMES_PORT>/redoc`
+
+## Architecture Decisions
+
+Hermes-specific architectural decisions are documented as ADRs in [`docs/adr/`](docs/adr/).
+
+| ADR | Decision |
+|-----|----------|
+| [ADR-001](docs/adr/ADR-001-nats-reconnect-strategy.md) | `allow_reconnect=False` — fail fast on NATS disconnect rather than buffering silently |
+| [ADR-002](docs/adr/ADR-002-dead-letter-strategy.md) | Route unknown event types to `hi.deadletter.<event>` JetStream subject |
+| [ADR-003](docs/adr/ADR-003-schema-version-field.md) | Include `schema_version` integer in every wire-format message |
+
 ## Configuration
 
 Copy `.env.example` to `.env` and fill in values:

--- a/docs/adr/ADR-001-nats-reconnect-strategy.md
+++ b/docs/adr/ADR-001-nats-reconnect-strategy.md
@@ -1,0 +1,85 @@
+# ADR-001: NATS Reconnect Strategy
+
+**Status:** Accepted
+**Date:** 2024-01-15
+**Deciders:** Hermes maintainers
+
+---
+
+## Context
+
+The nats-py client library supports automatic background reconnection: when the TCP connection to
+NATS drops, the library silently buffers outgoing messages and re-delivers them once the connection
+is restored. This is convenient but introduces hidden failure modes for a webhook bridge:
+
+- Buffered messages may be delivered out-of-order or after a significant delay, making events
+  appear stale to downstream consumers.
+- The HTTP caller receives a `200 OK` response even though the message has not been durably
+  published to JetStream — a false acknowledgement.
+- The `/health` and `/ready` endpoints cannot accurately report the service as unhealthy while the
+  library is silently attempting to reconnect in the background.
+
+Hermes is a thin, stateless bridge: its only job is to receive an HTTP webhook and durably publish
+it to NATS. If that publish cannot succeed immediately, the caller should know.
+
+---
+
+## Decision
+
+Hermes sets `allow_reconnect=False` when calling `nats.connect()` in `publisher.py`.
+
+Reconnection to NATS is handled **only at startup** via `_connect_with_retries()` in `server.py`,
+which retries with exponential backoff (default: 3 attempts, 5-second intervals) before allowing
+the service to start accepting traffic.
+
+Once the service is running, a NATS disconnect causes:
+
+1. `_on_disconnected()` callback fires; `publisher._connected` is set to `False`.
+2. `/health` and `/ready` return `503 Service Unavailable`.
+3. Incoming `POST /webhook` requests receive `503` immediately (checked before publishing).
+4. The operator is alerted and must restart Hermes or restore NATS connectivity.
+
+---
+
+## Rationale
+
+- **Observability over convenience:** A `503` response to the upstream webhook caller is honest.
+  The caller's retry logic handles re-delivery, which is better than Hermes silently buffering and
+  guessing when to flush.
+- **JetStream acknowledgements are the source of truth:** Only after `js.publish()` returns
+  successfully has the message been durably stored. Allowing reconnect would mean returning `200
+  OK` before that guarantee is met.
+- **Startup retries cover the common case:** The most frequent reason Hermes cannot reach NATS is
+  that both services are starting simultaneously (e.g., `docker compose up`). Startup retries
+  handle this without compromising the runtime contract.
+- **Simplicity:** One clear failure mode (disconnect → 503 → restart) is easier to operate and
+  alert on than a partially-connected buffering state.
+
+---
+
+## Consequences
+
+- Hermes must be restarted (or NATS must recover and Hermes restarted) after a persistent NATS
+  disconnect; there is no self-healing at runtime.
+- Upstream callers must implement retry logic with backoff. This is standard practice for webhook
+  delivery (GitHub, Slack, and most SaaS platforms retry on `5xx` responses).
+- The `/health` endpoint accurately reflects the NATS connection state, enabling reliable liveness
+  and readiness probes.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Reason Rejected |
+|-------------|----------------|
+| `allow_reconnect=True` (library default) | Silent buffering produces false `200 OK` responses and makes health probes unreliable. |
+| `allow_reconnect=True` + in-memory buffer with timeout | Adds complexity; still risks stale delivery; does not eliminate the false-ACK problem for JetStream. |
+| Circuit-breaker middleware | Adds a dependency and operational complexity for a problem that startup retries already solve. |
+
+---
+
+## Document Metadata
+
+**Status:** Accepted
+**Supersedes:** N/A
+**Superseded by:** N/A

--- a/docs/adr/ADR-002-dead-letter-strategy.md
+++ b/docs/adr/ADR-002-dead-letter-strategy.md
@@ -1,0 +1,89 @@
+# ADR-002: Dead-Letter Strategy for Unknown Event Types
+
+**Status:** Accepted
+**Date:** 2024-01-15
+**Deciders:** Hermes maintainers
+
+---
+
+## Context
+
+External services POST webhook payloads to Hermes. Each payload carries an `event` field (e.g.,
+`agent.created`, `task.completed`). Hermes routes known event types to well-defined NATS subjects
+(`hi.agents.*` and `hi.tasks.*`). However, external services may send event types that:
+
+- Are not yet implemented in Hermes (forward-compatible events from a newer upstream version).
+- Are misconfigured (typos, renamed event strings in upstream service).
+- Represent intentional extensions added by an operator without a corresponding Hermes update.
+
+Silently dropping unknown events means operators have no way to inspect, diagnose, or replay them.
+Raising a hard error and returning `4xx` to the caller is also wrong: the event is not malformed —
+it is simply unrecognised, and the caller cannot be expected to know Hermes's routing table.
+
+---
+
+## Decision
+
+Unknown event types are handled through a two-tier dead-letter mechanism, gated behind the
+`ENABLE_DEAD_LETTER` environment variable (default: `true`):
+
+**Tier 1 — JetStream dead-letter stream:**
+Unknown events are published to `hi.deadletter.<event-slug>` in NATS JetStream. JetStream provides
+durable storage, so events can be replayed after Hermes or consumer code is updated. The subject
+uses the sanitised event slug so consumers can subscribe selectively.
+
+**Tier 2 — In-memory deque:**
+A bounded deque (max 1000 entries) maintains a local copy of dead-lettered events for operator
+inspection via the `GET /dead-letters` endpoint. This allows immediate visibility without querying
+NATS.
+
+If `ENABLE_DEAD_LETTER=false`, unroutable events raise `UnknownEventTypeError` and the caller
+receives `422 Unprocessable Entity`.
+
+---
+
+## Rationale
+
+- **Never silently drop events:** A dropped webhook that should have triggered a downstream action
+  (e.g., agent state change) can cause cascading failures that are hard to diagnose.
+- **JetStream durability:** The dead-letter stream persists across Hermes restarts. An operator can
+  replay events after updating routing logic, without needing the upstream service to re-fire.
+- **In-memory view for rapid inspection:** The `/dead-letters` endpoint gives operators immediate
+  visibility without requiring NATS CLI access. The 1000-entry cap keeps memory usage bounded.
+- **Operator opt-out:** `ENABLE_DEAD_LETTER=false` supports strict environments where receiving
+  any unknown event type should be treated as a configuration error.
+- **Selective subscription:** Using `hi.deadletter.<event-slug>` subjects (rather than one flat
+  queue) allows consumers to subscribe to specific unrecognised event types independently.
+
+---
+
+## Consequences
+
+- The `hi.deadletter.>` JetStream stream must be provisioned in NATS before Hermes starts (or
+  Hermes must be granted stream creation permissions). The stream is created automatically on
+  startup via `_ensure_streams()` in `publisher.py` if JetStream admin permissions are available.
+- The in-memory deque is lost on restart; only the JetStream copy is durable.
+- Operators monitoring the dead-letter queue should set up alerts on the `hi.deadletter.>` stream
+  subject pattern and on the `dead_letter_count` field in the `/health` response.
+- Callers always receive `200 OK` for unknown events when dead-lettering is enabled, which is the
+  correct HTTP contract (the payload was received and processed — routing it to dead-letter *is*
+  the processing).
+
+---
+
+## Alternatives Considered
+
+| Alternative | Reason Rejected |
+|-------------|----------------|
+| Return `422` for all unknown events | Breaks callers that send forward-compatible events; shifts routing knowledge burden onto upstream services. |
+| Single flat `hi.deadletter` subject | Prevents selective subscription; makes replay and monitoring coarser. |
+| Database-backed dead-letter queue | Adds a stateful dependency; JetStream already provides durable storage. |
+| In-memory only (no JetStream tier) | Events are lost on restart; no replay capability. |
+
+---
+
+## Document Metadata
+
+**Status:** Accepted
+**Supersedes:** N/A
+**Superseded by:** N/A

--- a/docs/adr/ADR-003-schema-version-field.md
+++ b/docs/adr/ADR-003-schema-version-field.md
@@ -1,0 +1,102 @@
+# ADR-003: Wire Format Schema Versioning
+
+**Status:** Accepted
+**Date:** 2024-01-15
+**Deciders:** Hermes maintainers
+
+---
+
+## Context
+
+Hermes publishes structured JSON messages to NATS JetStream. Multiple downstream consumers
+(Argus, Agamemnon, Telemachy) deserialize these messages independently. Over time, the wire format
+will evolve: fields may be added, renamed, or removed.
+
+Without a versioning mechanism, a breaking wire format change requires all consumers to be updated
+and deployed simultaneously — a hard coordination problem in a distributed system with rolling
+deployments.
+
+Content-negotiation patterns (HTTP `Accept` / `Content-Type` headers) do not apply to pub/sub
+systems: there is no per-consumer negotiation channel between the publisher and individual
+subscribers in NATS JetStream.
+
+---
+
+## Decision
+
+Every message published by Hermes includes a `schema_version: int` field at the top level of the
+JSON payload. This field is defined in `HermesEventBase` in `src/hermes/models.py`:
+
+```python
+schema_version: int = Field(default=1, ge=1, description="Wire format schema version")
+```
+
+**Versioning rules:**
+
+| Change type | Version bump? |
+|-------------|--------------|
+| New **optional** field added | No — backwards-compatible |
+| Existing field **renamed** | Yes — breaking change |
+| Existing field **removed** | Yes — breaking change |
+| Field **type changed** | Yes — breaking change |
+| New **required** field added | Yes — breaking change |
+
+The current version is **1**. All messages carry `"schema_version": 1` until a breaking change
+warrants incrementing to `2`.
+
+**Consumer contract:**
+
+1. Deserialize only `schema_version` first (it is always at the top level).
+2. If `schema_version` is higher than the consumer's maximum known version, log a warning and
+   route the message to a dead-letter queue rather than crashing.
+3. If `schema_version` matches a known version, deserialize the full payload accordingly.
+4. During rolling deployments, consumers must handle messages from both the old and new schema
+   version simultaneously.
+
+---
+
+## Rationale
+
+- **Decoupled upgrades:** Publishers (Hermes) and consumers can be deployed independently.
+  Consumers detect version mismatches at message time rather than at deploy time.
+- **Simplicity over negotiation:** A single integer in the payload is universally parseable by any
+  JSON consumer without schema registry infrastructure.
+- **Conservative increment policy:** Bumping only on breaking changes means consumers do not need
+  to update code for additive changes, reducing deployment churn.
+- **Fail-safe consumer guidance:** Routing unknown versions to dead-letter (rather than crashing)
+  preserves events for later replay once the consumer is updated.
+- **Matches JetStream semantics:** JetStream already provides replay; pairing it with
+  `schema_version` gating gives consumers a complete upgrade path: old messages are replayable
+  with an updated consumer after a version bump.
+
+---
+
+## Consequences
+
+- All NATS consumers **must** read `schema_version` before full deserialization. This is a
+  non-negotiable contract for any service subscribing to Hermes-published subjects.
+- There is no automated migration: old messages stored in JetStream retain their original
+  `schema_version`. A consumer updating from v1 to v2 must handle both.
+- The `schema_version` field is validated with `ge=1` in Pydantic; values less than 1 are
+  rejected at the Hermes boundary and will never be published.
+- Additive changes (new optional fields) require no consumer-side code changes and no version
+  bump, which reduces the cost of evolving the wire format.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Reason Rejected |
+|-------------|----------------|
+| NATS subject-per-version (e.g., `hi.agents.v2.*`) | Subject proliferation; consumers must subscribe to N subjects; complicates routing logic. |
+| Schema registry (e.g., Confluent Schema Registry) | External infrastructure dependency; significant operational overhead for a lightweight bridge. |
+| Semantic versioning string (e.g., `"1.0.0"`) | Semver comparison logic in every consumer; integer comparison is simpler and sufficient. |
+| No versioning | First breaking change requires coordinated fleet-wide deployment; unacceptable for a distributed system. |
+
+---
+
+## Document Metadata
+
+**Status:** Accepted
+**Supersedes:** N/A
+**Superseded by:** N/A

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,23 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for Hermes-specific design decisions.
+
+ADRs document the context, decision, and consequences of significant architectural choices so that
+future maintainers understand *why* the code is the way it is.
+
+## Format
+
+Each ADR uses the following sections: **Status**, **Date**, **Deciders**, **Context**,
+**Decision**, **Rationale**, **Consequences**, **Alternatives Considered**.
+
+## Status Lifecycle
+
+`Proposed` → `Accepted` → `Deprecated` / `Superseded by ADR-NNN`
+
+## Index
+
+| # | Title | Status | Date |
+|---|-------|--------|------|
+| [ADR-001](ADR-001-nats-reconnect-strategy.md) | NATS Reconnect Strategy | Accepted | 2024-01-15 |
+| [ADR-002](ADR-002-dead-letter-strategy.md) | Dead-Letter Strategy for Unknown Event Types | Accepted | 2024-01-15 |
+| [ADR-003](ADR-003-schema-version-field.md) | Wire Format Schema Versioning | Accepted | 2024-01-15 |

--- a/justfile
+++ b/justfile
@@ -97,6 +97,12 @@ docker-up:
 docker-down:
     docker compose down
 
+# === Documentation ===
+
+# Regenerate the committed OpenAPI spec (openapi.json) from the FastAPI app
+export-openapi:
+    pixi run python scripts/export-openapi.py
+
 # === Security ===
 
 # Audit dependencies for known vulnerabilities

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,574 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "ProjectHermes",
+    "description": "Bridges external webhooks to NATS JetStream.",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "description": "Return service health and NATS connection status. Returns 503 when NATS is disconnected.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "NATS not reachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/version": {
+      "get": {
+        "summary": "Get Version",
+        "description": "Return the installed package version.",
+        "operationId": "get_version_version_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VersionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "description": "Readiness probe \u2014 returns 503 when NATS is not connected.",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Ready Ready Get"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "NATS not connected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webhook": {
+      "post": {
+        "summary": "Receive Webhook",
+        "description": "Receive an external webhook, validate its signature, and publish to NATS.",
+        "operationId": "receive_webhook_webhook_post",
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookAcceptedResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid webhook signature",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Malformed or invalid payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "NATS publisher not connected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subjects": {
+      "get": {
+        "summary": "List Subjects",
+        "description": "Return the list of NATS subjects that have been published to.",
+        "operationId": "list_subjects_subjects_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubjectsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "summary": "Metrics",
+        "description": "Expose Prometheus metrics in text format.",
+        "operationId": "metrics_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dead-letters": {
+      "get": {
+        "summary": "Dead Letters",
+        "description": "Return the in-memory dead-letter queue with optional pagination.\n\nQuery params:\n- ``offset``: number of items to skip (default 0).\n- ``limit``: maximum number of items to return (default: all).",
+        "operationId": "dead_letters_dead_letters_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeadLettersResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Drain Dead Letters",
+        "description": "Drain (clear) the in-memory dead-letter queue and return the count of drained items.",
+        "operationId": "drain_dead_letters_dead_letters_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "title": "Response Drain Dead Letters Dead Letters Delete"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/events": {
+      "get": {
+        "summary": "List Events",
+        "description": "Return the canonical set of supported webhook event types.",
+        "operationId": "list_events_events_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "type": "object",
+                  "title": "Response List Events Events Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DeadLettersResponse": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit"
+          },
+          "items": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "offset",
+          "limit",
+          "items"
+        ],
+        "title": "DeadLettersResponse",
+        "description": "Response body for GET /dead-letters (paginated)."
+      },
+      "ErrorResponse": {
+        "properties": {
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          },
+          "request_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "detail"
+        ],
+        "title": "ErrorResponse",
+        "description": "Standard error response body."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "HealthResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "nats_connected": {
+            "type": "boolean",
+            "title": "Nats Connected"
+          },
+          "shutting_down": {
+            "type": "boolean",
+            "title": "Shutting Down",
+            "default": false
+          },
+          "hmac_validation_enabled": {
+            "type": "boolean",
+            "title": "Hmac Validation Enabled",
+            "default": false
+          },
+          "hermes_public_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hermes Public Url"
+          },
+          "inflight_requests": {
+            "type": "integer",
+            "title": "Inflight Requests",
+            "default": 0
+          },
+          "dead_letter_count": {
+            "type": "integer",
+            "title": "Dead Letter Count",
+            "default": 0
+          },
+          "timeouts": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TimeoutSettings"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "nats_reconnect_count": {
+            "type": "integer",
+            "title": "Nats Reconnect Count",
+            "default": 0
+          },
+          "nats_last_error": {
+            "type": "string",
+            "title": "Nats Last Error",
+            "default": ""
+          },
+          "nats_retry_attempts": {
+            "type": "integer",
+            "title": "Nats Retry Attempts",
+            "default": 3
+          },
+          "nats_retry_interval": {
+            "type": "number",
+            "title": "Nats Retry Interval",
+            "default": 5.0
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "nats_connected"
+        ],
+        "title": "HealthResponse",
+        "description": "Response body for GET /health."
+      },
+      "SubjectsResponse": {
+        "properties": {
+          "subjects": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Subjects"
+          },
+          "hermes_public_url": {
+            "type": "string",
+            "title": "Hermes Public Url",
+            "default": ""
+          },
+          "active_subjects_max": {
+            "type": "integer",
+            "title": "Active Subjects Max",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "subjects"
+        ],
+        "title": "SubjectsResponse",
+        "description": "Response body for GET /subjects."
+      },
+      "TimeoutSettings": {
+        "properties": {
+          "nats_connect": {
+            "type": "number",
+            "title": "Nats Connect"
+          },
+          "nats_publish": {
+            "type": "number",
+            "title": "Nats Publish"
+          },
+          "agamemnon": {
+            "type": "number",
+            "title": "Agamemnon"
+          }
+        },
+        "type": "object",
+        "required": [
+          "nats_connect",
+          "nats_publish",
+          "agamemnon"
+        ],
+        "title": "TimeoutSettings",
+        "description": "Timeout values (seconds) surfaced in /health for observability."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "VersionResponse": {
+        "properties": {
+          "version": {
+            "type": "string",
+            "title": "Version"
+          }
+        },
+        "type": "object",
+        "required": [
+          "version"
+        ],
+        "title": "VersionResponse",
+        "description": "Response body for GET /version."
+      },
+      "WebhookAcceptedResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "event": {
+            "type": "string",
+            "title": "Event"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "event"
+        ],
+        "title": "WebhookAcceptedResponse",
+        "description": "Response body for POST /webhook (202 Accepted)."
+      }
+    }
+  }
+}

--- a/scripts/export-openapi.py
+++ b/scripts/export-openapi.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+"""Export the Hermes FastAPI app's OpenAPI schema to a JSON file.
+
+Usage:
+    python scripts/export-openapi.py [--output openapi.json]
+
+This script imports the FastAPI app object without starting the NATS lifespan,
+so it is safe to run without a running NATS server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from hermes.server import app  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export Hermes OpenAPI spec to JSON")
+    parser.add_argument(
+        "--output",
+        default="openapi.json",
+        help="Output file path (default: openapi.json)",
+    )
+    args = parser.parse_args()
+
+    spec = app.openapi()
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(spec, f, indent=2)
+        f.write("\n")
+
+    print(f"OpenAPI spec written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **OpenAPI spec**: adds `scripts/export-openapi.py` that dumps the live FastAPI `app.openapi()` to `openapi.json` without starting the NATS lifespan; adds `just export-openapi` recipe; commits `openapi.json` (8 endpoints)
- **ADR-001** (`docs/adr/ADR-001-nats-reconnect-strategy.md`): documents why `allow_reconnect=False` is used in `publisher.py` — fail-fast on NATS disconnect rather than silently buffering events and returning false `200 OK`s
- **ADR-002** (`docs/adr/ADR-002-dead-letter-strategy.md`): documents the two-tier dead-letter strategy (JetStream `hi.deadletter.<event>` + in-memory deque) for unknown event types
- **ADR-003** (`docs/adr/ADR-003-schema-version-field.md`): documents the `schema_version` integer field in `HermesEventBase`, versioning rules, and consumer contract
- **README**: adds "API Documentation" and "Architecture Decisions" sections pointing to `openapi.json` and `docs/adr/`

## Test plan

- [x] `pixi run python scripts/export-openapi.py` runs without a NATS server and writes valid JSON
- [x] `python -m json.tool openapi.json` validates successfully
- [x] `openapi.json` contains all 8 endpoints (`/health`, `/version`, `/ready`, `/webhook`, `/subjects`, `/metrics`, `/dead-letters`, `/events`)
- [x] `just --list` shows the `export-openapi` recipe
- [x] All 366 existing tests pass (`pytest` — 36.88s, 0 failures)
- [x] No backup files left in the working tree

Closes #320
Part of #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)