### PR TITLE
fix: consolidate all 3 CI blockers (unit-tests, integration-tests, markdownlint)

### DIFF
--- a/.github/ISSUE_TEMPLATE/tech_debt.md
+++ b/.github/ISSUE_TEMPLATE/tech_debt.md
@@ -11,6 +11,7 @@ labels: [tech-debt, chore]
 <!-- File path(s) and line number(s) where the debt lives, if applicable. -->
 
 ## Deliverables
+
 - [ ] <!-- specific sub-task 1 -->
 - [ ] <!-- specific sub-task 2 -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ bridge in the HomericIntelligence mesh. It covers three audiences:
 |-------------------|------------------------------------|
 | Service name      | `hermes`                           |
 | Default port      | `8080` (env: `HERMES_PORT`)        |
-| Default bind      | `127.0.0.1` (env: `HERMES_HOST`)  |
+| Default bind      | `127.0.0.1` (env: `HERMES_HOST`)   |
 | Production bind   | `0.0.0.0`                          |
 | Docker image      | `hermes` (see `docker-compose.yml`)|
 
@@ -63,11 +63,11 @@ POST {HERMES_PUBLIC_URL}/webhook
 }
 ```
 
-| Field       | Type            | Required | Notes                                               |
-|-------------|-----------------|----------|-----------------------------------------------------|
-| `event`     | string          | yes      | Must be a recognised event type (see below)         |
-| `data`      | object          | yes      | Arbitrary payload; routing fields pulled from here  |
-| `timestamp` | ISO 8601 string | yes      | Must include timezone offset; naive timestamps rejected |
+| Field       | Type            | Required | Notes                                                       |
+|-------------|-----------------|----------|-------------------------------------------------------------|
+| `event`     | string          | yes      | Must be a recognised event type (see below)                 |
+| `data`      | object          | yes      | Arbitrary payload; routing fields pulled from here          |
+| `timestamp` | ISO 8601 string | yes      | Must include timezone offset; naive timestamps rejected     |
 | `signature` | string          | no       | HMAC-SHA256 hex digest; required if `WEBHOOK_SECRET` is set |
 
 ### HMAC Validation
@@ -172,13 +172,13 @@ Every NATS message body is a UTF-8 JSON object:
 }
 ```
 
-| Field            | Type   | Notes                                               |
-|------------------|--------|-----------------------------------------------------|
-| `schema_version` | int    | Current value: `1`. Check before deserializing `data`. |
-| `event`          | string | Original event type string from the webhook         |
-| `data`           | object | Original webhook `data` payload verbatim            |
-| `timestamp`      | string | Timezone-aware ISO 8601                             |
-| `request_id`     | string | HTTP request correlation ID; empty string if absent |
+| Field            | Type   | Notes                                                   |
+|------------------|--------|---------------------------------------------------------|
+| `schema_version` | int    | Current value: `1`. Check before deserializing `data`.  |
+| `event`          | string | Original event type string from the webhook             |
+| `data`           | object | Original webhook `data` payload verbatim                |
+| `timestamp`      | string | Timezone-aware ISO 8601                                 |
+| `request_id`     | string | HTTP request correlation ID; empty string if absent     |
 
 ### Consumer Guidance
 
@@ -192,9 +192,9 @@ Every NATS message body is a UTF-8 JSON object:
 
 Hermes retries transient NATS publish failures with exponential backoff:
 
-| Setting                    | Default | Description                                    |
-|----------------------------|---------|------------------------------------------------|
-| `PUBLISH_RETRIES`          | 3       | Total publish attempts before giving up        |
+| Setting                    | Default | Description                                                     |
+|----------------------------|---------|-----------------------------------------------------------------|
+| `PUBLISH_RETRIES`          | 3       | Total publish attempts before giving up                         |
 | `PUBLISH_RETRY_BASE_DELAY` | 0.1 s   | Base delay; actual = `base × 2^attempt` ± jitter, capped at 2 s |
 
 Retryable errors: `TimeoutError`, `NoRespondersError`, `DrainTimeoutError`,
