### PR TITLE
docs: fix /webhook status code in README from 200 to 202

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Hermes exposes several endpoints for webhooks, health checks, and observability:
 
 | Endpoint         | Method | Description                                                                         | Status Code |
 |------------------|--------|-------------------------------------------------------------------------------------| ----------- |
-| `/webhook`       | POST   | Accept and validate incoming webhooks; publishes to NATS                            | 200 / 401 / 422 |
+| `/webhook`       | POST   | Accept and validate incoming webhooks; publishes to NATS                            | 202 / 401 / 422 |
 | `/health`        | GET    | Service health check; returns NATS connection status                                | 200 / 503   |
 | `/ready`         | GET    | Readiness probe for orchestrators (Kubernetes, Docker Compose)                      | 200 / 503   |
 | `/metrics`       | GET    | Prometheus metrics (counter, gauge, histogram)                                      | 200         |


### PR DESCRIPTION
## Summary

- Corrects the `/webhook` endpoint status code in the README endpoint table from `200` to `202 Accepted`, matching the actual implementation at `server.py:312`.

## Test plan

- [ ] No code changes; docs-only fix
- [ ] All existing tests pass (`366 passed`)

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)