### PR TITLE
fix(dead-letter): persistence TTL, alerting, backpressure, and server-side limit enforcement

### DIFF
--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -43,6 +43,11 @@ class Settings(BaseSettings):
     shutdown_timeout: float = Field(default=10.0, gt=0)
     max_payload_bytes: int = 1_048_576
     enable_dead_letter: bool = True
+    dead_letter_max_size: int = Field(default=1000, ge=1)
+    dead_letter_ttl_seconds: int = Field(default=86400, ge=0)
+    dead_letter_alert_threshold: float = Field(default=0.8, gt=0, le=1.0)
+    dead_letter_page_size_default: int = Field(default=100, ge=1)
+    dead_letter_page_size_max: int = Field(default=500, ge=1)
     log_json: bool = False
     active_subjects_max: int = 1000
     webhook_rate_limit: str = "60/minute"

--- a/src/hermes/metrics.py
+++ b/src/hermes/metrics.py
@@ -45,3 +45,13 @@ NATS_RECONNECTS: Counter = Counter(
     "Total number of external NATS reconnect attempts",
     ["result"],
 )
+
+DEAD_LETTER_QUEUE_DEPTH: Gauge = Gauge(
+    "hermes_dead_letter_queue_depth",
+    "Current number of items in the in-memory dead-letter queue",
+)
+
+DEAD_LETTER_QUEUE_ALERTS: Counter = Counter(
+    "hermes_dead_letter_queue_alerts_total",
+    "Number of times the dead-letter queue depth crossed the alert threshold",
+)

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -17,6 +17,8 @@ from nats.js import JetStreamContext
 
 from hermes.metrics import (
     ACTIVE_SUBJECTS,
+    DEAD_LETTER_QUEUE_ALERTS,
+    DEAD_LETTER_QUEUE_DEPTH,
     DEAD_LETTERS,
     NATS_RECONNECTS,
     PUBLISH_LATENCY,
@@ -59,14 +61,14 @@ class Publisher:
     def __init__(self, enable_dead_letter: bool = True, max_subjects: int | None = None) -> None:
         from hermes.config import get_settings
 
+        s = get_settings()
         self._nc: NATSClient | None = None
         self._js: JetStreamContext | None = None
-        self._max_subjects: int = (
-            max_subjects if max_subjects is not None else get_settings().active_subjects_max
-        )
+        self._max_subjects: int = max_subjects if max_subjects is not None else s.active_subjects_max
         self._active_subjects: OrderedDict[str, None] = OrderedDict()
         self._stream_names: list[str] = []
-        self._dead_letters: deque[dict[str, Any]] = deque(maxlen=1000)
+        self._dead_letters: deque[dict[str, Any]] = deque(maxlen=s.dead_letter_max_size)
+        self._dead_letter_alert_threshold: float = s.dead_letter_alert_threshold
         self._enable_dead_letter = enable_dead_letter
         self._connected: bool = False
         self.reconnect_count: int = 0
@@ -152,20 +154,38 @@ class Publisher:
 
     async def _ensure_streams(self) -> None:
         """Create JetStream streams if they don't exist yet."""
+        from datetime import timedelta
+
         from nats.js.api import StreamConfig
         from nats.js.errors import NotFoundError
 
+        from hermes.config import get_settings
+
         assert self._nc is not None
+        s = get_settings()
         jsm = self._nc.jsm()
-        for name, subjects in (
-            ("homeric-agents", ["hi.agents.>"]),
-            ("homeric-tasks", ["hi.tasks.>"]),
-            ("homeric-deadletter", ["hi.deadletter.>"]),
-        ):
+
+        dead_letter_ttl = (
+            timedelta(seconds=s.dead_letter_ttl_seconds)
+            if s.dead_letter_ttl_seconds > 0
+            else None
+        )
+
+        stream_configs: list[tuple[str, list[str], dict[str, Any]]] = [
+            ("homeric-agents", ["hi.agents.>"], {}),
+            ("homeric-tasks", ["hi.tasks.>"], {}),
+            (
+                "homeric-deadletter",
+                ["hi.deadletter.>"],
+                {"max_age": dead_letter_ttl} if dead_letter_ttl is not None else {},
+            ),
+        ]
+
+        for name, subjects, extra in stream_configs:
             try:
                 await jsm.stream_info(name)
             except NotFoundError:
-                await jsm.add_stream(StreamConfig(name=name, subjects=subjects))
+                await jsm.add_stream(StreamConfig(name=name, subjects=subjects, **extra))
                 logger.info("Created JetStream stream: %s (%s)", name, subjects)
             if name not in self._stream_names:
                 self._stream_names.append(name)
@@ -215,6 +235,7 @@ class Publisher:
         """Clear the dead-letter queue and return the number of drained items."""
         count = len(self._dead_letters)
         self._dead_letters.clear()
+        DEAD_LETTER_QUEUE_DEPTH.set(0)
         return count
 
     # ------------------------------------------------------------------
@@ -273,6 +294,17 @@ class Publisher:
                 self._dead_letters.append({"event": payload.event, "subject": dead_subject})
                 DEAD_LETTERS.labels(event_type=payload.event).inc()
                 self._track_subject(dead_subject)
+                depth = len(self._dead_letters)
+                DEAD_LETTER_QUEUE_DEPTH.set(depth)
+                capacity = self._dead_letters.maxlen or 0
+                if capacity > 0 and depth >= self._dead_letter_alert_threshold * capacity:
+                    logger.warning(
+                        "Dead-letter queue depth %d/%d exceeds %.0f%% threshold",
+                        depth,
+                        capacity,
+                        self._dead_letter_alert_threshold * 100,
+                    )
+                    DEAD_LETTER_QUEUE_ALERTS.inc()
                 logger.warning(
                     "No subject mapping for event type %r; dead-lettered to %s",
                     payload.event,

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -177,7 +177,7 @@ class Publisher:
             (
                 "homeric-deadletter",
                 ["hi.deadletter.>"],
-                {"max_age": dead_letter_ttl} if dead_letter_ttl is not None else {},
+                {"max_age": dead_letter_ttl.total_seconds()} if dead_letter_ttl is not None else {},
             ),
         ]
 

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -432,21 +432,32 @@ async def metrics() -> Response:
 
 @app.get("/dead-letters", response_model=DeadLettersResponse)
 async def dead_letters(
-    limit: int | None = None,
     offset: int = 0,
+    limit: int | None = None,
     _: None = Depends(_require_dead_letter_key),
 ) -> DeadLettersResponse:
     """Return the in-memory dead-letter queue with optional pagination.
 
     Query params:
     - ``offset``: number of items to skip (default 0).
-    - ``limit``: maximum number of items to return (default: all).
+    - ``limit``: maximum items to return (default: ``dead_letter_page_size_default``;
+      hard ceiling: ``dead_letter_page_size_max``).
     """
+    settings = get_settings()
+    effective_limit: int = limit if limit is not None else settings.dead_letter_page_size_default
+    if effective_limit > settings.dead_letter_page_size_max:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"limit must not exceed {settings.dead_letter_page_size_max}; "
+                f"got {effective_limit}"
+            ),
+        )
     publisher: Publisher = app.state.publisher
     all_items = publisher.dead_letters
     total = len(all_items)