@@ -207,11 +207,11 @@ and the message is dead-lettered (if `ENABLE_DEAD_LETTER=true`).
 
 These services are verified in `CLAUDE.md` and the repository architecture:
 
-| Service      | Role                  | Subscribes to                          | Notes                                         |
-|--------------|-----------------------|----------------------------------------|-----------------------------------------------|
-| **Argus**    | Observability         | `hi.agents.>`, `hi.tasks.>`            | Monitoring; no action taken                   |
+| Service      | Role                  | Subscribes to                          | Notes                                          |
+|--------------|-----------------------|----------------------------------------|------------------------------------------------|
+| **Argus**    | Observability         | `hi.agents.>`, `hi.tasks.>`            | Monitoring; no action taken                    |
 | **Agamemnon**| Coordination          | External; Hermes calls it via HTTP     | `AGAMEMNON_URL` + `AGAMEMNON_API_KEY` required |
-| **Telemachy**| Workflow engine       | `hi.tasks.>`                           | Drives task workflows from task events        |
+| **Telemachy**| Workflow engine       | `hi.tasks.>`                           | Drives task workflows from task events         |
 
 Unknown event types go to `homeric-deadletter` for inspection and replay.
 
@@ -255,6 +255,7 @@ Rules for AI agents making code changes in this repository:
 4. **Pin dependency versions** in `pixi.toml` using `>=X.Y,<NEXT_MAJOR`. Never use `*`.
 
 5. **Run tests before committing:**
