### PR TITLE
fix(publisher): remove type: ignore[misc] from raise last_exc

### DIFF
--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -248,7 +248,7 @@ class Publisher:
                     )
                     await asyncio.sleep(delay)
 
-        raise last_exc  # type: ignore[misc]
+        raise last_exc or RuntimeError("unreachable")
 
     def _track_subject(self, subject: str) -> None:
         """Add subject to the LRU OrderedDict, evicting the oldest if at capacity."""


### PR DESCRIPTION
## Summary

- Replaces `raise last_exc  # type: ignore[misc]` with `raise last_exc or RuntimeError("unreachable")` in the publish retry loop
- Eliminates the mypy suppression comment by making the non-None invariant explicit in code
- The `RuntimeError("unreachable")` branch is logically unreachable since `publish_retries` has `ge=1`, ensuring the loop always executes at least once and assigns `last_exc`

## Test plan

- [x] `just lint` passes (ruff — no new violations)
- [x] `pixi run python -m pytest tests/ -v` — all 366 tests pass
- [x] No new tests required: this is a type-safety fix, not a logic change; the unreachable branch cannot be triggered in any correctly configured execution

Closes #326
Part of #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)