### PR TITLE
fix(packaging): add [project.dependencies] to pyproject.toml

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -319,7 +319,17 @@ packages:
 - pypi: ./
   name: hermes
   version: 0.1.0
-  sha256: fd906a0e0d036b2d0809894088b95b6b24f8601c9d9a881223736f05113a5e26
+  sha256: 6676febc3f248c313df16c311d64a245b70ad8002b1e433a010c22af72317f6a
+  requires_dist:
+  - fastapi>=0.115,<1
+  - uvicorn[standard]>=0.30,<1
+  - nats-py>=2.9,<3
+  - pydantic>=2.0,<3
+  - pydantic-settings>=2.0,<3
+  - httpx>=0.27,<1
+  - slowapi>=0.1,<1
+  - limits>=3.0,<4
+  - prometheus-client>=0.20,<1
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
   name: httpcore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,17 @@ version = "0.1.0"
 description = "Lightweight service bridging external webhooks to NATS JetStream"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.115,<1",
+    "uvicorn[standard]>=0.30,<1",
+    "nats-py>=2.9,<3",
+    "pydantic>=2.0,<3",
+    "pydantic-settings>=2.0,<3",
+    "httpx>=0.27,<1",
+    "slowapi>=0.1,<1",
+    "limits>=3.0,<4",
+    "prometheus-client>=0.20,<1",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",


### PR DESCRIPTION
## Summary

- Adds `[project.dependencies]` section to `pyproject.toml` with version-pinned ranges matching `pixi.toml`
- Fixes packaging gap where `pip install .` previously performed unconstrained transitive dependency resolution
- `pixi.lock` auto-updated to reflect the new declared dependency metadata

## Test plan

- [ ] All 327 existing unit tests pass (`pixi run python -m pytest tests/ -v -m "not integration"`)
- [ ] `pip install .` now resolves within bounded version ranges matching the pixi environment

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)