### PR TITLE
fix(ci): make gitleaks secret scan fail the pipeline on findings

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -209,12 +209,11 @@ jobs:
         run: |
           if [ -f .gitleaks.toml ]; then
             gitleaks detect --source . --config .gitleaks.toml \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 0
+              --report-format sarif --report-path gitleaks.sarif --exit-code 1
           else
             gitleaks detect --source . \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 0
+              --report-format sarif --report-path gitleaks.sarif --exit-code 1
           fi
-        continue-on-error: true
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''


### PR DESCRIPTION
## Summary

- Change `--exit-code 0` → `--exit-code 1` in both branches of the `Run Gitleaks` step so any detected secret causes gitleaks to exit non-zero and fail CI.
- Remove `continue-on-error: true` from the same step — it was redundant with the hardcoded zero exit code and was actively hiding failures.
- The `Upload Gitleaks SARIF` step already uses `if: always()`, so SARIF reports continue to be uploaded even when the scan step fails.

No new files created; this is a two-line fix.

## Test plan

- [ ] Merge this PR and confirm the Gitleaks job passes on a clean branch (no secrets).
- [ ] Optionally: open a test branch with a dummy secret string matching a gitleaks rule and confirm the job now fails before reverting.

Closes #335
Part of #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)