### PR TITLE
fix(publisher): add external NATS reconnect loop (#346)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,8 @@ Every message published to NATS JetStream includes a `schema_version` integer fi
 | MAX_PAYLOAD_BYTES     | 1048576                        | Maximum accepted request body size in bytes (1 MB)      |
 | NATS_CONNECT_TIMEOUT  | 5.0                            | NATS connection timeout in seconds                      |
 | NATS_PUBLISH_TIMEOUT  | 5.0                            | NATS publish timeout in seconds                         |
+| NATS_RECONNECT_INTERVAL | 5.0                          | Seconds between external reconnect attempts             |
+| NATS_RECONNECT_HARD_TIMEOUT | 5.0                      | Per-attempt hard timeout for external reconnect (seconds) |
 | AGAMEMNON_URL         |                                | Base URL of the Agamemnon coordination service          |
 | AGAMEMNON_API_KEY     |                                | API key for authenticating with Agamemnon               |
 | AGAMEMNON_TIMEOUT     | 10.0                           | Agamemnon API call timeout in seconds                   |

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -51,6 +51,8 @@ class Settings(BaseSettings):
     webhook_rate_limit_key: str = "ip"
     publish_retries: int = Field(default=3, ge=1)
     publish_retry_base_delay: float = Field(default=0.1, gt=0)
+    nats_reconnect_interval: float = Field(default=5.0, gt=0)
+    nats_reconnect_hard_timeout: float = Field(default=5.0, gt=0)
 
     @field_validator("hermes_public_url", mode="before")
     @classmethod

--- a/src/hermes/metrics.py
+++ b/src/hermes/metrics.py
@@ -39,3 +39,9 @@ ACTIVE_SUBJECTS: Gauge = Gauge(
     "hermes_active_subjects_count",
     "Number of distinct NATS subjects that have been published to",
 )
+
+NATS_RECONNECTS: Counter = Counter(
+    "hermes_nats_reconnects_total",
+    "Total number of external NATS reconnect attempts",
+    ["result"],
+)

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -18,6 +18,7 @@ from nats.js import JetStreamContext
 from hermes.metrics import (
     ACTIVE_SUBJECTS,
     DEAD_LETTERS,
+    NATS_RECONNECTS,
     PUBLISH_LATENCY,
     WEBHOOKS_PUBLISHED,
 )
@@ -70,13 +71,32 @@ class Publisher:
         self._connected: bool = False
         self.reconnect_count: int = 0
         self.last_error: str = ""
+        self._stop_event: asyncio.Event = asyncio.Event()
+        self._reconnect_task: asyncio.Task[None] | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
     async def connect(self, url: str, connect_timeout: float = 5.0) -> None:
-        """Connect to the NATS server, obtain JetStream context, and ensure streams exist."""
+        """Connect to NATS, ensure streams exist, and start the background reconnect loop."""
+        from hermes.config import get_settings
+
+        settings = get_settings()
+        await self._connect_internal(url, connect_timeout)
+        logger.info("Connected to NATS at %s", url)
+        self._stop_event = asyncio.Event()
+        self._reconnect_task = asyncio.ensure_future(
+            self._reconnect_loop(
+                url,
+                connect_timeout,
+                settings.nats_reconnect_interval,
+                settings.nats_reconnect_hard_timeout,
+            )
+        )
+
+    async def _connect_internal(self, url: str, connect_timeout: float) -> None:
+        """Low-level connect: open the NATS socket, register callbacks, get JetStream context."""
 
         async def _on_disconnected() -> None:
             self._connected = False
@@ -98,7 +118,37 @@ class Publisher:
         self._connected = True
         self._js = self._nc.jetstream()
         await self._ensure_streams()
-        logger.info("Connected to NATS at %s", url)
+
+    async def _reconnect_loop(
+        self,
+        url: str,
+        connect_timeout: float,
+        reconnect_interval: float,
+        hard_timeout: float,
+    ) -> None:
+        """Background task: detect NATS connection loss and attempt to reconnect."""
+        while not self._stop_event.is_set():
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=reconnect_interval)
+                return  # stop_event fired during sleep
+            except asyncio.TimeoutError:
+                pass
+            if self._stop_event.is_set():
+                return
+            if self._nc is not None and not self._nc.is_closed:
+                continue  # connection still alive
+            logger.warning("NATS connection lost; attempting reconnect")
+            try:
+                await asyncio.wait_for(
+                    self._connect_internal(url, connect_timeout), timeout=hard_timeout
+                )
+                self.reconnect_count += 1
+                NATS_RECONNECTS.labels(result="success").inc()
+                logger.info("NATS reconnected via external loop (count=%d)", self.reconnect_count)
+            except Exception as exc:
+                self.last_error = str(exc)
+                NATS_RECONNECTS.labels(result="failed").inc()
+                logger.error("NATS reconnect failed: %s", exc)
 
     async def _ensure_streams(self) -> None:
         """Create JetStream streams if they don't exist yet."""