+
    ```bash
    just test          # pytest
    just lint          # ruff check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,8 @@ Unknown event types are routed to the `homeric-deadletter` NATS stream for inspe
 Every message published to NATS JetStream includes a `schema_version` integer field (from
 `HermesEventBase` in `src/hermes/models.py`).  The current version is **1**.
 
-| Field            | Type | Current value | Description                              |
-|------------------|------|---------------|------------------------------------------|
+| Field            | Type | Current value | Description                                         |
+|------------------|------|---------------|-----------------------------------------------------|
 | `schema_version` | int  | 1             | Wire format version; increments on breaking changes |
 
 **Consumer guidance:**
@@ -64,25 +64,25 @@ Every message published to NATS JetStream includes a `schema_version` integer fi
 
 ## Configuration
 
-| Variable              | Default                        | Description                                             |
-|-----------------------|--------------------------------|---------------------------------------------------------|
-| NATS_URL              | nats://localhost:4222          | NATS server URL                                         |
-| HERMES_HOST           | 127.0.0.1                     | Host/IP the server binds to                             |
-| HERMES_PORT           | 8080                           | Port Hermes listens on                                  |
-| HERMES_PUBLIC_URL     | `http://localhost:{HERMES_PORT}` | Externally-reachable base URL for the /webhook endpoint |
-| WEBHOOK_SECRET        |                                | HMAC secret for webhook validation (minimum 32 characters) |
-| MAX_PAYLOAD_BYTES     | 1048576                        | Maximum accepted request body size in bytes (1 MB)      |
-| NATS_CONNECT_TIMEOUT  | 5.0                            | NATS connection timeout in seconds                      |
-| NATS_PUBLISH_TIMEOUT  | 5.0                            | NATS publish timeout in seconds                         |
-| NATS_RECONNECT_INTERVAL | 5.0                          | Seconds between external reconnect attempts             |
-| NATS_RECONNECT_HARD_TIMEOUT | 5.0                      | Per-attempt hard timeout for external reconnect (seconds) |
-| AGAMEMNON_URL         |                                | Base URL of the Agamemnon coordination service          |
-| AGAMEMNON_API_KEY     |                                | API key for authenticating with Agamemnon               |
-| AGAMEMNON_TIMEOUT     | 10.0                           | Agamemnon API call timeout in seconds                   |
-| DEAD_LETTER_API_KEY   |                                | API key for GET/DELETE /dead-letters (min 32 chars; auth bypassed when unset) |
-| SHUTDOWN_TIMEOUT      | 10.0                           | Graceful shutdown timeout in seconds                    |
-| WEBHOOK_RATE_LIMIT    | 60/minute                      | Rate limit for POST /webhook endpoint                   |
-| SUBJECTS_RATE_LIMIT   | 60/minute                      | Rate limit for GET /subjects endpoint                   |
+| Variable                    | Default                          | Description                                                                   |
+|-----------------------------|----------------------------------|-------------------------------------------------------------------------------|
+| NATS_URL                    | nats://localhost:4222            | NATS server URL                                                               |
+| HERMES_HOST                 | 127.0.0.1                        | Host/IP the server binds to                                                   |
+| HERMES_PORT                 | 8080                             | Port Hermes listens on                                                        |
+| HERMES_PUBLIC_URL           | `http://localhost:{HERMES_PORT}` | Externally-reachable base URL for the /webhook endpoint                       |
+| WEBHOOK_SECRET              |                                  | HMAC secret for webhook validation (minimum 32 characters)                    |
+| MAX_PAYLOAD_BYTES           | 1048576                          | Maximum accepted request body size in bytes (1 MB)                            |
+| NATS_CONNECT_TIMEOUT        | 5.0                              | NATS connection timeout in seconds                                            |
+| NATS_PUBLISH_TIMEOUT        | 5.0                              | NATS publish timeout in seconds                                               |
+| NATS_RECONNECT_INTERVAL     | 5.0                              | Seconds between external reconnect attempts                                   |
+| NATS_RECONNECT_HARD_TIMEOUT | 5.0                              | Per-attempt hard timeout for external reconnect (seconds)                     |
+| AGAMEMNON_URL               |                                  | Base URL of the Agamemnon coordination service                                |
+| AGAMEMNON_API_KEY           |                                  | API key for authenticating with Agamemnon                                     |
+| AGAMEMNON_TIMEOUT           | 10.0                             | Agamemnon API call timeout in seconds                                         |
+| DEAD_LETTER_API_KEY         |                                  | API key for GET/DELETE /dead-letters (min 32 chars; auth bypassed when unset) |
+| SHUTDOWN_TIMEOUT            | 10.0                             | Graceful shutdown timeout in seconds                                          |
+| WEBHOOK_RATE_LIMIT          | 60/minute                        | Rate limit for POST /webhook endpoint                                         |
+| SUBJECTS_RATE_LIMIT         | 60/minute                        | Rate limit for GET /subjects endpoint                                         |
 
 Configure external services to POST to `http://<hermes-host>:<HERMES_PORT>/webhook`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,11 +198,11 @@ gh pr create --title "[Type] Brief description" --body "Closes #<issue-number>"
 
 ### Branching Strategy
 
-| Branch type | Naming convention | Base branch | Notes |
-|-------------|-------------------|-------------|-------|
-| Default | `main` | — | Protected; never push directly |
-| Feature / fix | `<issue>-<slug>` | `main` | e.g. `44-planning-templates` |
-| Release | `release/v<x.y.z>` | `main` | Created from `main` before tagging |
+| Branch type   | Naming convention  | Base branch | Notes                              |
+|---------------|--------------------|-------------|------------------------------------|
+| Default       | `main`             | —           | Protected; never push directly     |
+| Feature / fix | `<issue>-<slug>`   | `main`      | e.g. `44-planning-templates`       |
+| Release       | `release/v<x.y.z>` | `main`      | Created from `main` before tagging |
 
 **Merge strategy:**
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Example: `hi.tasks.team-alpha.task-42.updated`
 
 All NATS messages published by Hermes include a `schema_version` integer field.
 
-| Field            | Current value | Description                                        |
-|------------------|---------------|----------------------------------------------------|
+| Field            | Current value | Description                                         |
+|------------------|---------------|-----------------------------------------------------|
 | `schema_version` | 1             | Wire format version; increments on breaking changes |
 
 **Consumer guidance:**
