### PR TITLE
fix(tests): deflake reconnect counter assertions

### DIFF
--- a/tests/test_publisher_reconnect.py
+++ b/tests/test_publisher_reconnect.py
@@ -138,17 +138,18 @@ class TestReconnectLoopRetriesOnLostConnection:
         with patch("nats.connect", side_effect=fake_connect):
             await pub.connect("nats://localhost:4222")
 
-        initial_count = pub.reconnect_count
+            initial_count = pub.reconnect_count
 
-        # Simulate connection loss
-        pub._nc = _make_mock_nc(closed=True)
+            # Simulate connection loss
+            pub._nc = _make_mock_nc(closed=True)
 
-        loop_task = asyncio.ensure_future(
-            pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
-        )
-        await asyncio.sleep(0.12)
-        pub._stop_event.set()
-        await loop_task
+            pub._stop_event = asyncio.Event()
+            loop_task = asyncio.ensure_future(
+                pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
+            )
+            await asyncio.sleep(0.12)
+            pub._stop_event.set()
+            await loop_task
 
         assert pub.reconnect_count > initial_count
 
@@ -193,16 +194,17 @@ class TestReconnectLoopRetriesOnLostConnection:
         with patch("nats.connect", side_effect=fake_connect):
             await pub.connect("nats://localhost:4222")
 
-        before = NATS_RECONNECTS.labels(result="success")._value.get()
+            before = NATS_RECONNECTS.labels(result="success")._value.get()
 
-        pub._nc = _make_mock_nc(closed=True)
+            pub._nc = _make_mock_nc(closed=True)
 
-        loop_task = asyncio.ensure_future(
-            pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
-        )
-        await asyncio.sleep(0.12)
-        pub._stop_event.set()
-        await loop_task
+            pub._stop_event = asyncio.Event()
+            loop_task = asyncio.ensure_future(
+                pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
+            )
+            await asyncio.sleep(0.12)
+            pub._stop_event.set()
+            await loop_task
 
         after = NATS_RECONNECTS.labels(result="success")._value.get()
         assert after > before


### PR DESCRIPTION
Fixes flaky reconnect tests blocking main and the entire PR backlog.

The two failing tests (`test_reconnect_count_increments_on_success` and `test_nats_reconnects_metric_incremented_on_success`) had a patch-context scope bug: they called `pub.connect()` inside `with patch("nats.connect", ...)` to set up the mock, then exited the `with` block before starting the `_reconnect_loop` future. Once the context manager exited, the `nats.connect` mock was torn down. When the background reconnect loop subsequently called `_connect_internal`, it hit the **real** `nats.connect` (which immediately fails with no NATS server running), so `reconnect_count` was never incremented and `NATS_RECONNECTS` was never ticked — causing the assertions to flake 100% of the time, not just occasionally. The fix moves the `_stop_event` reset, `asyncio.ensure_future`, sleep, and stop-event set *inside* the patch context so the mock remains live for the full reconnect loop iteration.

Verified: 376 unit tests pass (96.97% coverage), target class passes 5/5 consecutive runs.