### PR TITLE
fix(docker): install tini and use ENTRYPOINT for reliable SIGTERM forwarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN pip install --no-cache-dir \
 FROM python:3.12-slim
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends tini && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /build/deps /usr/local/lib/python3.12/site-packages/
 COPY src/hermes/ ./hermes/
 
@@ -23,4 +25,5 @@ EXPOSE 8085
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:${HERMES_PORT:-8085}/ready || exit 1
 
+ENTRYPOINT ["tini", "--"]
 CMD ["python", "-m", "hermes.server"]

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -1,7 +1,8 @@
-"""Regression tests ensuring the Dockerfile uses pinned/versioned pip dependencies."""
+"""Regression tests ensuring the Dockerfile uses pinned/versioned pip dependencies and signal forwarding."""
 
 from __future__ import annotations
 
+import pathlib
 import re
 import tomllib
 from pathlib import Path
@@ -9,6 +10,7 @@ from pathlib import Path
 ROOT = Path(__file__).parent.parent
 DOCKERFILE = ROOT / "Dockerfile"
 PYPROJECT = ROOT / "pyproject.toml"
+_DOCKERFILE = pathlib.Path(__file__).parent.parent / "Dockerfile"
 
 _VERSION_SPEC_RE = re.compile(r"[><=!~]")
 _PIP_INSTALL_RE = re.compile(r"pip install\b")
@@ -93,3 +95,36 @@ def test_dockerfile_no_bare_unversioned_pip_packages() -> None:
             assert _VERSION_SPEC_RE.search(base), (
                 f"Dockerfile has unversioned package '{token}' in pip install line: {line!r}"
             )
+
+
+class TestDockerfileTini:
+    def test_tini_installed(self) -> None:
+        lines = _dockerfile_lines()
+        assert any("tini" in line for line in lines), \
+            "Dockerfile must install tini for PID-1 signal forwarding"
+
+    def test_entrypoint_uses_tini(self) -> None:
+        lines = _dockerfile_lines()
+        entrypoint_lines = [ln for ln in lines if ln.strip().startswith("ENTRYPOINT")]
+        assert entrypoint_lines, "Dockerfile must have an ENTRYPOINT directive"
+        assert "tini" in entrypoint_lines[-1], \
+            'ENTRYPOINT must use tini (e.g. ENTRYPOINT ["tini", "--"])'
+
+    def test_cmd_preserved(self) -> None:
+        lines = _dockerfile_lines()
+        cmd_lines = [ln for ln in lines if ln.startswith("CMD")]
+        assert cmd_lines, "Dockerfile must retain a CMD directive"
+        assert "hermes.server" in cmd_lines[-1], \
+            "CMD must still launch the hermes server"
+
+    def test_entrypoint_before_cmd(self) -> None:
+        lines = _dockerfile_lines()
+        entrypoint_idx = next(
+            (i for i, ln in enumerate(lines) if ln.startswith("ENTRYPOINT")), -1
+        )
+        cmd_idx = next(
+            (i for i, ln in enumerate(lines) if ln.startswith("CMD")), -1
+        )
+        assert entrypoint_idx != -1, "ENTRYPOINT not found"
+        assert cmd_idx != -1, "CMD not found"
+        assert entrypoint_idx < cmd_idx, "ENTRYPOINT must appear before CMD"


### PR DESCRIPTION
## Summary

- Installs `tini` in the runtime stage of the Dockerfile via `apt-get`
- Replaces bare `CMD` with `ENTRYPOINT ["tini", "--"]` + `CMD ["python", "-m", "hermes.server"]` so tini becomes PID 1 and reliably forwards SIGTERM to the Python process
- Adds `tests/test_dockerfile.py` with four structural assertions covering tini installation, ENTRYPOINT directive, CMD preservation, and correct ordering

## Motivation

When Python is PID 1 in a container, some runtimes (Docker without `--init`, Podman, non-Kubernetes OCI runtimes) may not forward SIGTERM correctly. Tini is the canonical minimal-init solution: it forwards signals to the child process and reaps zombies, ensuring the existing graceful-shutdown handlers in `server.py` always fire.

## Test plan

- [x] `pixi run python -m pytest tests/test_dockerfile.py -v` — all 4 new tests pass
- [x] `pixi run python -m pytest tests/ -v` — all 370 tests pass
- [x] `pixi run just lint` — ruff clean

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)