### PR TITLE
fix(server): make /subjects rate limit configurable via SUBJECTS_RATE_LIMIT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ Every message published to NATS JetStream includes a `schema_version` integer fi
 | AGAMEMNON_API_KEY     |                                | API key for authenticating with Agamemnon               |
 | AGAMEMNON_TIMEOUT     | 10.0                           | Agamemnon API call timeout in seconds                   |
 | SHUTDOWN_TIMEOUT      | 10.0                           | Graceful shutdown timeout in seconds                    |
+| WEBHOOK_RATE_LIMIT    | 60/minute                      | Rate limit for POST /webhook endpoint                   |
+| SUBJECTS_RATE_LIMIT   | 60/minute                      | Rate limit for GET /subjects endpoint                   |
 
 Configure external services to POST to `http://<hermes-host>:<HERMES_PORT>/webhook`.
 

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -49,6 +49,7 @@ class Settings(BaseSettings):
     active_subjects_max: int = 1000
     webhook_rate_limit: str = "60/minute"
     webhook_rate_limit_key: str = "ip"
+    subjects_rate_limit: str = "60/minute"
     publish_retries: int = Field(default=3, ge=1)
     publish_retry_base_delay: float = Field(default=0.1, gt=0)
 
@@ -82,11 +83,11 @@ class Settings(BaseSettings):
             return v
         raise ValueError(f"HERMES_HOST must be a valid IP or hostname, got: {v!r}")
 
-    @field_validator("webhook_rate_limit")
+    @field_validator("webhook_rate_limit", "subjects_rate_limit")
     @classmethod
     def _validate_rate_limit(cls, v: str) -> str:
         if not re.match(r"^\d+\s*/\s*(second|minute|hour|day)$", v):
-            raise ValueError(f"WEBHOOK_RATE_LIMIT must be like '100/minute', got: {v!r}")
+            raise ValueError(f"Rate limit must be like '100/minute', got: {v!r}")
         return v
 
     @field_validator("webhook_secret")

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -383,7 +383,7 @@ async def receive_webhook(request: Request, settings: SettingsDep) -> WebhookAcc
     "/subjects",
     response_model=SubjectsResponse,
 )
-@limiter.limit("60/minute")
+@limiter.limit(lambda: get_settings().subjects_rate_limit)
 async def list_subjects(request: Request, settings: SettingsDep) -> SubjectsResponse:
     """Return the list of NATS subjects that have been published to."""
     publisher: Publisher = app.state.publisher

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -194,3 +194,53 @@ class TestWebhookRateLimit:
 
         with pytest.raises(ValidationError):
             Settings()
+
+
+class TestSubjectsRateLimit:
+    def test_default_subjects_rate_limit_is_valid(self) -> None:
+        from hermes.config import Settings
+
+        s = Settings(_env_file=None)
+        assert s.subjects_rate_limit == "60/minute"
+
+    def test_subjects_rate_limit_rejects_invalid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUBJECTS_RATE_LIMIT", "not-valid")
+        from hermes.config import Settings
+
+        with pytest.raises(ValidationError):
+            Settings()
+
+    def test_subjects_rate_limit_accepts_valid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUBJECTS_RATE_LIMIT", "50/minute")
+        from hermes.config import Settings
+
+        s = Settings()
+        assert s.subjects_rate_limit == "50/minute"
+
+    def test_subjects_rate_limit_accepts_per_second(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUBJECTS_RATE_LIMIT", "10/second")
+        from hermes.config import Settings
+
+        s = Settings()
+        assert s.subjects_rate_limit == "10/second"
+
+    def test_subjects_rate_limit_accepts_per_hour(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUBJECTS_RATE_LIMIT", "1000/hour")
+        from hermes.config import Settings
+
+        s = Settings()
+        assert s.subjects_rate_limit == "1000/hour"
+
+    def test_subjects_rate_limit_rejects_missing_period(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUBJECTS_RATE_LIMIT", "100")
+        from hermes.config import Settings
+
+        with pytest.raises(ValidationError):
+            Settings()
+
+    def test_subjects_rate_limit_rejects_invalid_period(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUBJECTS_RATE_LIMIT", "100/week")
+        from hermes.config import Settings
+
+        with pytest.raises(ValidationError):
+            Settings()


### PR DESCRIPTION
## Summary

- Add `subjects_rate_limit: str = "60/minute"` field to `Settings` in `src/hermes/config.py`
- Extend `_validate_rate_limit` field validator to cover both `webhook_rate_limit` and `subjects_rate_limit` (generalised error message)
- Replace hardcoded `@limiter.limit("60/minute")` on the `/subjects` endpoint with `@limiter.limit(lambda: get_settings().subjects_rate_limit)`, matching the existing `/webhook` pattern
- Document `WEBHOOK_RATE_LIMIT` and `SUBJECTS_RATE_LIMIT` in the configuration table in `CLAUDE.md`

## Test plan

- [ ] `TestSubjectsRateLimit` class added to `tests/test_config.py` with 7 cases mirroring `TestWebhookRateLimit`
- [ ] All 373 tests pass (`pixi run python -m pytest tests/ -v`)
- [ ] No ruff lint errors

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)