### PR TITLE
feat(security): add Bearer token auth to /dead-letters endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Every message published to NATS JetStream includes a `schema_version` integer fi
 | HERMES_PORT           | 8080                           | Port Hermes listens on                                  |
 | HERMES_PUBLIC_URL     | `http://localhost:{HERMES_PORT}` | Externally-reachable base URL for the /webhook endpoint |
 | WEBHOOK_SECRET        |                                | HMAC secret for webhook validation (minimum 32 characters) |
+| ADMIN_API_KEY         |                                | Bearer token for `GET /dead-letters` and `DELETE /dead-letters`. If unset, both endpoints return 403. |
 | MAX_PAYLOAD_BYTES     | 1048576                        | Maximum accepted request body size in bytes (1 MB)      |
 | NATS_CONNECT_TIMEOUT  | 5.0                            | NATS connection timeout in seconds                      |
 | NATS_PUBLISH_TIMEOUT  | 5.0                            | NATS publish timeout in seconds                         |

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -42,6 +42,7 @@ class Settings(BaseSettings):
     agamemnon_url: str = ""
     agamemnon_api_key: str = ""
     agamemnon_timeout: float = Field(default=10.0, gt=0)
+    admin_api_key: str = ""
     shutdown_timeout: float = Field(default=10.0, gt=0)
     max_payload_bytes: int = 1_048_576
     enable_dead_letter: bool = True

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -205,6 +205,29 @@ async def _http_exception_handler_with_request_id(
 SettingsDep = Annotated[Settings, Depends(get_settings)]
 
 
+async def require_admin_key(
+    request: Request,
+    settings: SettingsDep,
+) -> None:
+    """Dependency that enforces Bearer token auth for admin endpoints."""
+    if not settings.admin_api_key:
+        raise HTTPException(status_code=403, detail="ADMIN_API_KEY is not configured")
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401,
+            detail="Missing or invalid Authorization header",
+            headers={"WWW-Authenticate": 'Bearer realm="hermes"'},
+        )
+    provided = auth.removeprefix("Bearer ")
+    if not hmac.compare_digest(provided, settings.admin_api_key):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid admin API key",
+            headers={"WWW-Authenticate": 'Bearer realm="hermes"'},
+        )
+
+
 # ---------------------------------------------------------------------------
 # Middleware
 # ---------------------------------------------------------------------------