-    sliced = all_items[offset:] if limit is None else all_items[offset : offset + limit]
-    return DeadLettersResponse(total=total, offset=offset, limit=limit, items=sliced)
+    sliced = all_items[offset : offset + effective_limit]
+    return DeadLettersResponse(total=total, offset=offset, limit=effective_limit, items=sliced)
 
 
 @app.delete("/dead-letters", status_code=status.HTTP_200_OK)

--- a/tests/test_dead_letter_limits.py
+++ b/tests/test_dead_letter_limits.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: MIT
+"""Tests for dead-letter queue limits, TTL config, gauge, and alerting (issue #347)."""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hermes.config import Settings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_client(items: list[dict]) -> TestClient:
+    from hermes.publisher import Publisher
+    from hermes.server import app
+
+    mock_publisher = MagicMock(spec=Publisher)
+    mock_publisher.is_connected = True
+    mock_publisher.active_subjects = []
+    mock_publisher.dead_letters = items
+    app.state.publisher = mock_publisher
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# Config defaults
+# ---------------------------------------------------------------------------
+
+
+class TestDeadLetterConfigDefaults:
+    """Verify the new config fields have sane defaults."""
+
+    def test_dead_letter_max_size_default(self) -> None:
+        s = Settings()
+        assert s.dead_letter_max_size == 1000
+
+    def test_dead_letter_ttl_seconds_default(self) -> None:
+        s = Settings()
+        assert s.dead_letter_ttl_seconds == 86400
+
+    def test_dead_letter_alert_threshold_default(self) -> None:
+        s = Settings()
+        assert s.dead_letter_alert_threshold == 0.8
+
+    def test_dead_letter_page_size_default_default(self) -> None:
+        s = Settings()
+        assert s.dead_letter_page_size_default == 100
+
+    def test_dead_letter_page_size_max_default(self) -> None:
+        s = Settings()
+        assert s.dead_letter_page_size_max == 500
+
+
+# ---------------------------------------------------------------------------
+# Publisher: config-driven deque size
+# ---------------------------------------------------------------------------
+
+
+class TestPublisherDequeSize:
+    """Deque capacity is driven by dead_letter_max_size config."""
+
+    def test_deque_maxlen_reflects_config(self) -> None:
+        from hermes.config import get_settings
+        from hermes.publisher import Publisher
+
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_max_size = 42
+        pub = Publisher()
+        assert pub._dead_letters.maxlen == 42
+
+    def test_deque_default_maxlen_is_1000(self) -> None:
+        from hermes.publisher import Publisher
+
+        pub = Publisher()
+        assert pub._dead_letters.maxlen == 1000
+
+
+# ---------------------------------------------------------------------------
+# Publisher: queue-depth gauge and alert counter
+# ---------------------------------------------------------------------------
+
+
+class TestDeadLetterQueueGauge:
+    """DEAD_LETTER_QUEUE_DEPTH gauge is updated on enqueue and drain."""
+
+    @pytest.mark.asyncio
+    async def test_gauge_updated_after_enqueue(self) -> None:
+        from datetime import datetime, timezone
+
+        from hermes.metrics import DEAD_LETTER_QUEUE_DEPTH
+        from hermes.models import WebhookPayload
+        from hermes.publisher import Publisher
+
+        pub = Publisher()
+        pub._js = AsyncMock()
+        pub._js.publish = AsyncMock()
+
+        payload = WebhookPayload(
+            event="unknown.event",
+            data={},
+            timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        await pub.publish(payload)
+        assert DEAD_LETTER_QUEUE_DEPTH._value.get() == 1.0
+
+    @pytest.mark.asyncio
+    async def test_gauge_reset_to_zero_after_drain(self) -> None:
+        from hermes.metrics import DEAD_LETTER_QUEUE_DEPTH
+        from hermes.publisher import Publisher
+
+        pub = Publisher()
+        pub._dead_letters = deque([{"event": "a"}, {"event": "b"}], maxlen=1000)
+        pub.drain_dead_letters()
+        assert DEAD_LETTER_QUEUE_DEPTH._value.get() == 0.0
+
+
+class TestDeadLetterAlertCounter:
+    """DEAD_LETTER_QUEUE_ALERTS counter increments when threshold is crossed."""
+
+    @pytest.mark.asyncio
+    async def test_alert_counter_increments_at_threshold(self) -> None:
+        from datetime import datetime, timezone
+
+        from hermes.config import get_settings
+        from hermes.metrics import DEAD_LETTER_QUEUE_ALERTS
+        from hermes.models import WebhookPayload
+        from hermes.publisher import Publisher
+
+        # Use a small queue so we hit the threshold quickly.
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_max_size = 5
+        s.dead_letter_alert_threshold = 0.8  # trigger at 4/5
+
+        before = DEAD_LETTER_QUEUE_ALERTS._value.get()
+
+        pub = Publisher()
+        pub._js = AsyncMock()
+        pub._js.publish = AsyncMock()
+
+        def _make_payload(name: str) -> WebhookPayload:
+            return WebhookPayload(
+                event=f"unknown.{name}",
+                data={},
+                timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+
+        # Enqueue 4 items — the 4th should cross 80 % of 5.
+        for i in range(4):
+            await pub.publish(_make_payload(str(i)))
+
+        after = DEAD_LETTER_QUEUE_ALERTS._value.get()
+        assert after > before
+
+    @pytest.mark.asyncio
+    async def test_no_alert_below_threshold(self) -> None:
+        from datetime import datetime, timezone
+
+        from hermes.config import get_settings
+        from hermes.metrics import DEAD_LETTER_QUEUE_ALERTS
+        from hermes.models import WebhookPayload
+        from hermes.publisher import Publisher
+
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_max_size = 100
+        s.dead_letter_alert_threshold = 0.8  # trigger at 80/100
+
+        before = DEAD_LETTER_QUEUE_ALERTS._value.get()
+
+        pub = Publisher()
+        pub._js = AsyncMock()
+        pub._js.publish = AsyncMock()
+
+        payload = WebhookPayload(
+            event="unknown.single",
+            data={},
+            timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        await pub.publish(payload)
+
+        after = DEAD_LETTER_QUEUE_ALERTS._value.get()
+        assert after == before
+
+
+# ---------------------------------------------------------------------------
+# Publisher: _ensure_streams passes max_age for dead-letter stream
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureStreamsDeadLetterTTL:
+    """_ensure_streams passes max_age to the homeric-deadletter stream when TTL is set."""
+
+    @pytest.mark.asyncio
+    async def test_max_age_passed_when_ttl_nonzero(self) -> None:
+        from nats.js.errors import NotFoundError
+
+        from hermes.config import get_settings
+        from hermes.publisher import Publisher
+
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_ttl_seconds = 3600
+
+        pub = Publisher()
+        mock_nc = MagicMock()
+        mock_jsm = AsyncMock()
+        mock_jsm.stream_info = AsyncMock(side_effect=NotFoundError)
+        mock_jsm.add_stream = AsyncMock()
+        mock_nc.jsm = MagicMock(return_value=mock_jsm)
+        pub._nc = mock_nc
+
+        await pub._ensure_streams()
+
+        calls = mock_jsm.add_stream.call_args_list
+        dead_letter_call = next(
+            c for c in calls if c.args[0].name == "homeric-deadletter"
+        )
+        cfg = dead_letter_call.args[0]
+        assert cfg.max_age == timedelta(seconds=3600)
+
+    @pytest.mark.asyncio
+    async def test_no_max_age_when_ttl_is_zero(self) -> None:
+        from nats.js.errors import NotFoundError
+
+        from hermes.config import get_settings
+        from hermes.publisher import Publisher
+
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_ttl_seconds = 0
+
+        pub = Publisher()
+        mock_nc = MagicMock()
+        mock_jsm = AsyncMock()
+        mock_jsm.stream_info = AsyncMock(side_effect=NotFoundError)
+        mock_jsm.add_stream = AsyncMock()
+        mock_nc.jsm = MagicMock(return_value=mock_jsm)
+        pub._nc = mock_nc
+
+        await pub._ensure_streams()
+
+        calls = mock_jsm.add_stream.call_args_list
+        dead_letter_call = next(
+            c for c in calls if c.args[0].name == "homeric-deadletter"
+        )
+        cfg = dead_letter_call.args[0]
+        assert cfg.max_age is None
+
+
+# ---------------------------------------------------------------------------
+# Server: GET /dead-letters default and max limit enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestDeadLettersDefaultLimit:
+    """GET /dead-letters applies the configured default page size when limit is omitted."""
+
+    def test_default_limit_applied_when_no_limit_param(self) -> None:
+        from hermes.config import get_settings
+
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_page_size_default = 3
+
+        items = [{"event": f"evt.{i}", "subject": f"hi.deadletter.evt-{i}"} for i in range(10)]
+        client = _build_client(items)
+        body = client.get("/dead-letters").json()
+        assert len(body["items"]) == 3
+        assert body["limit"] == 3
+        assert body["total"] == 10
+
+    def test_explicit_limit_overrides_default(self) -> None:
+        from hermes.config import get_settings
+
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_page_size_default = 3
+        s.dead_letter_page_size_max = 500
+
+        items = [{"event": f"evt.{i}", "subject": f"hi.deadletter.evt-{i}"} for i in range(10)]
+        client = _build_client(items)
+        body = client.get("/dead-letters?limit=5").json()
+        assert len(body["items"]) == 5
+        assert body["limit"] == 5
+
+
+class TestDeadLettersMaxLimitEnforcement:
+    """GET /dead-letters returns HTTP 400 when limit exceeds the configured maximum."""
+
+    def test_limit_exceeding_max_returns_400(self) -> None:
+        from hermes.config import get_settings
+
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_page_size_max = 50
+
+        client = _build_client([])
+        resp = client.get("/dead-letters?limit=51")
+        assert resp.status_code == 400
+
+    def test_limit_at_max_is_accepted(self) -> None:
+        from hermes.config import get_settings
+
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_page_size_max = 50
+
+        items = [{"event": f"evt.{i}", "subject": f"hi.deadletter.evt-{i}"} for i in range(10)]
+        client = _build_client(items)
+        resp = client.get("/dead-letters?limit=50")
+        assert resp.status_code == 200
+
+    def test_default_limit_within_max_is_accepted(self) -> None:
+        from hermes.config import get_settings
+
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_page_size_default = 100
+        s.dead_letter_page_size_max = 500
+
+        client = _build_client([])
+        resp = client.get("/dead-letters")
+        assert resp.status_code == 200
+
+    def test_error_detail_mentions_max(self) -> None:
+        from hermes.config import get_settings
+
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_page_size_max = 50
+
+        client = _build_client([])
+        body = client.get("/dead-letters?limit=999").json()
+        assert "50" in body["detail"]
+        assert "999" in body["detail"]

--- a/tests/test_dead_letter_limits.py
+++ b/tests/test_dead_letter_limits.py
@@ -226,7 +226,7 @@ class TestEnsureStreamsDeadLetterTTL:
             c for c in calls if c.args[0].name == "homeric-deadletter"
         )
         cfg = dead_letter_call.args[0]
-        assert cfg.max_age == timedelta(seconds=3600)
+        assert cfg.max_age == timedelta(seconds=3600).total_seconds()
 
     @pytest.mark.asyncio
     async def test_no_max_age_when_ttl_is_zero(self) -> None:

--- a/tests/test_integration_coverage.py
+++ b/tests/test_integration_coverage.py
@@ -185,3 +185,42 @@ class TestLoggingConfig:
         parsed = json.loads(out)
         assert "exc_info" in parsed
         assert "ValueError" in parsed["exc_info"]
+
+
+class TestPayloadSizeLimitMiddleware:
+    """Exercise ``hermes.middleware.PayloadSizeLimitMiddleware`` 413 branches.
+
+    These tests build a minimal FastAPI app with a tiny ``max_bytes`` limit
+    so they run without a live NATS server and without sending a full megabyte
+    of data over the wire.
+    """
+
+    def _mini_client(self, max_bytes: int = 10):  # type: ignore[no-untyped-def]
+        """Return a TestClient for a minimal FastAPI app with *max_bytes* limit."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from hermes.middleware import PayloadSizeLimitMiddleware
+
+        mini = FastAPI()
+        mini.add_middleware(PayloadSizeLimitMiddleware, max_bytes=max_bytes)
+
+        @mini.post("/")
+        async def _ok() -> dict:  # type: ignore[return]
+            return {"ok": True}
+
+        return TestClient(mini, raise_server_exceptions=False)
+
+    def test_content_length_too_large_returns_413(self) -> None:
+        """An 11-byte body with max_bytes=10 is rejected via the Content-Length header branch."""
+        # httpx/TestClient automatically sets Content-Length from the body, so
+        # the middleware sees Content-Length=11 > max_bytes=10 and returns 413
+        # before even reading the body (middleware.py lines 32-37).
+        client = self._mini_client(max_bytes=10)
+        response = client.post("/", content=b"x" * 11)
+        assert response.status_code == 413
+
+    def test_body_within_limit_passes_through(self) -> None:
+        """A request whose body fits within the limit reaches the route handler (200)."""
+        client = self._mini_client(max_bytes=10)
+        response = client.post("/", content=b"x" * 5)
+        assert response.status_code == 200

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -699,7 +699,7 @@ class TestDeadLettersGetEndpoint:
         body = client.get("/dead-letters").json()
         assert body["total"] == 0
         assert body["offset"] == 0
-        assert body["limit"] is None
+        assert body["limit"] is not None  # default page size is applied
         assert body["items"] == []
 
     def test_dead_letters_returns_all_by_default(self) -> None:
@@ -708,7 +708,7 @@ class TestDeadLettersGetEndpoint:
         body = client.get("/dead-letters").json()
         assert body["total"] == 5
         assert len(body["items"]) == 5
-        assert body["limit"] is None
+        assert body["limit"] is not None  # default page size is applied
 
     def test_dead_letters_limit_param(self) -> None:
         items = [{"event": f"evt.{i}", "subject": f"hi.deadletter.evt-{i}"} for i in range(10)]


### PR DESCRIPTION
## Summary

Fixes the four gaps in the dead-letter queue identified in issue #347:

- **Config-driven deque size** — `dead_letter_max_size` replaces the hardcoded `1000`
- **JetStream TTL** — `dead_letter_ttl_seconds` (default 24 h) is passed as `max_age` to the `homeric-deadletter` stream config; set to `0` to disable expiry
- **Prometheus observability** — new `hermes_dead_letter_queue_depth` gauge (updated on every enqueue and drain) and `hermes_dead_letter_queue_alerts_total` counter; a `WARNING` log is emitted when queue depth crosses `dead_letter_alert_threshold` (default 80 %)
- **Server-side pagination limits** — `GET /dead-letters` now applies `dead_letter_page_size_default` (100) when `limit` is omitted and returns HTTP 400 when `limit` exceeds `dead_letter_page_size_max` (500)

## New config variables

| Variable | Default | Description |
|---|---|---|
| `DEAD_LETTER_MAX_SIZE` | 1000 | Deque capacity |
| `DEAD_LETTER_TTL_SECONDS` | 86400 | JetStream `max_age` in seconds (0 = no TTL) |
| `DEAD_LETTER_ALERT_THRESHOLD` | 0.8 | Fraction of capacity that triggers a warning |
| `DEAD_LETTER_PAGE_SIZE_DEFAULT` | 100 | Default `limit` for `GET /dead-letters` |
| `DEAD_LETTER_PAGE_SIZE_MAX` | 500 | Hard ceiling on `limit` |

## Test plan

- [x] 19 new tests in `tests/test_dead_letter_limits.py` covering config defaults, deque sizing, gauge/counter updates, TTL stream config, default limit, and max limit enforcement
- [x] Updated two existing tests in `tests/test_webhook.py` that asserted `limit == None` (now returns the default page size)
- [x] All 346 non-integration tests pass (`pixi run pytest tests/ --ignore=tests/test_integration.py`)
- [x] `pixi run just lint` — clean
- [ ] Integration test flakiness (`test_integration.py`) is pre-existing (NATS stream state leaks between test runs); unrelated to this PR

Closes #347
Part of #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)