### PR TITLE
security(docker): enforce read-only filesystem and drop all capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ USER hermes
 ENV HERMES_HOST=0.0.0.0
 ENV HERMES_PORT=8085
 ENV HERMES_PUBLIC_URL=http://localhost:8085
+ENV PYTHONDONTWRITEBYTECODE=1
 EXPOSE 8085
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,20 +15,27 @@ services:
   hermes:
     build: .
     ports:
-      - "${HERMES_PORT:-8080}:8080"
+      - "${HERMES_PORT:-8085}:8085"
     environment:
       - NATS_URL=nats://nats:4222
-      - HERMES_PORT=8080
+      - HERMES_PORT=8085
       - WEBHOOK_SECRET=${WEBHOOK_SECRET:-}
     depends_on:
       nats:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/ready"]
+      test: ["CMD", "curl", "-f", "http://localhost:8085/ready"]
       interval: 30s
       timeout: 5s
       start_period: 10s
       retries: 3
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
 
 volumes:
   nats-data:


### PR DESCRIPTION
## Summary

- Add `read_only: true` to the hermes service so the container root filesystem is immutable at runtime, preventing post-exploitation file writes
- Add `tmpfs: [/tmp]` so uvicorn and other tools have a writable scratch space
- Add `cap_drop: [ALL]` and `security_opt: [no-new-privileges:true]` to minimize the attack surface
- Fix stale port mapping: `8080:8080` → `8085:8085` to match `EXPOSE 8085` in the Dockerfile
- Add `ENV PYTHONDONTWRITEBYTECODE=1` to the Dockerfile runtime stage so Python does not attempt to write `.pyc` files to the now-read-only filesystem

## Test plan

- [x] All 366 existing unit tests pass (`pixi run python -m pytest tests/ -v`)
- [ ] `docker compose up --build` — no `Read-only file system` errors in logs
- [ ] `curl -f http://localhost:8085/health` responds 200
- [ ] `curl -f http://localhost:8085/ready` responds 200
- [ ] `docker compose exec hermes touch /test-write` fails with permission error (read-only enforced)
- [ ] `docker compose exec hermes touch /tmp/test-write` succeeds (tmpfs writable)
- [ ] `docker compose exec hermes id` shows UID 1000 (hermes user, not root)

Closes #357
Part of #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)