@@ -404,6 +427,7 @@ async def metrics() -> Response:
 async def dead_letters(
     limit: int | None = None,
     offset: int = 0,
+    _: None = Depends(require_admin_key),
 ) -> DeadLettersResponse:
     """Return the in-memory dead-letter queue with optional pagination.
 
@@ -419,7 +443,7 @@ async def dead_letters(
 
 
 @app.delete("/dead-letters", status_code=status.HTTP_200_OK)
-async def drain_dead_letters() -> dict[str, int]:
+async def drain_dead_letters(_: None = Depends(require_admin_key)) -> dict[str, int]:
     """Drain (clear) the in-memory dead-letter queue and return the count of drained items."""
     publisher: Publisher = app.state.publisher
     drained = publisher.drain_dead_letters()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -11,6 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 _TEST_SECRET = "test-webhook-secret-padding-xxxxx"
+_TEST_ADMIN_KEY = "test-admin-key"
 
 
 def _sign(body: bytes) -> str:
@@ -18,8 +19,9 @@ def _sign(body: bytes) -> str:
 
 
 def _build_client(dead_letters: list | None = None) -> TestClient:
-    from hermes.server import app
+    from hermes.config import get_settings
     from hermes.publisher import Publisher
+    from hermes.server import app
 
     mock_publisher = MagicMock(spec=Publisher)
     mock_publisher.is_connected = True
@@ -28,6 +30,7 @@ def _build_client(dead_letters: list | None = None) -> TestClient:
     mock_publisher.dead_letters = dead_letters if dead_letters is not None else []
 
     app.state.publisher = mock_publisher
+    get_settings().admin_api_key = _TEST_ADMIN_KEY
     return TestClient(app, raise_server_exceptions=True)
 
 
@@ -54,15 +57,18 @@ class TestMetricsEndpoint:
         assert "hermes_active_subjects_count" in text
 
 
+_AUTH_HEADER = {"Authorization": f"Bearer {_TEST_ADMIN_KEY}"}
+
+
 class TestDeadLettersEndpoint:
     def test_dead_letters_returns_200(self) -> None:
         client = _build_client()
-        response = client.get("/dead-letters")
+        response = client.get("/dead-letters", headers=_AUTH_HEADER)
         assert response.status_code == 200
 
     def test_dead_letters_returns_list_when_empty(self) -> None:
         client = _build_client()
-        body = client.get("/dead-letters").json()
+        body = client.get("/dead-letters", headers=_AUTH_HEADER).json()
         assert "items" in body
         assert isinstance(body["items"], list)
         assert body["items"] == []
@@ -70,7 +76,7 @@ class TestDeadLettersEndpoint:
     def test_dead_letters_returns_entries(self) -> None:
         entries = [{"event": "unknown.event", "data": {"foo": "bar"}}]
         client = _build_client(dead_letters=entries)
-        body = client.get("/dead-letters").json()
+        body = client.get("/dead-letters", headers=_AUTH_HEADER).json()
         assert body["items"] == entries
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -676,10 +676,16 @@ class TestWildcardInjectionSanitization:
         assert ">" not in published_subjects[0]
 
 
+_ADMIN_KEY = "test-admin-key"
+
+
 class TestDeadLettersGetEndpoint:
     """Tests for GET /dead-letters with pagination (issues #108)."""
 
-    def _build_client_with_dead_letters(self, items: list[dict]) -> TestClient:
+    def _build_client_with_dead_letters(
+        self, items: list[dict], admin_api_key: str = _ADMIN_KEY
+    ) -> TestClient:
+        from hermes.config import get_settings
         from hermes.publisher import Publisher
         from hermes.server import app
 
@@ -689,16 +695,17 @@ class TestDeadLettersGetEndpoint:
         mock_publisher.publish = AsyncMock()
         mock_publisher.dead_letters = items
         app.state.publisher = mock_publisher
+        get_settings().admin_api_key = admin_api_key
         return TestClient(app, raise_server_exceptions=True)
 
     def test_dead_letters_returns_200(self) -> None:
         client = self._build_client_with_dead_letters([])
-        resp = client.get("/dead-letters")
+        resp = client.get("/dead-letters", headers={"Authorization": f"Bearer {_ADMIN_KEY}"})
         assert resp.status_code == 200
 
     def test_dead_letters_empty_queue_structure(self) -> None:
         client = self._build_client_with_dead_letters([])
-        body = client.get("/dead-letters").json()
+        body = client.get("/dead-letters", headers={"Authorization": f"Bearer {_ADMIN_KEY}"}).json()
         assert body["total"] == 0
         assert body["offset"] == 0
         assert body["limit"] is None
@@ -707,7 +714,7 @@ class TestDeadLettersGetEndpoint:
     def test_dead_letters_returns_all_by_default(self) -> None:
         items = [{"event": f"evt.{i}", "subject": f"hi.deadletter.evt-{i}"} for i in range(5)]
         client = self._build_client_with_dead_letters(items)
-        body = client.get("/dead-letters").json()
+        body = client.get("/dead-letters", headers={"Authorization": f"Bearer {_ADMIN_KEY}"}).json()
         assert body["total"] == 5
         assert len(body["items"]) == 5
         assert body["limit"] is None
@@ -715,7 +722,7 @@ class TestDeadLettersGetEndpoint:
     def test_dead_letters_limit_param(self) -> None:
         items = [{"event": f"evt.{i}", "subject": f"hi.deadletter.evt-{i}"} for i in range(10)]
         client = self._build_client_with_dead_letters(items)
-        body = client.get("/dead-letters?limit=3").json()
+        body = client.get("/dead-letters?limit=3", headers={"Authorization": f"Bearer {_ADMIN_KEY}"}).json()
         assert body["total"] == 10
         assert len(body["items"]) == 3
         assert body["limit"] == 3
@@ -724,7 +731,7 @@ class TestDeadLettersGetEndpoint:
     def test_dead_letters_offset_param(self) -> None:
         items = [{"event": f"evt.{i}", "subject": f"hi.deadletter.evt-{i}"} for i in range(10)]
         client = self._build_client_with_dead_letters(items)
-        body = client.get("/dead-letters?offset=5").json()
+        body = client.get("/dead-letters?offset=5", headers={"Authorization": f"Bearer {_ADMIN_KEY}"}).json()
         assert body["total"] == 10
         assert len(body["items"]) == 5
         assert body["offset"] == 5
@@ -733,7 +740,7 @@ class TestDeadLettersGetEndpoint:
     def test_dead_letters_limit_and_offset(self) -> None:
         items = [{"event": f"evt.{i}", "subject": f"hi.deadletter.evt-{i}"} for i in range(20)]
         client = self._build_client_with_dead_letters(items)
-        body = client.get("/dead-letters?offset=5&limit=10").json()
+        body = client.get("/dead-letters?offset=5&limit=10", headers={"Authorization": f"Bearer {_ADMIN_KEY}"}).json()
         assert body["total"] == 20
         assert body["offset"] == 5
         assert body["limit"] == 10
@@ -744,22 +751,49 @@ class TestDeadLettersGetEndpoint:
     def test_dead_letters_offset_beyond_total_returns_empty_items(self) -> None:
         items = [{"event": "evt.0", "subject": "hi.deadletter.evt-0"}]
         client = self._build_client_with_dead_letters(items)
-        body = client.get("/dead-letters?offset=100").json()
+        body = client.get("/dead-letters?offset=100", headers={"Authorization": f"Bearer {_ADMIN_KEY}"}).json()
         assert body["total"] == 1
         assert body["items"] == []
 
     def test_dead_letters_limit_larger_than_total(self) -> None:
         items = [{"event": "evt.0", "subject": "hi.deadletter.evt-0"}]
         client = self._build_client_with_dead_letters(items)
-        body = client.get("/dead-letters?limit=100").json()
+        body = client.get("/dead-letters?limit=100", headers={"Authorization": f"Bearer {_ADMIN_KEY}"}).json()
         assert body["total"] == 1
         assert len(body["items"]) == 1
+
+    def test_get_dead_letters_no_key_configured_returns_403(self) -> None:
+        client = self._build_client_with_dead_letters([], admin_api_key="")
+        resp = client.get("/dead-letters", headers={"Authorization": f"Bearer {_ADMIN_KEY}"})
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "ADMIN_API_KEY is not configured"
+
+    def test_get_dead_letters_missing_auth_header_returns_401(self) -> None:
+        client = self._build_client_with_dead_letters([])
+        resp = client.get("/dead-letters")
+        assert resp.status_code == 401
+        assert "WWW-Authenticate" in resp.headers
+        assert resp.headers["WWW-Authenticate"] == 'Bearer realm="hermes"'
+
+    def test_get_dead_letters_wrong_key_returns_401(self) -> None:
+        client = self._build_client_with_dead_letters([])
+        resp = client.get("/dead-letters", headers={"Authorization": "Bearer wrong-key"})
+        assert resp.status_code == 401
+        assert "WWW-Authenticate" in resp.headers
+
+    def test_get_dead_letters_malformed_auth_header_returns_401(self) -> None:
+        client = self._build_client_with_dead_letters([])
+        resp = client.get("/dead-letters", headers={"Authorization": "NotBearer token"})
+        assert resp.status_code == 401
 
 
 class TestDeadLettersDeleteEndpoint:
     """Tests for DELETE /dead-letters (issue #110)."""
 
-    def _build_client_with_drain(self, drained_count: int) -> TestClient:
+    def _build_client_with_drain(
+        self, drained_count: int, admin_api_key: str = _ADMIN_KEY
+    ) -> TestClient:
+        from hermes.config import get_settings
         from hermes.publisher import Publisher
         from hermes.server import app
 
@@ -769,24 +803,26 @@ class TestDeadLettersDeleteEndpoint:
         mock_publisher.publish = AsyncMock()
         mock_publisher.drain_dead_letters = MagicMock(return_value=drained_count)
         app.state.publisher = mock_publisher
+        get_settings().admin_api_key = admin_api_key
         return TestClient(app, raise_server_exceptions=True)
 
     def test_delete_dead_letters_returns_200(self) -> None:
         client = self._build_client_with_drain(0)
-        resp = client.delete("/dead-letters")
+        resp = client.delete("/dead-letters", headers={"Authorization": f"Bearer {_ADMIN_KEY}"})
         assert resp.status_code == 200
 
     def test_delete_dead_letters_returns_drained_count_zero(self) -> None:
         client = self._build_client_with_drain(0)
-        body = client.delete("/dead-letters").json()
+        body = client.delete("/dead-letters", headers={"Authorization": f"Bearer {_ADMIN_KEY}"}).json()
         assert body["drained"] == 0
 
     def test_delete_dead_letters_returns_drained_count_nonzero(self) -> None:
         client = self._build_client_with_drain(42)
-        body = client.delete("/dead-letters").json()
+        body = client.delete("/dead-letters", headers={"Authorization": f"Bearer {_ADMIN_KEY}"}).json()
         assert body["drained"] == 42
 
     def test_delete_dead_letters_calls_drain(self) -> None:
+        from hermes.config import get_settings
         from hermes.publisher import Publisher
         from hermes.server import app
 
@@ -796,9 +832,34 @@ class TestDeadLettersDeleteEndpoint:
         mock_publisher.publish = AsyncMock()
         mock_publisher.drain_dead_letters = MagicMock(return_value=5)
         app.state.publisher = mock_publisher
+        get_settings().admin_api_key = _ADMIN_KEY
         client = TestClient(app, raise_server_exceptions=True)
-        client.delete("/dead-letters")
+        client.delete("/dead-letters", headers={"Authorization": f"Bearer {_ADMIN_KEY}"})
         mock_publisher.drain_dead_letters.assert_called_once()
+
+    def test_delete_dead_letters_no_key_configured_returns_403(self) -> None:
+        client = self._build_client_with_drain(0, admin_api_key="")
+        resp = client.delete("/dead-letters", headers={"Authorization": f"Bearer {_ADMIN_KEY}"})
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "ADMIN_API_KEY is not configured"
+
+    def test_delete_dead_letters_missing_auth_header_returns_401(self) -> None:
+        client = self._build_client_with_drain(0)
+        resp = client.delete("/dead-letters")
+        assert resp.status_code == 401
+        assert "WWW-Authenticate" in resp.headers
+        assert resp.headers["WWW-Authenticate"] == 'Bearer realm="hermes"'
+
+    def test_delete_dead_letters_wrong_key_returns_401(self) -> None:
+        client = self._build_client_with_drain(0)
+        resp = client.delete("/dead-letters", headers={"Authorization": "Bearer wrong-key"})
+        assert resp.status_code == 401
+        assert "WWW-Authenticate" in resp.headers
+
+    def test_delete_dead_letters_malformed_auth_header_returns_401(self) -> None:
+        client = self._build_client_with_drain(0)
+        resp = client.delete("/dead-letters", headers={"Authorization": "Token abc123"})
+        assert resp.status_code == 401
 
 
 class TestPublisherDrainDeadLetters:


### PR DESCRIPTION
## Summary

- Adds `ADMIN_API_KEY` config field to `Settings` in `config.py`
- Adds `require_admin_key` FastAPI dependency in `server.py` using `hmac.compare_digest` for timing-safe comparison
- Wires auth into `GET /dead-letters` and `DELETE /dead-letters` — returns 403 when unconfigured, 401 with `WWW-Authenticate: Bearer realm="hermes"` for missing/invalid tokens
- Updates `CLAUDE.md` configuration table to document `ADMIN_API_KEY`
- Adds 8 new auth tests (4 per endpoint) covering 403/401/200 cases; updates all existing dead-letter tests in `test_webhook.py` and `test_metrics.py` to supply the Bearer token

## Test plan

- [x] All 374 tests pass (`pixi run python -m pytest tests/ -v`)
- [x] Lint clean (`pixi run ruff check src tests`)
- [x] `GET /dead-letters` with no `ADMIN_API_KEY` set → 403
- [x] `GET /dead-letters` with key configured but no header → 401 + `WWW-Authenticate` header
- [x] `GET /dead-letters` with wrong key → 401
- [x] `GET /dead-letters` with correct key → 200
- [x] Same four cases verified for `DELETE /dead-letters`

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)