### PR TITLE
fix(justfile): include checked path and stderr routing in nats-start fallback

### DIFF
--- a/justfile
+++ b/justfile
@@ -124,7 +124,7 @@ nats-start:
         echo "Starting NATS with Odysseus config: $ODYSSEUS_CONF"
         nats-server -c "$ODYSSEUS_CONF" &
     else
-        echo "Odysseus config not found; starting NATS with embedded defaults"
+        echo "Warning: Odysseus config not found at $ODYSSEUS_CONF — starting NATS with embedded defaults" >&2
         nats-server \
             --jetstream \
             --store_dir /tmp/nats-hermes \


### PR DESCRIPTION
## Summary

- Updated the `nats-start` fallback `echo` to include `$ODYSSEUS_CONF` in the message so developers see the exact path that was checked
- Prefixed with `Warning:` to clearly signal intent
- Routed the message to stderr (`>&2`) to keep stdout clean and separate from normal recipe output

## Test plan

- [ ] All 366 existing tests pass (`pixi run python -m pytest tests/ -v`)
- [ ] Manual verification: running `just nats-start` without `../Odysseus/configs/nats/server.conf` present emits `Warning: Odysseus config not found at ../Odysseus/configs/nats/server.conf — starting NATS with embedded defaults` on stderr, nothing on stdout

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)