### PR TITLE
docs: replace 'master' with 'main' in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,11 +76,11 @@ Before starting work:
 
 ### 2. Branch Naming Convention
 
-Create a feature branch from `master`:
+Create a feature branch from `main`:
 
 ```bash
-git checkout master
-git pull origin master
+git checkout main
+git pull origin main
 git checkout -b <issue-number>-<short-description>
 
 # Examples:
@@ -181,7 +181,7 @@ just register-webhook
 ### Before You Start
 
 1. Ensure an issue exists for your work
-2. Create a branch from `master` using the naming convention
+2. Create a branch from `main` using the naming convention
 3. Implement your changes
 4. Run `just test` and `just lint` to verify
 
@@ -224,18 +224,18 @@ gh pr create --title "[Type] Brief description" --body "Closes #<issue-number>"
 
 | Branch type | Naming convention | Base branch | Notes |
 |-------------|-------------------|-------------|-------|
-| Default | `master` | — | Protected; never push directly |
-| Feature / fix | `<issue>-<slug>` | `master` | e.g. `44-planning-templates` |
-| Release | `release/v<x.y.z>` | `master` | Created from `master` before tagging |
+| Default | `main` | — | Protected; never push directly |
+| Feature / fix | `<issue>-<slug>` | `main` | e.g. `44-planning-templates` |
+| Release | `release/v<x.y.z>` | `main` | Created from `main` before tagging |
 
 **Merge strategy:**
 
 - Single-concern PRs: squash-and-merge
 - Multi-commit story-arc PRs: rebase-and-merge
 
-### Never Push Directly to Master
+### Never Push Directly to Main
 
-The `master` branch is protected. All changes must go through pull requests.
+The `main` branch is protected. All changes must go through pull requests.
 
 ## Code Review
 


### PR DESCRIPTION
## Summary

- Replaced all 8 occurrences of `master` with `main` in `CONTRIBUTING.md` (lines 79, 82, 83, 184, 227, 228, 229, 238)
- Updated branch naming convention section, branching strategy table, and the "Never Push Directly" section
- The actual default/protected branch is `main`; these instructions were directing contributors to the wrong branch

## Test plan

- [ ] Verify no remaining `master` references exist in `CONTRIBUTING.md`
- [ ] Confirm all workflow steps now correctly reference `main`

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)