### PR TITLE
refactor(tests): consolidate _sign() helper into tests/helpers.py

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,13 @@
+"""Shared test utilities for ProjectHermes tests."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as hmac_mod
+
+TEST_SECRET = "test-webhook-secret-padding-xxxxx"
+
+
+def sign_body(body: bytes, secret: str) -> str:
+    """Return the HMAC-SHA256 hex digest of *body* signed with *secret*."""
+    return hmac_mod.new(secret.encode(), body, hashlib.sha256).hexdigest()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,8 +8,6 @@ cannot be reached at TEST_NATS_URL (default nats://localhost:4222).
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import hmac as hmac_mod
 import json
 import logging
 import os
@@ -22,6 +20,8 @@ from httpx import ASGITransport, AsyncClient
 from hermes.models import WebhookPayload
 from hermes.publisher import Publisher
 
+from tests.helpers import sign_body
+
 _FIXED_TS = datetime(2026, 4, 22, tzinfo=timezone.utc)
 
 pytestmark = pytest.mark.integration
@@ -31,7 +31,7 @@ _TEST_SECRET = "integration-test-secret-for-hermes-webhook"
 
 
 def _sign(body: bytes) -> str:
-    return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return sign_body(body, _TEST_SECRET)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-import hashlib
-import hmac as hmac_mod
 import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 
-_TEST_SECRET = "test-webhook-secret-padding-xxxxx"
+from tests.helpers import TEST_SECRET, sign_body
+
+_TEST_SECRET = TEST_SECRET
 
 
 def _sign(body: bytes) -> str:
-    return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return sign_body(body, _TEST_SECRET)
 
 
 def _build_client(dead_letters: list | None = None) -> TestClient:

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import hmac as hmac_mod
 import json
 import os
 from collections.abc import Generator
@@ -13,7 +11,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 from fastapi.testclient import TestClient
 
-_TEST_SECRET = "test-webhook-secret-padding-xxxxx"
+from tests.helpers import TEST_SECRET, sign_body
+
+_TEST_SECRET = TEST_SECRET
 _VALID_PAYLOAD = {
     "event": "agent.created",
     "data": {"host": "localhost", "name": "bot"},
@@ -22,7 +22,7 @@ _VALID_PAYLOAD = {
 
 
 def _sign(body: bytes) -> str:
-    return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return sign_body(body, _TEST_SECRET)
 
 
 @contextmanager

--- a/tests/test_request_id_context.py
+++ b/tests/test_request_id_context.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import hashlib
-import hmac as hmac_mod
 import json
 import logging
 import uuid
@@ -13,11 +11,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
-_TEST_SECRET = "test-webhook-secret-padding-xxxxx"
+from tests.helpers import TEST_SECRET, sign_body
+
+_TEST_SECRET = TEST_SECRET
 
 
 def _sign(body: bytes) -> str:
-    return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return sign_body(body, _TEST_SECRET)
 
 
 def _build_client(*, connected: bool = True) -> TestClient:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -3,21 +3,19 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import hmac as hmac_mod
 import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 
-# Fixed secret used across all webhook tests
-_TEST_SECRET = "test-webhook-secret-padding-xxxxx"
+from tests.helpers import TEST_SECRET, sign_body
+
+_TEST_SECRET = TEST_SECRET
 
 
 def _sign(body: bytes) -> str:
-    """Compute HMAC-SHA256 hex digest for the given body using _TEST_SECRET."""
-    return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return sign_body(body, _TEST_SECRET)
 
 
 def _build_client(


### PR DESCRIPTION
## Summary

- Extracts the duplicated `_sign(body: bytes) -> str` HMAC-SHA256 helper from five test files into `tests/helpers.py` as `sign_body(body: bytes, secret: str) -> str` alongside the shared `TEST_SECRET` constant
- Each test file now imports `sign_body` (and `TEST_SECRET` where applicable) from `tests.helpers` and delegates its local `_sign()` wrapper to it — removing the copy-pasted implementation in every file
- `test_integration.py` keeps its own `_TEST_SECRET` (a different secret for integration tests) and passes it explicitly to `sign_body`

## Test plan

- [x] All 327 existing tests pass (`pixi run python -m pytest tests/ --ignore=tests/test_integration.py -v`)
- [x] `pixi run just lint` passes with no errors
- [x] No new tests were needed — this is a pure refactor with no behaviour change

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)