### PR TITLE
fix(publisher): restore NATS automatic reconnection via background loop

### DIFF
--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -70,35 +70,80 @@ class Publisher:
         self._connected: bool = False
         self.reconnect_count: int = 0
         self.last_error: str = ""
+        self._stop_event: asyncio.Event = asyncio.Event()
+        self._reconnect_task: asyncio.Task[None] | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
+    async def _on_disconnected(self) -> None:
+        """Callback invoked by nats-py when the connection is lost."""
+        self._connected = False
+        self.last_error = "NATS disconnected"
+        logger.warning("NATS disconnected")
+
+    async def _on_reconnected(self) -> None:
+        """Callback invoked after a successful reconnect."""
+        self._connected = True
+        self.reconnect_count += 1
+        logger.info("NATS reconnected (count=%d)", self.reconnect_count)
+
     async def connect(self, url: str, connect_timeout: float = 5.0) -> None:
         """Connect to the NATS server, obtain JetStream context, and ensure streams exist."""
-
-        async def _on_disconnected() -> None:
-            self._connected = False
-            self.last_error = "NATS disconnected"
-            logger.warning("NATS disconnected")
-
-        async def _on_reconnected() -> None:
-            self._connected = True
-            self.reconnect_count += 1
-            logger.info("NATS reconnected (count=%d)", self.reconnect_count)
-
         self._nc = await nats.connect(
             url,
             allow_reconnect=False,
             connect_timeout=connect_timeout,
-            disconnected_cb=_on_disconnected,
-            reconnected_cb=_on_reconnected,
+            disconnected_cb=self._on_disconnected,
+            reconnected_cb=self._on_reconnected,
         )
         self._connected = True
         self._js = self._nc.jetstream()
         await self._ensure_streams()
+        self._stop_event.clear()
+        self._reconnect_task = asyncio.create_task(
+            self._reconnect_loop(url, connect_timeout), name="nats-reconnect-loop"
+        )
         logger.info("Connected to NATS at %s", url)
+
+    async def _reconnect_loop(self, url: str, connect_timeout: float) -> None:
+        """Poll for connection loss and re-establish the NATS connection when dropped.
+
+        Runs as a background task.  Exits cleanly when _stop_event is set.
+        Uses interruptible sleep so shutdown is not delayed by the poll interval.
+        """
+        from hermes.config import get_settings
+
+        poll_interval = get_settings().nats_retry_interval
+        while not self._stop_event.is_set():
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=poll_interval)
+                return  # stop event fired during sleep
+            except asyncio.TimeoutError:
+                pass
+
+            if self._nc is None or not self._nc.is_closed:
+                continue
+
+            logger.warning("NATS connection lost; attempting reconnect")
+            try:
+                nc = await asyncio.wait_for(
+                    nats.connect(
+                        url,
+                        allow_reconnect=False,
+                        connect_timeout=connect_timeout,
+                        disconnected_cb=self._on_disconnected,
+                        reconnected_cb=self._on_reconnected,
+                    ),
+                    timeout=connect_timeout + 1.0,
+                )
+                self._nc = nc
+                self._js = nc.jetstream()
+                await self._on_reconnected()
+            except Exception as exc:
+                logger.warning("NATS reconnect failed: %s", exc)
+                self.last_error = str(exc)
 
     async def _ensure_streams(self) -> None:
         """Create JetStream streams if they don't exist yet."""
@@ -122,6 +167,14 @@ class Publisher:
 
     async def disconnect(self) -> None:
         """Drain and close the NATS connection."""
+        self._stop_event.set()
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+            try:
+                await self._reconnect_task
+            except asyncio.CancelledError:
+                pass
+            self._reconnect_task = None
         if self._nc is not None:
             await self._nc.drain()
             self._nc = None

