### PR TITLE
feat(webhook): add request_id to 202 response body

### DIFF
--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -77,6 +77,7 @@ class WebhookAcceptedResponse(BaseModel):
 
     status: str
     event: str
+    request_id: str
 
 
 class SubjectsResponse(BaseModel):

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -376,7 +376,7 @@ async def receive_webhook(request: Request, settings: SettingsDep) -> WebhookAcc
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Unknown event type: {exc}",
         ) from exc
-    return WebhookAcceptedResponse(status="accepted", event=payload.event)
+    return WebhookAcceptedResponse(status="accepted", event=payload.event, request_id=request_id)
 
 
 @app.get(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,9 +6,11 @@ import sys
 import os
 from datetime import datetime, timezone
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from hermes.models import WebhookPayload
+from hermes.models import WebhookAcceptedResponse, WebhookPayload
 
 
 class TestWebhookPayloadTimestamp:
@@ -20,6 +22,23 @@ class TestWebhookPayloadTimestamp:
         ts = datetime(2026, 3, 15, tzinfo=timezone.utc)
         p = WebhookPayload(event="x", data={}, timestamp=ts)
         assert p.timestamp == ts
+
+
+class TestWebhookAcceptedResponse:
+    def test_requires_request_id(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            WebhookAcceptedResponse(status="accepted", event="agent.created")
+
+    def test_model_dump_includes_request_id(self) -> None:
+        r = WebhookAcceptedResponse(
+            status="accepted", event="agent.created", request_id="test-id-123"
+        )
+        dumped = r.model_dump()
+        assert dumped["request_id"] == "test-id-123"
+        assert dumped["status"] == "accepted"
+        assert dumped["event"] == "agent.created"
 
 
 class TestPackageExports:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -214,6 +214,12 @@ class TestWebhookEndpoint:
             },
         )
         assert response.status_code == 202
+        body = response.json()
+        assert body["status"] == "accepted"
+        assert body["event"] == "agent.created"
+        assert "request_id" in body
+        assert isinstance(body["request_id"], str)
+        assert len(body["request_id"]) > 0
 
     def test_webhook_invalid_payload_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
@@ -401,6 +407,7 @@ class TestRequestIDMiddleware:
             },
         )
         assert response.headers.get("X-Request-ID") == valid_id
+        assert response.json()["request_id"] == valid_id
 
     def test_invalid_chars_in_request_id_are_replaced_with_uuid(self) -> None:
         import uuid as uuid_mod


### PR DESCRIPTION
## Summary

- Added `request_id: str` field to `WebhookAcceptedResponse` in `models.py`
- Pass `request_id` (from `request.state.request_id`) when constructing the response in `server.py`
- Clients can now read the correlation ID from the JSON body without inspecting the `X-Request-ID` response header

## Test plan

- Updated `tests/test_webhook.py::TestWebhookEndpoint::test_valid_payload_returns_202` to assert `request_id` is present in the response body as a non-empty string
- Updated `tests/test_webhook.py::TestWebhookEndpoint::test_valid_uuid_request_id_is_passed_through` to assert body `request_id` matches the header value
- Added `tests/test_models.py::TestWebhookAcceptedResponse` with:
  - `test_requires_request_id` — `ValidationError` if field is missing
  - `test_model_dump_includes_request_id` — field appears in `.model_dump()`
- All 368 tests pass

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)