### PR TITLE
fix: remove dead agamemnon config fields (YAGNI)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,6 @@ LOG_JSON=false                       # Enable JSON-formatted logs for parsing
 ENABLE_DEAD_LETTER=true             # Store unparseable events to hi.deadletter.>
 
 ## Timeouts
-AGAMEMNON_TIMEOUT=10.0              # HTTP timeout for Agamemnon requests
 SHUTDOWN_TIMEOUT=10.0               # Grace period for shutdown
 
 # TLS configuration (optional; leave blank for plaintext/dev use)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,25 +64,22 @@ Every message published to NATS JetStream includes a `schema_version` integer fi
 
 ## Configuration
 
-| Variable                    | Default                          | Description                                                                   |
-|-----------------------------|----------------------------------|-------------------------------------------------------------------------------|
-| NATS_URL                    | nats://localhost:4222            | NATS server URL                                                               |
-| HERMES_HOST                 | 127.0.0.1                        | Host/IP the server binds to                                                   |
-| HERMES_PORT                 | 8080                             | Port Hermes listens on                                                        |
-| HERMES_PUBLIC_URL           | `http://localhost:{HERMES_PORT}` | Externally-reachable base URL for the /webhook endpoint                       |
-| WEBHOOK_SECRET              |                                  | HMAC secret for webhook validation (minimum 32 characters)                    |
-| MAX_PAYLOAD_BYTES           | 1048576                          | Maximum accepted request body size in bytes (1 MB)                            |
-| NATS_CONNECT_TIMEOUT        | 5.0                              | NATS connection timeout in seconds                                            |
-| NATS_PUBLISH_TIMEOUT        | 5.0                              | NATS publish timeout in seconds                                               |
-| NATS_RECONNECT_INTERVAL     | 5.0                              | Seconds between external reconnect attempts                                   |
-| NATS_RECONNECT_HARD_TIMEOUT | 5.0                              | Per-attempt hard timeout for external reconnect (seconds)                     |
-| AGAMEMNON_URL               |                                  | Base URL of the Agamemnon coordination service                                |
-| AGAMEMNON_API_KEY           |                                  | API key for authenticating with Agamemnon                                     |
-| AGAMEMNON_TIMEOUT           | 10.0                             | Agamemnon API call timeout in seconds                                         |
-| DEAD_LETTER_API_KEY         |                                  | API key for GET/DELETE /dead-letters (min 32 chars; auth bypassed when unset) |
-| SHUTDOWN_TIMEOUT            | 10.0                             | Graceful shutdown timeout in seconds                                          |
-| WEBHOOK_RATE_LIMIT          | 60/minute                        | Rate limit for POST /webhook endpoint                                         |
-| SUBJECTS_RATE_LIMIT         | 60/minute                        | Rate limit for GET /subjects endpoint                                         |
+| Variable              | Default                        | Description                                             |
+|-----------------------|--------------------------------|---------------------------------------------------------|
+| NATS_URL              | nats://localhost:4222          | NATS server URL                                         |
+| HERMES_HOST           | 127.0.0.1                     | Host/IP the server binds to                             |
+| HERMES_PORT           | 8080                           | Port Hermes listens on                                  |
+| HERMES_PUBLIC_URL     | `http://localhost:{HERMES_PORT}` | Externally-reachable base URL for the /webhook endpoint |
+| WEBHOOK_SECRET        |                                | HMAC secret for webhook validation (minimum 32 characters) |
+| MAX_PAYLOAD_BYTES     | 1048576                        | Maximum accepted request body size in bytes (1 MB)      |
+| NATS_CONNECT_TIMEOUT  | 5.0                            | NATS connection timeout in seconds                      |
+| NATS_PUBLISH_TIMEOUT  | 5.0                            | NATS publish timeout in seconds                         |
+| NATS_RECONNECT_INTERVAL | 5.0                          | Seconds between external reconnect attempts             |
+| NATS_RECONNECT_HARD_TIMEOUT | 5.0                      | Per-attempt hard timeout for external reconnect (seconds) |
+| DEAD_LETTER_API_KEY   |                                | API key for GET/DELETE /dead-letters (min 32 chars; auth bypassed when unset) |
+| SHUTDOWN_TIMEOUT      | 10.0                           | Graceful shutdown timeout in seconds                    |
+| WEBHOOK_RATE_LIMIT    | 60/minute                      | Rate limit for POST /webhook endpoint                   |
+| SUBJECTS_RATE_LIMIT   | 60/minute                      | Rate limit for GET /subjects endpoint                   |
 
 Configure external services to POST to `http://<hermes-host>:<HERMES_PORT>/webhook`.
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ cp .env.example .env
 | ACTIVE_SUBJECTS_MAX   | 1000                      | Max distinct NATS subjects to track in memory               |
 | LOG_JSON              | false                     | Enable JSON-formatted logs for structured logging           |
 | ENABLE_DEAD_LETTER    | true                      | Store unparseable events to `hi.deadletter.>` stream        |