@@ -98,15 +98,15 @@ All NATS messages published by Hermes include a `schema_version` integer field.
 
 Hermes exposes several endpoints for webhooks, health checks, and observability:
 
-| Endpoint         | Method | Description                                                                         | Status Code |
-|------------------|--------|-------------------------------------------------------------------------------------| ----------- |
+| Endpoint         | Method | Description                                                                         | Status Code     |
+|------------------|--------|-------------------------------------------------------------------------------------|-----------------|
 | `/webhook`       | POST   | Accept and validate incoming webhooks; publishes to NATS                            | 202 / 401 / 422 |
-| `/health`        | GET    | Service health check; returns NATS connection status                                | 200 / 503   |
-| `/ready`         | GET    | Readiness probe for orchestrators (Kubernetes, Docker Compose)                      | 200 / 503   |
-| `/metrics`       | GET    | Prometheus metrics (counter, gauge, histogram)                                      | 200         |
-| `/subjects`      | GET    | List all NATS subjects published to in this session                                 | 200         |
-| `/events`        | GET    | Canonical list of supported webhook event types (agent_events, task_events)         | 200         |
-| `/dead-letters`  | GET    | View in-memory dead-letter queue of unroutable events                               | 200         |
+| `/health`        | GET    | Service health check; returns NATS connection status                                | 200 / 503       |
+| `/ready`         | GET    | Readiness probe for orchestrators (Kubernetes, Docker Compose)                      | 200 / 503       |
+| `/metrics`       | GET    | Prometheus metrics (counter, gauge, histogram)                                      | 200             |
+| `/subjects`      | GET    | List all NATS subjects published to in this session                                 | 200             |
+| `/events`        | GET    | Canonical list of supported webhook event types (agent_events, task_events)         | 200             |
+| `/dead-letters`  | GET    | View in-memory dead-letter queue of unroutable events                               | 200             |
 
 ### Health Checks
 
@@ -135,11 +135,11 @@ FastAPI also serves interactive docs at runtime:
 
 Hermes-specific architectural decisions are documented as ADRs in [`docs/adr/`](docs/adr/).
 
-| ADR | Decision |
-|-----|----------|
+| ADR                                                    | Decision                                                                              |
+|--------------------------------------------------------|---------------------------------------------------------------------------------------|
 | [ADR-001](docs/adr/ADR-001-nats-reconnect-strategy.md) | `allow_reconnect=False` — fail fast on NATS disconnect rather than buffering silently |
-| [ADR-002](docs/adr/ADR-002-dead-letter-strategy.md) | Route unknown event types to `hi.deadletter.<event>` JetStream subject |
-| [ADR-003](docs/adr/ADR-003-schema-version-field.md) | Include `schema_version` integer in every wire-format message |
+| [ADR-002](docs/adr/ADR-002-dead-letter-strategy.md)    | Route unknown event types to `hi.deadletter.<event>` JetStream subject                |
+| [ADR-003](docs/adr/ADR-003-schema-version-field.md)    | Include `schema_version` integer in every wire-format message                         |
 
 ## Configuration
 
@@ -151,26 +151,26 @@ cp .env.example .env
 
 ### Environment Variables
 
