### PR TITLE
refactor(config): remove module-level settings singleton, standardize DI

### DIFF
--- a/.github/ISSUE_TEMPLATE/tech_debt.md
+++ b/.github/ISSUE_TEMPLATE/tech_debt.md
@@ -5,9 +5,11 @@ labels: [tech-debt, chore]
 ---
 
 ## Objective
+
 <!-- What needs to be improved and why. -->
 
 ## Context
+
 <!-- File path(s) and line number(s) where the debt lives, if applicable. -->
 
 ## Deliverables
@@ -16,7 +18,9 @@ labels: [tech-debt, chore]
 - [ ] <!-- specific sub-task 2 -->
 
 ## Success Criteria
+
 <!-- How will we know this is resolved? -->
 
 ## Parent Issue
+
 <!-- Link to the Epic tracking issue, e.g. #NNN -->

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -191,7 +191,3 @@ class Settings(BaseSettings):
 def get_settings() -> Settings:
     """Return the cached Settings instance."""
     return Settings()
-
-
-# Module-level singleton — allows tests to mutate settings in-place.
-settings: Settings = get_settings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,10 +47,14 @@ def pytest_configure(config: pytest.Config) -> None:
 
 @pytest.fixture(autouse=True)
 def reset_settings() -> Generator[None, None, None]:
-    """Clear the get_settings LRU cache before each test so mutations don't leak."""
+    """Clear the get_settings LRU cache and dependency overrides before/after each test."""
+    from hermes.server import app
+
     get_settings.cache_clear()
+    app.dependency_overrides.clear()
     yield
     get_settings.cache_clear()
+    app.dependency_overrides.clear()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_request_id_context.py
+++ b/tests/test_request_id_context.py
@@ -21,7 +21,7 @@ def _sign(body: bytes) -> str:
 
 
 def _build_client(*, connected: bool = True) -> TestClient:
-    from hermes.config import get_settings
+    from hermes.config import Settings, get_settings
     from hermes.publisher import Publisher
     from hermes.server import app
 
@@ -32,7 +32,7 @@ def _build_client(*, connected: bool = True) -> TestClient:
     mock_publisher.publish = AsyncMock()
 
     app.state.publisher = mock_publisher
-    get_settings().webhook_secret = _TEST_SECRET
+    app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret=_TEST_SECRET)
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -105,7 +105,7 @@ class TestRequestIdInLogContext:
         """A 503 from publish timeout should emit a log record with request_id in extra."""
         import asyncio
 
-        from hermes.config import get_settings
+        from hermes.config import Settings, get_settings
         from hermes.publisher import Publisher
         from hermes.server import app
 
@@ -114,7 +114,7 @@ class TestRequestIdInLogContext:
         mock_publisher.active_subjects = []
         mock_publisher.publish = AsyncMock(side_effect=asyncio.TimeoutError())
         app.state.publisher = mock_publisher
-        get_settings().webhook_secret = _TEST_SECRET
+        app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret=_TEST_SECRET)
 
         client = TestClient(app, raise_server_exceptions=False)
         payload = {
@@ -222,7 +222,7 @@ class TestRequestIdInErrorResponses:
         """Publish timeout 503 response body must include request_id."""
         import asyncio
 
-        from hermes.config import get_settings
+        from hermes.config import Settings, get_settings
         from hermes.publisher import Publisher
         from hermes.server import app
 
@@ -231,7 +231,7 @@ class TestRequestIdInErrorResponses:
         mock_publisher.active_subjects = []
         mock_publisher.publish = AsyncMock(side_effect=asyncio.TimeoutError())
         app.state.publisher = mock_publisher
-        get_settings().webhook_secret = _TEST_SECRET
+        app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret=_TEST_SECRET)
 
         client = TestClient(app, raise_server_exceptions=False)
         payload = {

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -145,11 +145,12 @@ class TestShutdownMiddleware:
 
     def test_webhook_accepted_when_not_shutting_down(self) -> None:
         import hermes.server as srv
-        from hermes.config import get_settings
+        from hermes.config import Settings, get_settings
+        from hermes.server import app
 
         srv._shutdown_event = asyncio.Event()
         # Disable HMAC validation so the test works regardless of .env contents
-        get_settings().webhook_secret = ""
+        app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret="")
         client = _build_client()
         response = client.post(
             "/webhook",

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -27,7 +27,7 @@ def _build_client(
     last_error: str = "",
 ) -> TestClient:
     """Build a TestClient with a mocked Publisher and a known webhook secret."""
-    from hermes.config import get_settings
+    from hermes.config import Settings, get_settings
     from hermes.publisher import Publisher
     from hermes.rate_limit import limiter
     from hermes.server import app
@@ -43,8 +43,9 @@ def _build_client(
 
     # Inject the mock before the test client starts
     app.state.publisher = mock_publisher
-    # Set a known secret on the live cached Settings instance
-    get_settings().webhook_secret = _TEST_SECRET
+    # Override settings via FastAPI dependency injection
+    test_settings = Settings(webhook_secret=_TEST_SECRET)
+    app.dependency_overrides[get_settings] = lambda: test_settings
     # Reset rate limiter so each test starts with a clean slate
     limiter._storage.reset()  # type: ignore[attr-defined]
     return TestClient(app, raise_server_exceptions=True)
@@ -325,9 +326,9 @@ class TestWebhookEndpoint:
         mock_publisher.publish = AsyncMock(side_effect=asyncio.TimeoutError())
         app.state.publisher = mock_publisher
 
-        from hermes.config import get_settings
+        from hermes.config import Settings, get_settings
 
-        get_settings().webhook_secret = _TEST_SECRET
+        app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret=_TEST_SECRET)
 
         client = TestClient(app, raise_server_exceptions=False)
         payload = {
@@ -1123,7 +1124,7 @@ class TestUnknownEventType:
     """Tests for #125: unknown event types return 422 when dead-lettering is disabled."""
 
     def _build_client_with_unknown_event(self, event: str) -> TestClient:
-        from hermes.config import get_settings
+        from hermes.config import Settings, get_settings
         from hermes.publisher import UnknownEventTypeError, Publisher
         from hermes.rate_limit import limiter
         from hermes.server import app
@@ -1134,10 +1135,7 @@ class TestUnknownEventType:
         mock_publisher.publish = AsyncMock(side_effect=UnknownEventTypeError(event))
 
         app.state.publisher = mock_publisher
-        # Disable HMAC signature validation by clearing the cached Settings secret.
-        # The /webhook handler uses Depends(get_settings), which returns the
-        # lru_cache'd singleton; mutating it here propagates into the request.
-        get_settings().webhook_secret = ""
+        app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret="")
         limiter._storage.reset()  # type: ignore[attr-defined]
         return TestClient(app, raise_server_exceptions=True)
 


### PR DESCRIPTION
## Summary

- Deleted the `settings: Settings = get_settings()` module-level singleton from `src/hermes/config.py` — the root cause of the dual access pattern described in #325
- Replaced all `get_settings().webhook_secret = ...` mutations in tests with idiomatic `app.dependency_overrides[get_settings] = lambda: Settings(...)` — eliminating test-order dependencies
- Extended the `reset_settings` autouse fixture in `conftest.py` to clear `app.dependency_overrides` before and after each test, preventing override leakage

## Test plan

- [x] All 327 existing tests pass (`pixi run python -m pytest tests/ -v` — 327 passed, 0 failed)
- [x] No remaining references to `from hermes.config import settings` or `get_settings().webhook_secret =`
- [x] `app.dependency_overrides` cleared between tests via autouse fixture

Closes #325
Part of #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)