### PR TITLE
fix(config): warn loudly when WEBHOOK_SECRET unset on production binding

### DIFF
--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -127,6 +127,24 @@ class Settings(BaseSettings):
     tls_verify: bool = True
 
     @model_validator(mode="after")
+    def _warn_hmac_disabled_in_production(self) -> "Settings":
+        """Emit a loud WARNING when WEBHOOK_SECRET is unset while bound to all interfaces.
+
+        Production is inferred when ``hermes_host`` is ``0.0.0.0`` (listening on all interfaces).
+        Without a secret, any source can POST to /webhook without authentication.
+        """
+        if not self.webhook_secret and self.hermes_host == "0.0.0.0":
+            _config_logger.warning(
+                "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
+                "  WEBHOOK_SECRET is NOT SET while HERMES_HOST=0.0.0.0 (PRODUCTION)\n"
+                "  HMAC webhook signature validation is DISABLED — any source can\n"
+                "  POST to /webhook without authentication.  Set WEBHOOK_SECRET to\n"
+                "  a random string of at least 32 characters to enable validation.\n"
+                "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+            )
+        return self
+
+    @model_validator(mode="after")
     def _warn_tls_verify_disabled(self) -> "Settings":
         """Emit a loud WARNING when TLS verification is disabled in a production-like environment.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -244,3 +244,52 @@ class TestSubjectsRateLimit:
 
         with pytest.raises(ValidationError):
             Settings()
+
+
+class TestWebhookSecretProductionWarning:
+    """WEBHOOK_SECRET unset + HERMES_HOST=0.0.0.0 must emit a loud warning."""
+
+    def test_no_warning_when_secret_set_and_host_0000(self) -> None:
+        from unittest.mock import patch
+
+        import hermes.config as cfg
+        from hermes.config import Settings
+
+        with patch.object(cfg._config_logger, "warning") as mock_warn:
+            Settings(
+                webhook_secret="a" * 32,
+                hermes_host="0.0.0.0",
+                _env_file=None,
+            )
+        for call in mock_warn.call_args_list:
+            assert "WEBHOOK_SECRET is NOT SET" not in (call.args[0] if call.args else "")
+
+    def test_no_warning_when_secret_empty_and_host_localhost(self) -> None:
+        from unittest.mock import patch
+
+        import hermes.config as cfg
+        from hermes.config import Settings
+
+        with patch.object(cfg._config_logger, "warning") as mock_warn:
+            Settings(
+                webhook_secret="",
+                hermes_host="127.0.0.1",
+                _env_file=None,
+            )
+        for call in mock_warn.call_args_list:
+            assert "WEBHOOK_SECRET is NOT SET" not in (call.args[0] if call.args else "")
+
+    def test_loud_warning_when_secret_empty_and_host_0000(self) -> None:
+        from unittest.mock import patch
+
+        import hermes.config as cfg
+        from hermes.config import Settings
+
+        with patch.object(cfg._config_logger, "warning") as mock_warn:
+            Settings(
+                webhook_secret="",
+                hermes_host="0.0.0.0",
+                _env_file=None,
+            )
+        warning_messages = [call.args[0] for call in mock_warn.call_args_list if call.args]
+        assert any("WEBHOOK_SECRET is NOT SET" in msg for msg in warning_messages)


### PR DESCRIPTION
## Summary

- Adds `_warn_hmac_disabled_in_production` model validator to `Settings` that emits a loud multi-line exclamation-banner `WARNING` when `webhook_secret` is empty and `hermes_host == "0.0.0.0"`
- Mirrors the existing `_warn_tls_verify_disabled` pattern exactly — same banner style, same production-inference heuristic
- Does **not** fail hard (HMAC is intentionally optional); makes the insecure default impossible to miss in operator logs
- Existing `lifespan()` warning in `server.py` is preserved (covers the `127.0.0.1` + no-secret dev case)

## Test plan

- [x] `test_no_warning_when_secret_set_and_host_0000` — secret present + production host → no HMAC warning
- [x] `test_no_warning_when_secret_empty_and_host_localhost` — empty secret + localhost → no HMAC warning
- [x] `test_loud_warning_when_secret_empty_and_host_0000` — empty secret + `0.0.0.0` → warning contains `WEBHOOK_SECRET is NOT SET`
- [x] Full suite: 369 passed, 0 failures
- [x] `ruff check src tests`: All checks passed

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)