-| Variable              | Default          | Description                                                 |
-|-----------------------|------------------|-------------------------------------------------------------|
-| NATS_URL              | nats://localhost:4222 | NATS server URL                                         |
-| NATS_CONNECT_TIMEOUT  | 5.0              | Seconds to wait for initial NATS connection                 |
-| NATS_PUBLISH_TIMEOUT  | 5.0              | Seconds to wait for publish confirmation                    |
-| HERMES_HOST           | 127.0.0.1        | Host/IP to bind (use 0.0.0.0 in Docker)                   |
-| HERMES_PORT           | 8080             | Port Hermes listens on                                      |
-| HERMES_PUBLIC_URL     | `http://localhost:{port}` | Externally-reachable base URL for the /webhook endpoint |
-| WEBHOOK_SECRET        |                  | HMAC secret for webhook validation (min 32 chars)           |
-| WEBHOOK_RATE_LIMIT    | 60/minute        | Rate limit per IP (e.g., 60/minute, 100/hour)              |
-| MAX_PAYLOAD_BYTES     | 1048576          | Max webhook payload size in bytes (1 MiB default)           |
-| ACTIVE_SUBJECTS_MAX   | 1000             | Max distinct NATS subjects to track in memory               |
-| LOG_JSON              | false            | Enable JSON-formatted logs for structured logging           |
-| ENABLE_DEAD_LETTER    | true             | Store unparseable events to `hi.deadletter.>` stream        |
-| AGAMEMNON_TIMEOUT     | 10.0             | HTTP timeout for Agamemnon requests in seconds              |
-| SHUTDOWN_TIMEOUT      | 10.0             | Grace period for graceful shutdown in seconds               |
-| TLS_CA_BUNDLE         |                  | Path to CA certificate bundle (PEM)                         |
-| TLS_CERT_FILE         |                  | Path to client TLS certificate (PEM) for mTLS               |
-| TLS_KEY_FILE          |                  | Path to client TLS private key (PEM)                        |
-| TLS_VERIFY            | true             | Verify TLS certificates (set false only for dev/testing)    |
+| Variable              | Default                   | Description                                                 |
+|-----------------------|---------------------------|-------------------------------------------------------------|
+| NATS_URL              | nats://localhost:4222     | NATS server URL                                             |
+| NATS_CONNECT_TIMEOUT  | 5.0                       | Seconds to wait for initial NATS connection                 |
+| NATS_PUBLISH_TIMEOUT  | 5.0                       | Seconds to wait for publish confirmation                    |
+| HERMES_HOST           | 127.0.0.1                 | Host/IP to bind (use 0.0.0.0 in Docker)                     |
+| HERMES_PORT           | 8080                      | Port Hermes listens on                                      |
+| HERMES_PUBLIC_URL     | `http://localhost:{port}` | Externally-reachable base URL for the /webhook endpoint     |
+| WEBHOOK_SECRET        |                           | HMAC secret for webhook validation (min 32 chars)           |
+| WEBHOOK_RATE_LIMIT    | 60/minute                 | Rate limit per IP (e.g., 60/minute, 100/hour)               |
+| MAX_PAYLOAD_BYTES     | 1048576                   | Max webhook payload size in bytes (1 MiB default)           |
+| ACTIVE_SUBJECTS_MAX   | 1000                      | Max distinct NATS subjects to track in memory               |
+| LOG_JSON              | false                     | Enable JSON-formatted logs for structured logging           |
+| ENABLE_DEAD_LETTER    | true                      | Store unparseable events to `hi.deadletter.>` stream        |
+| AGAMEMNON_TIMEOUT     | 10.0                      | HTTP timeout for Agamemnon requests in seconds              |
+| SHUTDOWN_TIMEOUT      | 10.0                      | Grace period for graceful shutdown in seconds               |
+| TLS_CA_BUNDLE         |                           | Path to CA certificate bundle (PEM)                         |
+| TLS_CERT_FILE         |                           | Path to client TLS certificate (PEM) for mTLS               |
+| TLS_KEY_FILE          |                           | Path to client TLS private key (PEM)                        |
+| TLS_VERIFY            | true                      | Verify TLS certificates (set false only for dev/testing)    |
 
 > **Security:** If `WEBHOOK_SECRET` is empty, HMAC validation is **disabled** and a warning is
 > logged at startup. Always set a secret in production.
@@ -208,9 +208,9 @@ Set the following environment variables:
 | Variable       | Description                                                            |
 |----------------|------------------------------------------------------------------------|
 | TLS_CA_BUNDLE  | Path to CA certificate bundle file (for server certificate validation) |
