### PR TITLE
chore(github): add structured project planning infrastructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Roadmap & Project Planning
+    url: https://github.com/HomericIntelligence/ProjectHermes/issues/545
+    about: See the current roadmap and phased delivery plan.
   - name: Security Vulnerability
     url: https://github.com/HomericIntelligence/ProjectHermes/security/advisories/new
     about: Please report security vulnerabilities via GitHub Security Advisories, not public issues.

--- a/.github/ISSUE_TEMPLATE/tech_debt.md
+++ b/.github/ISSUE_TEMPLATE/tech_debt.md
@@ -1,0 +1,21 @@
+---
+name: Technical Debt
+about: File a known technical-debt item for tracking and future resolution
+labels: [tech-debt, chore]
+---
+
+## Objective
+<!-- What needs to be improved and why. -->
+
+## Context
+<!-- File path(s) and line number(s) where the debt lives, if applicable. -->
+
+## Deliverables
+- [ ] <!-- specific sub-task 1 -->
+- [ ] <!-- specific sub-task 2 -->
+
+## Success Criteria
+<!-- How will we know this is resolved? -->
+
+## Parent Issue
+<!-- Link to the Epic tracking issue, e.g. #NNN -->

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,12 @@
+- name: tech-debt
+  color: "e4e669"
+  description: "Known technical debt items to address in future sprints"
+- name: roadmap
+  color: "0075ca"
+  description: "Tracks planned features and phased delivery"
+- name: chore
+  color: "fef2c0"
+  description: "Maintenance tasks with no user-visible impact"
+- name: cleanup
+  color: "c5def5"
+  description: "Code or config cleanup"

--- a/scripts/discover-tech-debt.sh
+++ b/scripts/discover-tech-debt.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "=== Technical Debt Discovery: ProjectHermes ==="
+grep -rn "FIXME\|TODO\|DEPRECATED\|HACK\|XXX" \
+  --include="*.py" --include="*.toml" --include="*.yml" \
+  --exclude-dir='.git' --exclude-dir='.pixi' \
+  . 2>/dev/null || echo "(none found)"


### PR DESCRIPTION
## Summary

- Add `.github/labels.yml` with `tech-debt`, `roadmap`, `chore`, and `cleanup` label definitions (applied via `gh label create`)
- Add `.github/ISSUE_TEMPLATE/tech_debt.md` so contributors can file debt in a structured way
- Add `scripts/discover-tech-debt.sh` to grep for FIXME/TODO/DEPRECATED markers on demand
- Update `.github/ISSUE_TEMPLATE/config.yml` to add a Roadmap contact link pointing to #545

**Tracking issues created:**
- Epic #544 — Technical Debt Backlog
- Issue #545 — Roadmap: ProjectHermes Delivery Phases

## Test plan

- [x] `bash scripts/discover-tech-debt.sh` exits 0 and reports `(none found)` — codebase is clean
- [x] Labels `tech-debt`, `roadmap`, `chore`, `cleanup` confirmed present in repo (`gh label list`)
- [x] Epic issue #544 is open and labeled `tech-debt` + `epic`
- [x] Roadmap issue #545 is open and labeled `roadmap` + `epic`
- [x] `config.yml` shows Roadmap contact link pointing to #545
- [x] `tech_debt.md` template will appear in the GitHub new-issue UI (auto-labeled `tech-debt`, `chore`)

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)