--- a/tests/test_publisher_reconnect.py
+++ b/tests/test_publisher_reconnect.py
@@ -1,0 +1,337 @@
+"""Tests for Publisher._reconnect_loop background task."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hermes.publisher import Publisher
+
+
+def _make_mock_nc(*, is_closed: bool = False) -> MagicMock:
+    """Return a MagicMock NATS client with configurable is_closed."""
+    nc = MagicMock()
+    nc.is_closed = is_closed
+    nc.jetstream.return_value = MagicMock()
+    jsm = AsyncMock()
+    nc.jsm.return_value = jsm
+    nc.drain = AsyncMock()
+    return nc
+
+
+async def _connect_publisher(pub: Publisher, mock_nc: MagicMock) -> None:
+    """Helper: patch nats.connect and call pub.connect()."""
+    with patch("nats.connect", return_value=mock_nc):
+        await pub.connect("nats://localhost:4222", connect_timeout=5.0)
+
+
+class TestReconnectLoopStartsOnConnect:
+    @pytest.mark.asyncio
+    async def test_reconnect_task_created_after_connect(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+        await _connect_publisher(pub, mock_nc)
+
+        assert pub._reconnect_task is not None
+        assert not pub._reconnect_task.done()
+
+        # Clean up
+        pub._stop_event.set()
+        await asyncio.sleep(0)
+        pub._reconnect_task.cancel()
+        try:
+            await pub._reconnect_task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_reconnect_task_cancelled_on_disconnect(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+        await _connect_publisher(pub, mock_nc)
+
+        task = pub._reconnect_task
+        assert task is not None
+
+        await pub.disconnect()
+
+        assert task.done()
+        assert pub._reconnect_task is None
+
+
+class TestReconnectLoopStopEvent:
+    @pytest.mark.asyncio
+    async def test_loop_exits_when_stop_event_set(self) -> None:
+        pub = Publisher()
+        # Run the loop with a very long poll interval; stop event fires immediately.
+        pub._stop_event.set()
+        await asyncio.wait_for(pub._reconnect_loop("nats://localhost:4222", 5.0), timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_stop_event_set_before_poll_interval_elapses(self) -> None:
+        pub = Publisher()
+
+        with patch("hermes.config.get_settings") as mock_settings:
+            mock_settings.return_value.nats_retry_interval = 60.0
+
+            loop_task = asyncio.create_task(pub._reconnect_loop("nats://localhost:4222", 5.0))
+            await asyncio.sleep(0)  # let the loop start waiting
+            pub._stop_event.set()
+            await asyncio.wait_for(loop_task, timeout=1.0)  # should exit quickly, not after 60s
+
+
+class TestReconnectLoopDetectsClosedConnection:
+    @pytest.mark.asyncio
+    async def test_no_reconnect_attempt_when_connection_open(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc(is_closed=False)
+        pub._nc = mock_nc
+        pub._connected = True
+
+        reconnect_calls: list[str] = []
+
+        with (
+            patch("hermes.config.get_settings") as mock_settings,
+            patch("nats.connect", side_effect=lambda *a, **kw: reconnect_calls.append("called")),
+        ):
+            mock_settings.return_value.nats_retry_interval = 0.05
+
+            loop_task = asyncio.create_task(pub._reconnect_loop("nats://localhost:4222", 5.0))
+            await asyncio.sleep(0.12)  # two poll cycles
+            pub._stop_event.set()
+            await asyncio.wait_for(loop_task, timeout=1.0)
+
+        assert reconnect_calls == [], "nats.connect should not be called while connection is open"
+
+    @pytest.mark.asyncio
+    async def test_reconnect_attempted_when_connection_closed(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc(is_closed=True)
+        pub._nc = mock_nc
+
+        new_nc = _make_mock_nc(is_closed=False)
+        connect_calls: list[tuple] = []
+
+        async def fake_connect(*args: object, **kwargs: object) -> MagicMock:
+            connect_calls.append((args, kwargs))
+            pub._stop_event.set()  # stop after first successful reconnect
+            return new_nc
+
+        with (
+            patch("hermes.config.get_settings") as mock_settings,
+            patch("nats.connect", side_effect=fake_connect),
+        ):
+            mock_settings.return_value.nats_retry_interval = 0.05
+
+            await asyncio.wait_for(
+                pub._reconnect_loop("nats://localhost:4222", 5.0), timeout=2.0
+            )
+
+        assert len(connect_calls) == 1
+        assert pub._nc is new_nc
+
+
+class TestReconnectLoopSuccess:
+    @pytest.mark.asyncio
+    async def test_successful_reconnect_fires_on_reconnected(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc(is_closed=True)
+        pub._nc = mock_nc
+        pub._connected = False
+
+        new_nc = _make_mock_nc(is_closed=False)
+
+        async def fake_connect(*args: object, **kwargs: object) -> MagicMock:
+            pub._stop_event.set()
+            return new_nc
+
+        with (
+            patch("hermes.config.get_settings") as mock_settings,
+            patch("nats.connect", side_effect=fake_connect),
+        ):
+            mock_settings.return_value.nats_retry_interval = 0.05
+
+            await asyncio.wait_for(
+                pub._reconnect_loop("nats://localhost:4222", 5.0), timeout=2.0
+            )
+
+        assert pub._connected is True
+
+    @pytest.mark.asyncio
+    async def test_successful_reconnect_increments_reconnect_count(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc(is_closed=True)
+        pub._nc = mock_nc
+
+        new_nc = _make_mock_nc(is_closed=False)
+
+        async def fake_connect(*args: object, **kwargs: object) -> MagicMock:
+            pub._stop_event.set()
+            return new_nc
+
+        with (
+            patch("hermes.config.get_settings") as mock_settings,
+            patch("nats.connect", side_effect=fake_connect),
+        ):
+            mock_settings.return_value.nats_retry_interval = 0.05
+
+            await asyncio.wait_for(
+                pub._reconnect_loop("nats://localhost:4222", 5.0), timeout=2.0
+            )
+
+        assert pub.reconnect_count == 1
+
+    @pytest.mark.asyncio
+    async def test_successful_reconnect_updates_nc_and_js(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc(is_closed=True)
+        pub._nc = mock_nc
+
+        new_nc = _make_mock_nc(is_closed=False)
+        new_js = MagicMock()
+        new_nc.jetstream.return_value = new_js
+
+        async def fake_connect(*args: object, **kwargs: object) -> MagicMock:
+            pub._stop_event.set()
+            return new_nc
+
+        with (
+            patch("hermes.config.get_settings") as mock_settings,
+            patch("nats.connect", side_effect=fake_connect),
+        ):
+            mock_settings.return_value.nats_retry_interval = 0.05
+
+            await asyncio.wait_for(
+                pub._reconnect_loop("nats://localhost:4222", 5.0), timeout=2.0
+            )
+
+        assert pub._nc is new_nc
+        assert pub._js is new_js
+
+
+class TestReconnectLoopFailure:
+    @pytest.mark.asyncio
+    async def test_failed_reconnect_logs_warning_and_keeps_looping(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc(is_closed=True)
+        pub._nc = mock_nc
+
+        call_count = 0
+
+        async def fake_connect(*args: object, **kwargs: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                pub._stop_event.set()
+            raise ConnectionRefusedError("NATS unavailable")
+
+        with (
+            patch("hermes.config.get_settings") as mock_settings,
+            patch("nats.connect", side_effect=fake_connect),
+            patch("hermes.publisher.logger") as mock_logger,
+        ):
+            mock_settings.return_value.nats_retry_interval = 0.05
+
+            await asyncio.wait_for(
+                pub._reconnect_loop("nats://localhost:4222", 5.0), timeout=2.0
+            )
+
+        assert call_count >= 2
+        warning_messages = [c.args[0] for c in mock_logger.warning.call_args_list]
+        assert any("reconnect failed" in m for m in warning_messages)
+
+    @pytest.mark.asyncio
+    async def test_failed_reconnect_updates_last_error(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc(is_closed=True)
+        pub._nc = mock_nc
+
+        async def fake_connect(*args: object, **kwargs: object) -> MagicMock:
+            pub._stop_event.set()
+            raise ConnectionRefusedError("NATS gone")
+
+        with (
+            patch("hermes.config.get_settings") as mock_settings,
+            patch("nats.connect", side_effect=fake_connect),
+        ):
+            mock_settings.return_value.nats_retry_interval = 0.05
+
+            await asyncio.wait_for(
+                pub._reconnect_loop("nats://localhost:4222", 5.0), timeout=2.0
+            )
+
+        assert "NATS gone" in pub.last_error
+
+    @pytest.mark.asyncio
+    async def test_failed_reconnect_does_not_change_nc(self) -> None:
+        pub = Publisher()
+        original_nc = _make_mock_nc(is_closed=True)
+        pub._nc = original_nc
+
+        async def fake_connect(*args: object, **kwargs: object) -> MagicMock:
+            pub._stop_event.set()
+            raise OSError("connection refused")
+
+        with (
+            patch("hermes.config.get_settings") as mock_settings,
+            patch("nats.connect", side_effect=fake_connect),
+        ):
+            mock_settings.return_value.nats_retry_interval = 0.05
+
+            await asyncio.wait_for(
+                pub._reconnect_loop("nats://localhost:4222", 5.0), timeout=2.0
+            )
+
+        assert pub._nc is original_nc
+
+
+class TestReconnectLoopConnectTimeout:
+    @pytest.mark.asyncio
+    async def test_connect_timeout_applied_via_wait_for(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc(is_closed=True)
+        pub._nc = mock_nc
+
+        async def slow_connect(*args: object, **kwargs: object) -> MagicMock:
+            await asyncio.sleep(100)  # exceeds deadline
+            return MagicMock()  # never reached
+
+        with (
+            patch("hermes.config.get_settings") as mock_settings,
+            patch("nats.connect", side_effect=slow_connect),
+            patch("hermes.publisher.logger") as mock_logger,
+        ):
+            mock_settings.return_value.nats_retry_interval = 0.05
+
+            loop_task = asyncio.create_task(pub._reconnect_loop("nats://localhost:4222", 0.05))
+            await asyncio.sleep(0.2)  # give loop time to attempt and time out
+            pub._stop_event.set()
+            await asyncio.wait_for(loop_task, timeout=1.0)
+
+        warning_messages = [c.args[0] for c in mock_logger.warning.call_args_list]
+        assert any("reconnect failed" in m for m in warning_messages)
+
+
+class TestDisconnectCancelsLoop:
+    @pytest.mark.asyncio
+    async def test_disconnect_sets_stop_event_and_cancels_task(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+        await _connect_publisher(pub, mock_nc)
+
+        task = pub._reconnect_task
+        assert task is not None
+
+        await pub.disconnect()
+
+        assert pub._stop_event.is_set()
+        assert task.done()
+        assert pub._reconnect_task is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect_without_prior_connect_does_not_raise(self) -> None:
+        pub = Publisher()
+        # _reconnect_task is None — disconnect must not raise
+        await pub.disconnect()


### PR DESCRIPTION
## Summary

- `allow_reconnect=False` in `Publisher.connect()` permanently disabled nats-py's built-in reconnection; after any NATS drop the publisher stayed disconnected until Hermes was restarted and `reconnect_count` was always 0 in production.
- Replaced the dead pattern with a `_reconnect_loop` background `asyncio.Task` that polls `nc.is_closed` at `nats_retry_interval`-second intervals using interruptible `asyncio.wait_for(stop_event.wait(), ...)` sleep.
- On connection loss the loop calls `asyncio.wait_for(nats.connect(...), timeout=connect_timeout + 1)` and fires `_on_reconnected()` manually on success (nats-py won't fire it for a fresh `connect()` call), so `reconnect_count` now accumulates correctly.
- Refactored `_on_disconnected` / `_on_reconnected` from nested closures into proper `Publisher` methods so `_reconnect_loop` can call them.
- Loop is started in `connect()` (after the initial connection succeeds) and cancelled/awaited in `disconnect()` for clean shutdown.

## Test plan

- [ ] `pixi run python -m pytest tests/test_publisher_reconnect.py -v` — 15 new tests covering: task created/cancelled, stop event exits loop, no reconnect when open, reconnect on close, `_on_reconnected` fires + `reconnect_count` increments, failed reconnect logs + updates `last_error`, connect timeout via `wait_for`, `disconnect()` cancels task
- [ ] `pixi run python -m pytest tests/test_publisher_callbacks.py -v` — all 7 existing callback tests still pass
- [ ] `pixi run python -m pytest tests/ -m "not integration"` — 342 passed, 0 failed
- [ ] `pixi run just lint` — no errors

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)