-| TLS_CERT_FILE  | Path to client certificate file (for mTLS)                            |
-| TLS_KEY_FILE   | Path to client private key file (for mTLS)                            |
-| TLS_VERIFY     | Enable/disable hostname verification (default: true)                  |
+| TLS_CERT_FILE  | Path to client certificate file (for mTLS)                             |
+| TLS_KEY_FILE   | Path to client private key file (for mTLS)                             |
+| TLS_VERIFY     | Enable/disable hostname verification (default: true)                   |
 
 Example with mTLS (mutual TLS):
 

--- a/docs/adr/ADR-001-nats-reconnect-strategy.md
+++ b/docs/adr/ADR-001-nats-reconnect-strategy.md
@@ -70,11 +70,11 @@ Once the service is running, a NATS disconnect causes:
 
 ## Alternatives Considered
 
-| Alternative | Reason Rejected |
-|-------------|----------------|
-| `allow_reconnect=True` (library default) | Silent buffering produces false `200 OK` responses and makes health probes unreliable. |
+| Alternative                                            | Reason Rejected                                                                                      |
+|--------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+| `allow_reconnect=True` (library default)               | Silent buffering produces false `200 OK` responses and makes health probes unreliable.               |
 | `allow_reconnect=True` + in-memory buffer with timeout | Adds complexity; still risks stale delivery; does not eliminate the false-ACK problem for JetStream. |
-| Circuit-breaker middleware | Adds a dependency and operational complexity for a problem that startup retries already solve. |
+| Circuit-breaker middleware                             | Adds a dependency and operational complexity for a problem that startup retries already solve.       |
 
 ---
 

--- a/docs/adr/ADR-002-dead-letter-strategy.md
+++ b/docs/adr/ADR-002-dead-letter-strategy.md
@@ -73,12 +73,12 @@ receives `422 Unprocessable Entity`.
 
 ## Alternatives Considered
 
-| Alternative | Reason Rejected |
-|-------------|----------------|
+| Alternative                         | Reason Rejected                                                                                             |
+|-------------------------------------|-------------------------------------------------------------------------------------------------------------|
 | Return `422` for all unknown events | Breaks callers that send forward-compatible events; shifts routing knowledge burden onto upstream services. |
-| Single flat `hi.deadletter` subject | Prevents selective subscription; makes replay and monitoring coarser. |
-| Database-backed dead-letter queue | Adds a stateful dependency; JetStream already provides durable storage. |
-| In-memory only (no JetStream tier) | Events are lost on restart; no replay capability. |
+| Single flat `hi.deadletter` subject | Prevents selective subscription; makes replay and monitoring coarser.                                       |
+| Database-backed dead-letter queue   | Adds a stateful dependency; JetStream already provides durable storage.                                     |
+| In-memory only (no JetStream tier)  | Events are lost on restart; no replay capability.                                                           |
 
 ---
 

