### PR TITLE
chore: easy-issue sweep — refs #353 (and closes #339, #350, #368, #370 as stale)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,37 @@
 {
   "enabledPlugins": {
     "hephaestus@ProjectHephaestus": true
+  },
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf /*)",
+      "Bash(rm -rf ~)",
+      "Bash(rm -rf $HOME*)",
+      "Bash(sudo:*)",
+      "Bash(curl * | sh)",
+      "Bash(curl * | bash)",
+      "Bash(wget * | sh)",
+      "Bash(wget * | bash)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git reset --hard origin/main)",
+      "Bash(git reset --hard origin/master)",
+      "Bash(git push * --no-verify*)",
+      "Bash(git commit * --no-verify*)",
+      "Bash(git commit *--amend*)",
+      "Bash(gh pr merge * --admin*)",
+      "Write(/etc/**)",
+      "Write(/root/**)",
+      "Write(/usr/**)",
+      "Write(/var/**)",
+      "Write(~/.ssh/**)",
+      "Write(~/.aws/**)",
+      "Write(~/.gnupg/**)",
+      "Edit(/etc/**)",
+      "Edit(/root/**)",
+      "Edit(~/.ssh/**)",
+      "Edit(~/.aws/**)",
+      "Edit(~/.gnupg/**)"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Easy-issue sweep across §7/§10/§11/§15 minor audit findings. Only one issue
required code changes; the other four were verified as stale and closed
with evidence on the issue threads.

### Implemented
- **#353** §11 — Add `permissions.deny` guardrails to `.claude/settings.json`.
  The plugin previously ran with no scope; now there is a baseline deny list
  for destructive shell ops, force pushes, `--no-verify` bypasses, and
  writes outside the repo (e.g. `/etc`, `~/.ssh`, `~/.aws`).

### Closed as stale (with verification on the issue thread)
- **#370** §15 — `master` does not appear in `CONTRIBUTING.md`, the
  workflows, or `.pre-commit-config.yaml`. Default branch is `main` and
  CONTRIBUTING.md consistently references it. The `no-commit-to-branch`
  hook was dropped in commit bce7f01.
- **#339** §7 — `pixi.toml` already lists `osx-arm64` and `osx-64`
  alongside `linux-64`.
- **#368** §15 / **#350** §10 — `CHANGELOG.md` no longer exists in the
  repo (removed during the 2026-05-07 ecosystem cleanup that also dropped
  CHANGELOG.md from Myrmidons/Telemachy/AchaeanFleet/Hephaestus/Proteus).

### Skipped
- **#360** auth issue — needs a dedicated PR with tests; commented on
  the issue saying so.

## Test plan
- [x] `python3 -c "import json; json.load(open('.claude/settings.json'))"` passes
- [x] Diff is +32 lines / -0 lines, well under the 300 LOC budget
- [x] No API or auth code touched

Refs #353
Closes #339
Closes #350
Closes #368
Closes #370