### PR TITLE
fix(tests): replace deprecated event loop API with asyncio.run()

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -58,7 +58,7 @@ def require_nats() -> None:  # type: ignore[return]
         except Exception:
             return False
 
-    reachable = _asyncio.get_event_loop_policy().new_event_loop().run_until_complete(_check())
+    reachable = _asyncio.run(_check())
     if not reachable:
         pytest.skip("NATS server not available at " + _NATS_URL, allow_module_level=True)
 


### PR DESCRIPTION
## Summary

- Replaces `asyncio.get_event_loop_policy().new_event_loop().run_until_complete(_check())` with `asyncio.run(_check())` in the `require_nats` fixture in `tests/test_integration.py:61`
- The old form is deprecated since Python 3.10 and emits `DeprecationWarning` on Python 3.12+

## Test plan

- [x] All 46 existing tests pass with `pixi run python -m pytest tests/ -v`
- [x] No new tests required — this is a one-line fix to test infrastructure

Closes #331
Part of #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)