--- a/docs/adr/ADR-003-schema-version-field.md
+++ b/docs/adr/ADR-003-schema-version-field.md
@@ -33,13 +33,13 @@ schema_version: int = Field(default=1, ge=1, description="Wire format schema ver
 
 **Versioning rules:**
 
-| Change type | Version bump? |
-|-------------|--------------|
+| Change type                  | Version bump?             |
+|------------------------------|---------------------------|
 | New **optional** field added | No — backwards-compatible |
-| Existing field **renamed** | Yes — breaking change |
-| Existing field **removed** | Yes — breaking change |
-| Field **type changed** | Yes — breaking change |
-| New **required** field added | Yes — breaking change |
+| Existing field **renamed**   | Yes — breaking change     |
+| Existing field **removed**   | Yes — breaking change     |
+| Field **type changed**       | Yes — breaking change     |
+| New **required** field added | Yes — breaking change     |
 
 The current version is **1**. All messages carry `"schema_version": 1` until a breaking change
 warrants incrementing to `2`.
@@ -86,12 +86,12 @@ warrants incrementing to `2`.
 
 ## Alternatives Considered
 
-| Alternative | Reason Rejected |
-|-------------|----------------|
-| NATS subject-per-version (e.g., `hi.agents.v2.*`) | Subject proliferation; consumers must subscribe to N subjects; complicates routing logic. |
-| Schema registry (e.g., Confluent Schema Registry) | External infrastructure dependency; significant operational overhead for a lightweight bridge. |
-| Semantic versioning string (e.g., `"1.0.0"`) | Semver comparison logic in every consumer; integer comparison is simpler and sufficient. |
-| No versioning | First breaking change requires coordinated fleet-wide deployment; unacceptable for a distributed system. |
+| Alternative                                       | Reason Rejected                                                                                          |
+|---------------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| NATS subject-per-version (e.g., `hi.agents.v2.*`) | Subject proliferation; consumers must subscribe to N subjects; complicates routing logic.                |
+| Schema registry (e.g., Confluent Schema Registry) | External infrastructure dependency; significant operational overhead for a lightweight bridge.           |
+| Semantic versioning string (e.g., `"1.0.0"`)      | Semver comparison logic in every consumer; integer comparison is simpler and sufficient.                 |
+| No versioning                                     | First breaking change requires coordinated fleet-wide deployment; unacceptable for a distributed system. |
 
 ---
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,8 +16,8 @@ Each ADR uses the following sections: **Status**, **Date**, **Deciders**, **Cont
 
 ## Index
 
-| # | Title | Status | Date |
-|---|-------|--------|------|
-| [ADR-001](ADR-001-nats-reconnect-strategy.md) | NATS Reconnect Strategy | Accepted | 2024-01-15 |
-| [ADR-002](ADR-002-dead-letter-strategy.md) | Dead-Letter Strategy for Unknown Event Types | Accepted | 2024-01-15 |
-| [ADR-003](ADR-003-schema-version-field.md) | Wire Format Schema Versioning | Accepted | 2024-01-15 |
+| #                                             | Title                                        | Status   | Date       |
+|-----------------------------------------------|----------------------------------------------|----------|------------|
+| [ADR-001](ADR-001-nats-reconnect-strategy.md) | NATS Reconnect Strategy                      | Accepted | 2024-01-15 |
+| [ADR-002](ADR-002-dead-letter-strategy.md)    | Dead-Letter Strategy for Unknown Event Types | Accepted | 2024-01-15 |
+| [ADR-003](ADR-003-schema-version-field.md)    | Wire Format Schema Versioning                | Accepted | 2024-01-15 |

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -537,6 +537,7 @@ class TestPublishSchemaVersion:
             received.append(m)
 
         sub = await nats_client.subscribe("hi.agents.schema-host.schema-agent.created", cb=_cb)
+        await nats_client.flush()  # ensure server has ack'd the subscription before we publish
 
         payload = WebhookPayload(
             event="agent.created",
@@ -563,6 +564,7 @@ class TestPublishSchemaVersion:
             received.append(m)
 
         sub = await nats_client.subscribe("hi.tasks.team-sv.task-sv.updated", cb=_cb)
+        await nats_client.flush()  # ensure server has ack'd the subscription before we publish
 
         payload = WebhookPayload(
             event="task.updated",

--- a/tests/test_publisher_reconnect.py
+++ b/tests/test_publisher_reconnect.py
@@ -138,17 +138,18 @@ class TestReconnectLoopRetriesOnLostConnection:
         with patch("nats.connect", side_effect=fake_connect):
             await pub.connect("nats://localhost:4222")
 
-        initial_count = pub.reconnect_count
+            initial_count = pub.reconnect_count
 
-        # Simulate connection loss
-        pub._nc = _make_mock_nc(closed=True)
+            # Simulate connection loss
+            pub._nc = _make_mock_nc(closed=True)
 
-        loop_task = asyncio.ensure_future(
-            pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
-        )
-        await asyncio.sleep(0.12)
-        pub._stop_event.set()
-        await loop_task
+            pub._stop_event = asyncio.Event()
+            loop_task = asyncio.ensure_future(
+                pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
+            )
+            await asyncio.sleep(0.12)
+            pub._stop_event.set()
+            await loop_task
 
         assert pub.reconnect_count > initial_count
 
@@ -193,16 +194,17 @@ class TestReconnectLoopRetriesOnLostConnection:
         with patch("nats.connect", side_effect=fake_connect):
             await pub.connect("nats://localhost:4222")
 
-        before = NATS_RECONNECTS.labels(result="success")._value.get()
+            before = NATS_RECONNECTS.labels(result="success")._value.get()
 
-        pub._nc = _make_mock_nc(closed=True)
+            pub._nc = _make_mock_nc(closed=True)
 
-        loop_task = asyncio.ensure_future(
-            pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
-        )
-        await asyncio.sleep(0.12)
-        pub._stop_event.set()
-        await loop_task
+            pub._stop_event = asyncio.Event()
+            loop_task = asyncio.ensure_future(
+                pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
+            )
+            await asyncio.sleep(0.12)
+            pub._stop_event.set()
+            await loop_task
 
         after = NATS_RECONNECTS.labels(result="success")._value.get()
         assert after > before


### PR DESCRIPTION
## Summary

This PR consolidates three separate CI failures into a single fix, so one merge unblocks `main` and all 17 BLOCKED PRs. It supersedes PR #606 (unit-test fix) and PR #607 (integration-test fix), and adds the markdownlint fix that neither prior PR addressed.

### RC 1 — Unit-test flakes (cherry-pick from #606, commit `07cec7b`)
`tests/test_publisher_reconnect.py` — `test_reconnect_count_increments_on_success` and `test_nats_reconnects_metric_incremented_on_success` were non-deterministically producing `assert 0 > 0` / `assert 1.0 > 1.0`. Root cause: `asyncio.ensure_future(_reconnect_loop())` was started **outside** the `with patch("nats.connect")` context manager, so the mock was torn down before the loop ran. Fix: move the `_stop_event` reset, `ensure_future`, sleep, and stop-event set **inside** the patch context.

### RC 2 — Integration race (cherry-pick from #607, commit `2499c1d`)
`tests/test_integration.py::TestPublishSchemaVersion` — subscribe-before-publish race caused the NATS subscription to sometimes not be registered at the server before the message was published. Fix: add `await nats_client.flush()` after each `subscribe()` call, mirroring the pattern already used in passing tests.

### RC 3 — Markdownlint violations (new, not in #606 or #607)
`markdownlint` CI job was failing with 66 violations across 9 files. The task spec called out:
- `.github/ISSUE_TEMPLATE/tech_debt.md`: MD022 (no blank line before `## Deliverables`) and MD032 (no blank line before list)
- `AGENTS.md:258`: MD031 (no blank line before fenced code block)

Additionally, 57 MD060 (table column alignment) violations existed pre-existing across `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, and `docs/adr/*.md`. All fixed via table normalization so the `markdownlint` job passes completely.

## Files Changed

- `tests/test_publisher_reconnect.py` — reconnect loop moved inside mock context (RC 1)
- `tests/test_integration.py` — `flush()` after subscribe (RC 2)
- `.github/ISSUE_TEMPLATE/tech_debt.md` — MD022/MD032 blank lines (RC 3)
- `AGENTS.md` — MD031 blank line before fence + MD060 table alignment (RC 3)
- `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `docs/adr/README.md`, `docs/adr/ADR-001-*.md`, `docs/adr/ADR-002-*.md`, `docs/adr/ADR-003-*.md` — MD060 table alignment (RC 3)

## Test plan

- [x] 5/5 unit tests in `TestReconnectLoopRetriesOnLostConnection` pass locally (pixi run pytest)
- [x] `npx markdownlint-cli2 "**/*.md"` reports 0 errors locally
- [ ] Integration tests require live NATS server — rely on CI (`integration-tests` job)
- [ ] Full CI suite on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)