### PR TITLE
ci(coverage): add per-module minimums and XML trend tracking

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -149,14 +149,29 @@ jobs:
           cache: true
 
       - name: Unit tests (no NATS required)
-        run: pixi run pytest -m "not integration" --cov-fail-under=80
+        run: pixi run pytest -m "not integration"
+
+      - name: Per-module coverage minimums
+        run: |
+          pixi run coverage report --include="src/hermes/__init__.py" --fail-under=70
+          pixi run coverage report --include="src/hermes/__main__.py" --fail-under=95
+          pixi run coverage report --include="src/hermes/config.py" --fail-under=90
+          pixi run coverage report --include="src/hermes/logging_config.py" --fail-under=90
+          pixi run coverage report --include="src/hermes/metrics.py" --fail-under=95
+          pixi run coverage report --include="src/hermes/middleware.py" --fail-under=80
+          pixi run coverage report --include="src/hermes/models.py" --fail-under=90
+          pixi run coverage report --include="src/hermes/publisher.py" --fail-under=90
+          pixi run coverage report --include="src/hermes/rate_limit.py" --fail-under=95
+          pixi run coverage report --include="src/hermes/server.py" --fail-under=90
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage-html
-          path: htmlcov/
+          path: |
+            htmlcov/
+            coverage.xml
 
   integration-tests:
     name: integration-tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ addopts = [
     "--cov=hermes",
     "--cov-report=term-missing",
     "--cov-report=html",
+    "--cov-report=xml",
 ]
 markers = [
     "integration: requires a running NATS server",
@@ -37,6 +38,8 @@ markers = [
 source = ["hermes"]
 
 [tool.coverage.report]
+fail_under = 80
+precision = 2
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",
@@ -44,6 +47,7 @@ exclude_lines = [
     "if __name__ == .__main__.:",
     "class .*\\bProtocol\\):",
     "@(abc\\.)?abstractmethod",
+    "def __repr__",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
## Summary

- Moves `fail_under = 80` into `[tool.coverage.report]` in `pyproject.toml` as the **single source of truth**, removing the duplicate `--cov-fail-under=80` from the CI pytest invocation to eliminate local/CI drift
- Adds `--cov-report=xml` to `pytest addopts` so `coverage.xml` is always produced locally and in CI, enabling future Codecov/Coveralls integration
- Adds a **Per-module coverage minimums** CI step that enforces individual floors for each `hermes` module (set ~5–10% below current baseline to give headroom while catching regressions)
- Uploads `coverage.xml` alongside `htmlcov/` in the CI artifact for trend visibility
- Adds `precision = 2` and `def __repr__` exclusion to `[tool.coverage.report]`

**Per-module floors vs. actual coverage:**

| Module | Actual | Floor |
|---|---|---|
| `__init__.py` | 75% | 70% |
| `__main__.py` | 100% | 95% |
| `config.py` | 96% | 90% |
| `logging_config.py` | 97% | 90% |
| `metrics.py` | 100% | 95% |
| `middleware.py` | 85% | 80% |
| `models.py` | 95% | 90% |
| `publisher.py` | 98% | 90% |
| `rate_limit.py` | 100% | 95% |
| `server.py` | 99% | 90% |

## Test plan

- [x] All 327 unit tests pass locally (`pixi run pytest -m "not integration"`)
- [x] Overall coverage 96.84% — passes 80% global threshold enforced via `pyproject.toml`
- [x] All 10 per-module `coverage report --fail-under` commands exit 0 locally
- [x] `coverage.xml` generated at repo root after test run

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)