### PR TITLE
refactor(tests): deduplicate _sign() helper into tests/helpers.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 packages = ["src/hermes"]
 
 [tool.pytest.ini_options]
-pythonpath = ["src"]
+pythonpath = ["src", "tests"]
 asyncio_mode = "auto"
 addopts = [
     "--cov=hermes",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,11 @@
+"""Shared test helpers for ProjectHermes tests."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as hmac_mod
+
+
+def sign_body(secret: str, body: bytes) -> str:
+    """Return the HMAC-SHA256 hex digest of *body* signed with *secret*."""
+    return hmac_mod.new(secret.encode(), body, hashlib.sha256).hexdigest()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,8 +8,6 @@ cannot be reached at TEST_NATS_URL (default nats://localhost:4222).
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import hmac as hmac_mod
 import json
 import logging
 import os
@@ -22,6 +20,8 @@ from httpx import ASGITransport, AsyncClient
 from hermes.models import WebhookPayload
 from hermes.publisher import Publisher
 
+from helpers import sign_body
+
 _FIXED_TS = datetime(2026, 4, 22, tzinfo=timezone.utc)
 
 pytestmark = pytest.mark.integration
@@ -31,7 +31,7 @@ _TEST_SECRET = "integration-test-secret-for-hermes-webhook"
 
 
 def _sign(body: bytes) -> str:
-    return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return sign_body(_TEST_SECRET, body)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-import hashlib
-import hmac as hmac_mod
 import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 
+from helpers import sign_body
+
 _TEST_SECRET = "test-webhook-secret-padding-xxxxx"
 
 
 def _sign(body: bytes) -> str:
-    return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return sign_body(_TEST_SECRET, body)
 
 
 def _build_client(dead_letters: list | None = None) -> TestClient:

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import hmac as hmac_mod
 import json
 import os
 from collections.abc import Generator
@@ -12,6 +10,8 @@ from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock
 
 from fastapi.testclient import TestClient
+
+from helpers import sign_body
 
 _TEST_SECRET = "test-webhook-secret-padding-xxxxx"
 _VALID_PAYLOAD = {
@@ -22,7 +22,7 @@ _VALID_PAYLOAD = {
 
 
 def _sign(body: bytes) -> str:
-    return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return sign_body(_TEST_SECRET, body)
 
 
 @contextmanager

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import hmac as hmac_mod
 import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
+
+from helpers import sign_body
 
 # Fixed secret used across all webhook tests
 _TEST_SECRET = "test-webhook-secret-padding-xxxxx"
@@ -17,7 +17,7 @@ _TEST_SECRET = "test-webhook-secret-padding-xxxxx"
 
 def _sign(body: bytes) -> str:
     """Compute HMAC-SHA256 hex digest for the given body using _TEST_SECRET."""
-    return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return sign_body(_TEST_SECRET, body)
 
 
 def _build_client(


### PR DESCRIPTION
## Summary

- Extract the identical `_sign(body)` HMAC-SHA256 helper copy-pasted across `test_webhook.py`, `test_integration.py`, `test_rate_limit.py`, and `test_metrics.py` into a single `sign_body(secret, body)` function in `tests/helpers.py`
- Each test module keeps its own `_sign()` one-liner that delegates to `sign_body()` with its local `_TEST_SECRET`, preserving the existing call sites unchanged
- Add `"tests"` to `pythonpath` in `pyproject.toml` so pytest can resolve the new shared module

## Test plan

- [x] All 327 non-integration tests pass (`pixi run python -m pytest tests/ --ignore=tests/test_integration.py`)
- [x] No existing call sites changed — `_sign(body_bytes)` usage is identical across all files

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)