### PR TITLE
test(publisher): rename misleading TLS test to reflect actual assertion

### DIFF
--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -623,8 +623,8 @@ class TestTLSPublisherConnect:
         assert pub.is_connected is True
 
     @pytest.mark.asyncio
-    async def test_connect_passes_ssl_context_from_settings(self) -> None:
-        """Publisher.connect() passes the SSL context from Settings to nats.connect()."""
+    async def test_connect_omits_tls_kwarg_when_ssl_not_configured(self) -> None:
+        """Publisher.connect() omits the tls kwarg when no TLS settings are configured."""
         pub = Publisher()
         mock_nc = MagicMock()
         mock_nc.jetstream.return_value = MagicMock()


### PR DESCRIPTION
## Summary

- Renames `test_connect_passes_ssl_context_from_settings` → `test_connect_omits_tls_kwarg_when_ssl_not_configured`
- Updates the docstring to match: _"Publisher.connect() omits the tls kwarg when no TLS settings are configured."_
- No logic changes — the assertion itself was correct; only the name and docstring were misleading

Fixes the POLA violation flagged in #333: the test name implied it verified an SSL context _is_ passed, but it actually verified the `tls` kwarg is **absent** when no TLS is configured.

## Test plan

- [x] Renamed test passes: `pytest tests/test_publisher.py -v -k "ssl or tls"` — 2 passed
- [x] Full publisher suite: `pytest tests/test_publisher.py -v` — all pass
- [x] Linter clean: `just lint` — no violations

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)