### PR TITLE
ci(publish): restrict publish.yml to tag-only triggers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,17 +2,23 @@ name: Publish
 
 on:
   push:
-    branches: [main]
-    tags: [v*.*.*]
+    tags: ['v*.*.*']
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   publish:
     name: Publish Docker Image
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      packages: write
 
     steps:
       - name: Checkout
@@ -34,11 +40,8 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix={{branch}}-
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,10 @@ Configure external services to POST to `http://<hermes-host>:<HERMES_PORT>/webho
    hyphens, dots become hyphens, and wildcards (`*` and `>`) are stripped entirely. Tokens are
    lowercased and subject strings are typically capped at 64 characters.
 
+## CI/CD
+
+Docker images are published to GHCR (`ghcr.io/<org>/projecthermes`) **only on version tags** matching `v*.*.*` and via manual `workflow_dispatch`. Merges to `main` do **not** trigger a publish. To release a new image, push a semver tag (e.g. `git tag v1.2.3 && git push origin v1.2.3`).
+
 ## Common Commands
 
 ```bash


### PR DESCRIPTION
## Summary

- Remove `push: branches: [main]` so Docker images are only published on `v*.*.*` version tags and manual `workflow_dispatch`, not on every merge to main
- Scope `packages: write` permission to job level only (minimal blast radius)
- Add `concurrency` group to cancel redundant concurrent runs on rapid tag pushes
- Add `timeout-minutes: 20` to cap zombie runs
- Remove branch-only `docker/metadata-action` tag types (`type=ref,event=branch`, `type=sha,prefix={{branch}}-`, `type=raw,value=latest,enable={{is_default_branch}}`)
- Document tag-only publish policy in `CLAUDE.md`

## Test plan

- [ ] Confirm workflow syntax is valid (`gh workflow view publish.yml`)
- [ ] Verify a branch push to main does **not** trigger the publish workflow
- [ ] Verify pushing a `v*.*.*` tag triggers the publish job
- [ ] Verify `gh workflow run publish.yml` (manual dispatch) works
- [ ] After a tag push, confirm the versioned image appears in GHCR with no `:latest` or `:<sha>` variants

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)