### PR TITLE
fix(tests): deflake integration schema_version tests with flush() before publish

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -537,6 +537,7 @@ class TestPublishSchemaVersion:
             received.append(m)
 
         sub = await nats_client.subscribe("hi.agents.schema-host.schema-agent.created", cb=_cb)
+        await nats_client.flush()  # ensure server has ack'd the subscription before we publish
 
         payload = WebhookPayload(
             event="agent.created",
@@ -563,6 +564,7 @@ class TestPublishSchemaVersion:
             received.append(m)
 
         sub = await nats_client.subscribe("hi.tasks.team-sv.task-sv.updated", cb=_cb)
+        await nats_client.flush()  # ensure server has ack'd the subscription before we publish
 
         payload = WebhookPayload(
             event="task.updated",


### PR DESCRIPTION
## Summary

- **RC**: Missing `await nats_client.flush()` between `subscribe()` and `publisher.publish()` in both `TestPublishSchemaVersion` tests — a subscribe-before-publish race where the NATS server hadn't registered the subscription by the time the message arrived, so `received` was empty (`len([]) == 0`).
- **Fix**: Added `await nats_client.flush()` after each `nats_client.subscribe()` call in `test_publish_includes_schema_version` and `test_publish_schema_version_present_in_task_event`, matching the pattern already used in `test_publish_agent_event_delivers_message` and `test_publish_task_event_delivers_message`.
- **Production code**: Unchanged — `schema_version: 1` is already correctly included in every published message.

The test was added as part of Issue #100 but was authored without the flush guard that all other similar tests carry.

## Test plan

- [x] Ran `pytest tests/test_integration.py::TestPublishSchemaVersion -v --no-cov` locally against a live NATS server — both tests pass (2 passed, 0 failed)
- [x] Ran `pytest tests/test_integration.py::TestPublishSchemaVersion::test_publish_includes_schema_version -x -v` in isolation — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)