### PR TITLE
ci: pin pixi-version to v0.67.2 in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: latest
+          pixi-version: v0.67.2
           cache: true
 
       - name: Check version consistency
@@ -74,7 +74,7 @@ jobs:
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: latest
+          pixi-version: v0.67.2
           cache: true
 
       - name: Start NATS with JetStream


### PR DESCRIPTION
## Summary

- Both `setup-pixi` steps in `ci.yml` used `pixi-version: latest`, which is non-deterministic.
- `_required.yml` already pins to `v0.67.2`; this PR aligns `ci.yml` to the same pinned version.
- No logic changes — CI behaviour is identical, builds are now reproducible.

## Test plan

- [ ] CI passes on this PR (the only change is pinning a version string)

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)