@@ -121,7 +171,15 @@ class Publisher:
                 self._stream_names.append(name)
 
     async def disconnect(self) -> None:
-        """Drain and close the NATS connection."""
+        """Stop the reconnect loop, drain, and close the NATS connection."""
+        self._stop_event.set()
+        if self._reconnect_task is not None:
+            self._reconnect_task.cancel()
+            try:
+                await self._reconnect_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._reconnect_task = None
         if self._nc is not None:
             await self._nc.drain()
             self._nc = None

--- a/tests/test_publisher_reconnect.py
+++ b/tests/test_publisher_reconnect.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the external NATS reconnect loop in Publisher."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hermes.publisher import Publisher
+
+
+def _make_mock_nc(*, closed: bool = False) -> MagicMock:
+    """Return a minimal mock NATSClient."""
+    nc = MagicMock()
+    nc.is_closed = closed
+    nc.jetstream.return_value = MagicMock()
+    jsm = AsyncMock()
+    nc.jsm.return_value = jsm
+    nc.drain = AsyncMock()
+    return nc
+
+
+async def _do_connect(pub: Publisher, mock_nc: MagicMock) -> None:
+    """Connect pub using a patched nats.connect that returns mock_nc."""
+    with patch("nats.connect", return_value=mock_nc):
+        await pub.connect("nats://localhost:4222")
+
+
+class TestReconnectLoopStartsOnConnect:
+    @pytest.mark.asyncio
+    async def test_reconnect_task_created_after_connect(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+        await _do_connect(pub, mock_nc)
+        assert pub._reconnect_task is not None
+        assert not pub._reconnect_task.done()
+        # cleanup
+        await pub.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_stop_event_clear_after_connect(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+        await _do_connect(pub, mock_nc)
+        assert not pub._stop_event.is_set()
+        await pub.disconnect()
+
+
+class TestReconnectLoopStopsOnDisconnect:
+    @pytest.mark.asyncio
+    async def test_reconnect_task_done_after_disconnect(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+        await _do_connect(pub, mock_nc)
+        task = pub._reconnect_task
+        await pub.disconnect()
+        assert task is not None
+        assert task.done()
+
+    @pytest.mark.asyncio
+    async def test_stop_event_set_after_disconnect(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+        await _do_connect(pub, mock_nc)
+        await pub.disconnect()
+        assert pub._stop_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_reconnect_task_none_after_disconnect(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+        await _do_connect(pub, mock_nc)
+        await pub.disconnect()
+        assert pub._reconnect_task is None
+
+
+class TestReconnectLoopDoesNotReconnectWhenAlive:
+    @pytest.mark.asyncio
+    async def test_no_reconnect_while_connection_alive(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc(closed=False)
+
+        with patch("nats.connect", return_value=mock_nc) as mock_conn:
+            await pub.connect("nats://localhost:4222")
+            connect_call_count = mock_conn.call_count  # 1 from initial connect
+
+            # Run one loop iteration: sleep (very short), then check
+            with patch("hermes.config.get_settings") as mock_settings:
+                settings = MagicMock()
+                settings.nats_reconnect_interval = 0.05
+                settings.nats_reconnect_hard_timeout = 5.0
+                mock_settings.return_value = settings
+
+                await asyncio.sleep(0.12)  # allow 2 iterations
+
+            # nats.connect must NOT have been called again (connection is alive)
+            assert mock_conn.call_count == connect_call_count
+
+        await pub.disconnect()
+
+
+class TestReconnectLoopRetriesOnLostConnection:
+    @pytest.mark.asyncio
+    async def test_reconnect_called_when_nc_is_closed(self) -> None:
+        pub = Publisher()
+        connect_calls: list[str] = []
+
+        async def fake_connect(url: str, **kwargs: object) -> MagicMock:
+            connect_calls.append(url)
+            return _make_mock_nc(closed=False)
+
+        with patch("nats.connect", side_effect=fake_connect):
+            await pub.connect("nats://localhost:4222")
+            first_call_count = len(connect_calls)  # 1
+
+            # Simulate connection loss while patch is still active
+            pub._nc = _make_mock_nc(closed=True)
+
+            pub._stop_event = asyncio.Event()
+            loop_task = asyncio.ensure_future(
+                pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
+            )
+            await asyncio.sleep(0.12)
+            pub._stop_event.set()
+            await loop_task
+
+        assert len(connect_calls) > first_call_count  # reconnect was attempted
+
+    @pytest.mark.asyncio
+    async def test_reconnect_count_increments_on_success(self) -> None:
+        pub = Publisher()
+
+        async def fake_connect(url: str, **kwargs: object) -> MagicMock:
+            return _make_mock_nc(closed=False)
+
+        with patch("nats.connect", side_effect=fake_connect):
+            await pub.connect("nats://localhost:4222")
+
+        initial_count = pub.reconnect_count
+
+        # Simulate connection loss
+        pub._nc = _make_mock_nc(closed=True)
+
+        loop_task = asyncio.ensure_future(
+            pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
+        )
+        await asyncio.sleep(0.12)
+        pub._stop_event.set()
+        await loop_task
+
+        assert pub.reconnect_count > initial_count
+
+    @pytest.mark.asyncio
+    async def test_last_error_set_on_failed_reconnect(self) -> None:
+        pub = Publisher()
+        call_count = 0
+
+        async def fake_connect(url: str, **kwargs: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _make_mock_nc(closed=False)
+            raise OSError("connection refused")
+
+        with patch("nats.connect", side_effect=fake_connect):
+            await pub.connect("nats://localhost:4222")
+            assert pub.last_error == ""
+
+            # Simulate connection loss while patch is still active
+            pub._nc = _make_mock_nc(closed=True)
+
+            pub._stop_event = asyncio.Event()
+            loop_task = asyncio.ensure_future(
+                pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
+            )
+            await asyncio.sleep(0.12)
+            pub._stop_event.set()
+            await loop_task
+
+        assert pub.last_error != ""
+
+    @pytest.mark.asyncio
+    async def test_nats_reconnects_metric_incremented_on_success(self) -> None:
+        from hermes.metrics import NATS_RECONNECTS
+
+        pub = Publisher()
+
+        async def fake_connect(url: str, **kwargs: object) -> MagicMock:
+            return _make_mock_nc(closed=False)
+
+        with patch("nats.connect", side_effect=fake_connect):
+            await pub.connect("nats://localhost:4222")
+
+        before = NATS_RECONNECTS.labels(result="success")._value.get()
+
+        pub._nc = _make_mock_nc(closed=True)
+
+        loop_task = asyncio.ensure_future(
+            pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
+        )
+        await asyncio.sleep(0.12)
+        pub._stop_event.set()
+        await loop_task
+
+        after = NATS_RECONNECTS.labels(result="success")._value.get()
+        assert after > before
+
+    @pytest.mark.asyncio
+    async def test_nats_reconnects_metric_incremented_on_failure(self) -> None:
+        from hermes.metrics import NATS_RECONNECTS
+
+        pub = Publisher()
+        call_count = 0
+
+        async def fake_connect(url: str, **kwargs: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _make_mock_nc(closed=False)
+            raise OSError("refused")
+
+        with patch("nats.connect", side_effect=fake_connect):
+            await pub.connect("nats://localhost:4222")
+            before = NATS_RECONNECTS.labels(result="failed")._value.get()
+
+            # Simulate connection loss while patch is still active
+            pub._nc = _make_mock_nc(closed=True)
+
+            pub._stop_event = asyncio.Event()
+            loop_task = asyncio.ensure_future(
+                pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
+            )
+            await asyncio.sleep(0.12)
+            pub._stop_event.set()
+            await loop_task
+
+        after = NATS_RECONNECTS.labels(result="failed")._value.get()
+        assert after > before
+
+
+class TestReconnectLoopInterruptibleSleep:
+    @pytest.mark.asyncio
+    async def test_shutdown_during_sleep_returns_promptly(self) -> None:
+        """Stopping the loop while it is sleeping should return well before the interval expires."""
+        pub = Publisher()
+        mock_nc = _make_mock_nc(closed=False)
+        await _do_connect(pub, mock_nc)
+
+        # Replace the reconnect task with a fresh loop that has a 60s interval
+        pub._stop_event = asyncio.Event()
+        loop_task = asyncio.ensure_future(
+            pub._reconnect_loop("nats://localhost:4222", 5.0, 60.0, 5.0)
+        )
+
+        await asyncio.sleep(0.05)  # let loop enter wait_for sleep
+        t0 = asyncio.get_event_loop().time()
+        pub._stop_event.set()
+        await asyncio.wait_for(loop_task, timeout=2.0)  # must not take 60s
+        elapsed = asyncio.get_event_loop().time() - t0
+        assert elapsed < 2.0
+
+        await pub.disconnect()
+
+
+class TestConnectInternalExtracted:
+    @pytest.mark.asyncio
+    async def test_connect_internal_sets_connected_and_js(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+
+        with patch("nats.connect", return_value=mock_nc):
+            await pub._connect_internal("nats://localhost:4222", 5.0)
+
+        assert pub._connected is True
+        assert pub._js is not None
+
+    @pytest.mark.asyncio
+    async def test_connect_internal_registers_callbacks(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+        captured: dict[str, object] = {}
+
+        async def fake_connect(url: str, **kwargs: object) -> MagicMock:
+            captured.update(kwargs)
+            return mock_nc
+
+        with patch("nats.connect", side_effect=fake_connect):
+            await pub._connect_internal("nats://localhost:4222", 5.0)
+
+        assert "disconnected_cb" in captured
+        assert "reconnected_cb" in captured
+
+    @pytest.mark.asyncio
+    async def test_connect_calls_connect_internal(self) -> None:
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+
+        with patch("nats.connect", return_value=mock_nc) as mock_conn:
+            await pub.connect("nats://localhost:4222")
+
+        mock_conn.assert_called_once()
+        await pub.disconnect()


### PR DESCRIPTION
## Summary

- Extracts `_connect_internal()` from `connect()` so the low-level NATS socket setup can be called from both the initial connect path and the reconnect loop
- Adds `_reconnect_loop()` background asyncio task that polls `nc.is_closed` every `NATS_RECONNECT_INTERVAL` seconds and attempts reconnection via `asyncio.wait_for(_connect_internal(), timeout=NATS_RECONNECT_HARD_TIMEOUT)` — keeping `allow_reconnect=False` per team knowledge
- Shutdown is prompt: the per-interval sleep is `asyncio.wait_for(stop_event.wait(), timeout=interval)` so `disconnect()` interrupts it immediately
- Adds `NATS_RECONNECTS` Prometheus counter (`hermes_nats_reconnects_total{result="success|failed"}`) for alerting on reconnect storms vs. recovery
- Adds two new config fields: `NATS_RECONNECT_INTERVAL` (default 5.0s) and `NATS_RECONNECT_HARD_TIMEOUT` (default 5.0s)

## Test plan

- [x] `tests/test_publisher_reconnect.py` — 15 new tests covering: loop starts/stops with connect/disconnect, no spurious reconnects while alive, reconnect fires when `nc.is_closed`, `reconnect_count` increments on success, `last_error` set on failure, both Prometheus labels increment, interruptible sleep returns promptly on shutdown
- [x] All 78 publisher tests pass (`just test`)
- [x] `just lint` (ruff) passes clean

Closes #346
Part of #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)