### PR TITLE
fix(docker): pin nats image to nats:2.10@sha256 digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+  - package-ecosystem: docker-compose
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 2

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Start NATS with JetStream
         run: |
-          docker run -d --name nats-js -p 4222:4222 -p 8222:8222 nats:alpine -js -m 8222
+          docker run -d --name nats-js -p 4222:4222 -p 8222:8222 nats:2.10@sha256:5498ba57b9471840be3d15b033a4eec554d1c02fa6c2cc0ca2d888637f6c6e2f -js -m 8222
           until curl -sf http://localhost:8222/healthz; do sleep 1; done
 
       - name: Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Start NATS with JetStream
         run: |
-          docker run -d --name nats-js -p 4222:4222 -p 8222:8222 nats:alpine -js -m 8222
+          docker run -d --name nats-js -p 4222:4222 -p 8222:8222 nats:2.10@sha256:5498ba57b9471840be3d15b033a4eec554d1c02fa6c2cc0ca2d888637f6c6e2f -js -m 8222
           until curl -sf http://localhost:8222/healthz; do sleep 1; done
 
       - name: Integration tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   nats:
-    image: nats:latest
+    # pinned — bump digest monthly or when CVE scan fires
+    image: nats:2.10@sha256:5498ba57b9471840be3d15b033a4eec554d1c02fa6c2cc0ca2d888637f6c6e2f
     command: ["--jetstream", "--store_dir", "/data"]
     ports:
       - "4222:4222"


### PR DESCRIPTION
## Summary

- Replace unpinned `nats:latest` with `nats:2.10@sha256:5498ba57b9471840be3d15b033a4eec554d1c02fa6c2cc0ca2d888637f6c6e2f` in `docker-compose.yml`, `.github/workflows/ci.yml`, and `.github/workflows/_required.yml`
- Add a maintenance comment in `docker-compose.yml` noting when to bump the digest
- Add `docker-compose` ecosystem to `.github/dependabot.yml` for automated monthly digest-bump PRs

## Test plan

- [x] Verified `nats:latest` no longer appears in any tracked file (`grep -r 'nats:latest'` returns nothing outside the prompt file)
- [x] Confirmed digest is valid 64-hex SHA256 (`echo "<digest>" | grep -E '^[0-9a-f]{64}$'`)
- [x] Digest retrieved via `docker pull nats:2.10 && docker inspect --format='{{index .RepoDigests 0}}' nats:2.10`
- [ ] CI integration-test job will exercise the pinned image on merge

Closes #356
Part of #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)