### PR TITLE
fix(__main__): replace logging.basicConfig with setup_logging()

### DIFF
--- a/src/hermes/__main__.py
+++ b/src/hermes/__main__.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 
 import argparse
 import logging
-import sys
+
+from hermes.config import get_settings
+from hermes.logging_config import setup_logging
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments, falling back to environment-variable defaults."""
-    from hermes.config import get_settings
-
     settings = get_settings()
 
     parser = argparse.ArgumentParser(
@@ -48,12 +48,8 @@ def main(argv: list[str] | None = None) -> None:
     import uvicorn
 
     args = _parse_args(argv)
-
-    logging.basicConfig(
-        level=args.log_level.upper(),
-        stream=sys.stdout,
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    settings = get_settings()
+    setup_logging(level=getattr(logging, args.log_level.upper()), json_format=settings.log_json)
 
     uvicorn.run(
         "hermes.server:app",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -97,3 +98,44 @@ class TestMain:
 
         _, kwargs = mock_uvicorn.run.call_args
         assert kwargs.get("reload") is False
+
+    def test_main_calls_setup_logging(self) -> None:
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}), patch(
+            "hermes.__main__.setup_logging"
+        ) as mock_setup:
+            main([])
+
+        mock_setup.assert_called_once_with(level=logging.INFO, json_format=False)
+
+    def test_main_log_json_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LOG_JSON", "true")
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}), patch(
+            "hermes.__main__.setup_logging"
+        ) as mock_setup, patch("hermes.__main__.get_settings") as mock_get_settings:
+            mock_settings = MagicMock()
+            mock_settings.log_json = True
+            mock_settings.hermes_port = 8080
+            mock_get_settings.return_value = mock_settings
+            main([])
+
+        mock_setup.assert_called_once_with(level=logging.INFO, json_format=True)
+
+    def test_main_log_level_forwarded(self) -> None:
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}), patch(
+            "hermes.__main__.setup_logging"
+        ) as mock_setup:
+            main(["--log-level", "debug"])
+
+        mock_setup.assert_called_once_with(level=logging.DEBUG, json_format=False)
+
+    def test_main_basicconfig_not_called(self) -> None:
+        mock_uvicorn = MagicMock()
+        with patch.dict("sys.modules", {"uvicorn": mock_uvicorn}), patch(
+            "hermes.__main__.setup_logging"
+        ), patch("logging.basicConfig") as mock_basicconfig:
+            main([])
+
+        mock_basicconfig.assert_not_called()


### PR DESCRIPTION
## Summary

- Replaces `logging.basicConfig()` in `src/hermes/__main__.py` with `setup_logging()` from `logging_config.py`
- Moves `get_settings`, `setup_logging`, and `logging` imports to module level (enabling proper test patching)
- Removes duplicate `from hermes.config import get_settings` that was inside `_parse_args`

## Test plan

- [x] `test_main_calls_setup_logging` — verifies `setup_logging` is called with `json_format=False` by default
- [x] `test_main_log_json_env_var` — verifies `LOG_JSON=true` is forwarded as `json_format=True`
- [x] `test_main_log_level_forwarded` — verifies `--log-level debug` maps to `logging.DEBUG`
- [x] `test_main_basicconfig_not_called` — verifies `logging.basicConfig` is never called
- [x] All 20 `test_main.py` tests pass; no regressions in full suite

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)