### PR TITLE
fix(tests): stabilize test_publisher_reconnect async timing flakes (unblocks 10 PRs)

### DIFF
--- a/tests/test_publisher_reconnect.py
+++ b/tests/test_publisher_reconnect.py
@@ -106,9 +106,15 @@ class TestReconnectLoopRetriesOnLostConnection:
     async def test_reconnect_called_when_nc_is_closed(self) -> None:
         pub = Publisher()
         connect_calls: list[str] = []
+        # Fired as soon as the reconnect loop attempts a second nats.connect call
+        reconnect_attempted: asyncio.Event = asyncio.Event()
 
         async def fake_connect(url: str, **kwargs: object) -> MagicMock:
             connect_calls.append(url)
+            if len(connect_calls) > 1:
+                # This is a reconnect attempt — signal the test and stop the loop
+                reconnect_attempted.set()
+                pub._stop_event.set()
             return _make_mock_nc(closed=False)
 
         with patch("nats.connect", side_effect=fake_connect):
@@ -122,7 +128,8 @@ class TestReconnectLoopRetriesOnLostConnection:
             loop_task = asyncio.ensure_future(
                 pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
             )
-            await asyncio.sleep(0.12)
+            # Block until the reconnect fires (self-terminates) or 5 s safety timeout
+            await asyncio.wait_for(reconnect_attempted.wait(), timeout=5.0)
             pub._stop_event.set()
             await loop_task
 
@@ -131,8 +138,17 @@ class TestReconnectLoopRetriesOnLostConnection:
     @pytest.mark.asyncio
     async def test_reconnect_count_increments_on_success(self) -> None:
         pub = Publisher()
+        call_count = 0
+        # Fired as soon as the reconnect loop successfully reconnects
+        reconnected: asyncio.Event = asyncio.Event()
 
         async def fake_connect(url: str, **kwargs: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                # This is a reconnect attempt — signal the test and stop the loop
+                reconnected.set()
+                pub._stop_event.set()
             return _make_mock_nc(closed=False)
 
         with patch("nats.connect", side_effect=fake_connect):
@@ -147,7 +163,8 @@ class TestReconnectLoopRetriesOnLostConnection:
             loop_task = asyncio.ensure_future(
                 pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
             )
-            await asyncio.sleep(0.12)
+            # Block until the reconnect fires (self-terminates) or 5 s safety timeout
+            await asyncio.wait_for(reconnected.wait(), timeout=5.0)
             pub._stop_event.set()
             await loop_task
 


### PR DESCRIPTION
## Summary

- Two tests in `TestReconnectLoopRetriesOnLostConnection` asserted `reconnect_count > initial_count` / `len(connect_calls) > first_call_count` but observed `0 > 0` on slow CI runners because they used `asyncio.sleep(0.12)` to wait for the reconnect loop to tick — a wall-time race that fails when the event loop is busy.
- Fix replaces the sleep-and-hope pattern with an `asyncio.Event` set inside `fake_connect` on the first reconnect call. The test blocks on `asyncio.wait_for(event.wait(), timeout=5.0)`, making termination deterministic rather than timing-dependent.
- The reconnect logic in `publisher.py` is correct and unchanged — this is a pure test stabilisation.

## Unblocks

These 10 open PRs are blocked on main's flaky CI and will be unblocked once this merges:

- #605
- #604
- #602
- #601
- #600
- #573
- #564
- #560
- #535
- #522

## Test plan

- [x] `pixi run pytest tests/test_publisher_reconnect.py -v --no-cov` — 15/15 passed locally
- [x] All 15 tests in the file pass (not just the 2 fixed ones)
- [x] No changes to production code (`publisher.py` untouched)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)