-| AGAMEMNON_TIMEOUT     | 10.0                      | HTTP timeout for Agamemnon requests in seconds              |
 | SHUTDOWN_TIMEOUT      | 10.0                      | Grace period for graceful shutdown in seconds               |
 | TLS_CA_BUNDLE         |                           | Path to CA certificate bundle (PEM)                         |
 | TLS_CERT_FILE         |                           | Path to client TLS certificate (PEM) for mTLS               |

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -39,9 +39,6 @@ class Settings(BaseSettings):
     nats_publish_timeout: float = Field(default=5.0, gt=0)
     nats_retry_attempts: int = Field(default=3, ge=1)
     nats_retry_interval: float = Field(default=5.0, gt=0)
-    agamemnon_url: str = ""
-    agamemnon_api_key: str = ""
-    agamemnon_timeout: float = Field(default=10.0, gt=0)
     dead_letter_api_key: str = ""
     shutdown_timeout: float = Field(default=10.0, gt=0)
     max_payload_bytes: int = 1_048_576

--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -52,7 +52,6 @@ class TimeoutSettings(BaseModel):
 
     nats_connect: float
     nats_publish: float
-    agamemnon: float
 
 
 class HealthResponse(BaseModel):

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -299,7 +299,6 @@ async def health(response: Response) -> HealthResponse:
         timeouts=TimeoutSettings(
             nats_connect=cfg.nats_connect_timeout,
             nats_publish=cfg.nats_publish_timeout,
-            agamemnon=cfg.agamemnon_timeout,
         ),
         nats_reconnect_count=publisher.reconnect_count,
         nats_last_error=publisher.last_error,

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -170,4 +170,3 @@ class TestTimeoutValidation:
         monkeypatch.setenv("NATS_PUBLISH_TIMEOUT", "-5")
         with pytest.raises(ValidationError):
             Settings()
-

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -25,11 +25,6 @@ class TestTimeoutSettings:
         s = Settings()
         assert s.nats_publish_timeout == 5.0
 
-    def test_agamemnon_timeout_default(self) -> None:
-        """agamemnon_timeout defaults to 10.0 seconds."""
-        s = Settings()
-        assert s.agamemnon_timeout == 10.0
-
     def test_nats_connect_timeout_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """nats_connect_timeout can be overridden via environment variable."""
         monkeypatch.setenv("NATS_CONNECT_TIMEOUT", "15.0")
@@ -41,12 +36,6 @@ class TestTimeoutSettings:
         monkeypatch.setenv("NATS_PUBLISH_TIMEOUT", "3.0")
         s = Settings()
         assert s.nats_publish_timeout == 3.0
-
-    def test_agamemnon_timeout_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """agamemnon_timeout can be overridden via environment variable."""
-        monkeypatch.setenv("AGAMEMNON_TIMEOUT", "20.0")
-        s = Settings()
-        assert s.agamemnon_timeout == 20.0
 
     def test_nats_retry_attempts_default(self) -> None:
         """nats_retry_attempts defaults to 3."""
@@ -182,12 +171,3 @@ class TestTimeoutValidation:
         with pytest.raises(ValidationError):
             Settings()
 
-    def test_agamemnon_timeout_rejects_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("AGAMEMNON_TIMEOUT", "0")
-        with pytest.raises(ValidationError):
-            Settings()
-
-    def test_agamemnon_timeout_rejects_negative(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("AGAMEMNON_TIMEOUT", "-0.1")
-        with pytest.raises(ValidationError):
-            Settings()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -105,7 +105,6 @@ class TestHealthEndpoint:
         assert "timeouts" in body
         assert body["timeouts"]["nats_connect"] > 0
         assert body["timeouts"]["nats_publish"] > 0
-        assert body["timeouts"]["agamemnon"] > 0
 
     def test_health_includes_dead_letter_count(self) -> None:
         client = _build_client()


### PR DESCRIPTION
## Summary

- Remove `agamemnon_url`, `agamemnon_api_key`, and `agamemnon_timeout` from `Settings` — no code ever reads them to make an Agamemnon API call
- Remove `TimeoutSettings.agamemnon` from `/health` response model — the field surfaced a timeout that guarded no real operation, creating a misleading observability signal
- Clean up all downstream surfaces: test assertions, `.env.example`, `CLAUDE.md`, `README.md`

## Test plan

- [x] Deleted four dead agamemnon timeout tests (`test_agamemnon_timeout_default`, `test_agamemnon_timeout_from_env`, `test_agamemnon_timeout_rejects_zero`, `test_agamemnon_timeout_rejects_negative`)
- [x] Removed `agamemnon` assertion from `test_health_includes_timeout_fields`
- [x] All 362 tests pass (`pixi run python -m pytest tests/ -v`)
- [x] Lint clean (`just lint`)
- [x] `grep -r "agamemnon" src/ tests/ .env.example CLAUDE.md README.md` → zero matches

Closes #324
Part of #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)