### PR TITLE
docs: reconcile default branch name to 'main'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: no-commit-to-branch
-        args: [--branch, master]
+        args: [--branch, main]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.15.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,11 +76,11 @@ Before starting work:
 
 ### 2. Branch Naming Convention
 
-Create a feature branch from `master`:
+Create a feature branch from `main`:
 
 ```bash
-git checkout master
-git pull origin master
+git checkout main
+git pull origin main
 git checkout -b <issue-number>-<short-description>
 
 # Examples:
@@ -181,7 +181,7 @@ just register-webhook
 ### Before You Start
 
 1. Ensure an issue exists for your work
-2. Create a branch from `master` using the naming convention
+2. Create a branch from `main` using the naming convention
 3. Implement your changes
 4. Run `just test` and `just lint` to verify
 
@@ -224,18 +224,18 @@ gh pr create --title "[Type] Brief description" --body "Closes #<issue-number>"
 
 | Branch type | Naming convention | Base branch | Notes |
 |-------------|-------------------|-------------|-------|
-| Default | `master` | — | Protected; never push directly |
-| Feature / fix | `<issue>-<slug>` | `master` | e.g. `44-planning-templates` |
-| Release | `release/v<x.y.z>` | `master` | Created from `master` before tagging |
+| Default | `main` | — | Protected; never push directly |
+| Feature / fix | `<issue>-<slug>` | `main` | e.g. `44-planning-templates` |
+| Release | `release/v<x.y.z>` | `main` | Created from `main` before tagging |
 
 **Merge strategy:**
 
 - Single-concern PRs: squash-and-merge
 - Multi-commit story-arc PRs: rebase-and-merge
 
-### Never Push Directly to Master
+### Never Push Directly to Main
 
-The `master` branch is protected. All changes must go through pull requests.
+The `main` branch is protected. All changes must go through pull requests.
 
 ## Code Review
 


### PR DESCRIPTION
## Summary

- Replaced all 8 occurrences of `master` in `CONTRIBUTING.md` with `main` (branch examples, branching strategy table, section heading, and protection notice)
- Updated `.pre-commit-config.yaml` `no-commit-to-branch` hook from `--branch, master` to `--branch, main`

All three sources now consistently refer to `main` as the default/protected branch, matching the CI/CD workflows which were already correct.

## Test plan

- [x] `grep -n "master" CONTRIBUTING.md .pre-commit-config.yaml` returns no output
- [x] CI workflows (`ci.yml`, `publish.yml`, `security.yml`, `_required.yml`) already target `main` — unchanged
- [x] YAML in `.pre-commit-config.yaml` is syntactically valid (no structural changes, only value change)
- [x] Markdown tables in `CONTRIBUTING.md` remain properly formatted

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)