### PR TITLE
Add forbid-suppressions lint guard

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -46,6 +46,57 @@ jobs:
       - name: Type check
         run: pixi run typecheck
 
+  forbid-suppressions:
+    name: forbid-suppressions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: "Reject silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
+        run: |
+          # Ports the regression guard from HomericIntelligence/Odysseus#280.
+          # Matches the forbidden idiom at end of line or before a trailing comment.
+          set -euo pipefail
+          mapfile -t files < <(git ls-files \
+            -- \
+            '*.sh' '*.bash' '*.yml' '*.yaml' '*.hcl' \
+            'Dockerfile*' '**/Dockerfile*' \
+            'justfile' '**/justfile' 'Justfile' '**/Justfile')
+          # Skip this workflow file itself (heredoc would otherwise self-match).
+          declare -a scan_files=()
+          for f in "${files[@]}"; do
+            case "$f" in
+              .github/workflows/_required.yml) continue ;;
+            esac
+            scan_files+=("$f")
+          done
+          if [ "${#scan_files[@]}" -eq 0 ]; then
+            echo "No files to scan"
+            exit 0
+          fi
+          if grep -nE '\|\|[[:space:]]*true([[:space:]]*$|[[:space:]]+#)' "${scan_files[@]}"; then
+            echo ""
+            echo '::error::Found silent-failure workarounds above. Refactor to an explicit if-guard or real conditional.'
+            exit 1
+          fi
+          echo 'OK: no silent-failure workarounds found'
+
+      - name: "Reject continue-on-error workflow opt-out"
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No workflow files"
+            exit 0
+          fi
+          if grep -nE '^[[:space:]]*continue-on-error:[[:space:]]*true[[:space:]]*$' "${files[@]}"; then
+            echo ""
+            echo '::error::Found "continue-on-error: true" above. Fix the root cause instead of suppressing the failure.'
+            exit 1
+          fi
+          echo 'OK: no "continue-on-error: true" found'
+
   markdownlint:
     name: markdownlint
     runs-on: ubuntu-24.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,27 @@ repos:
         language: pygrep
         entry: 'gitleaks detect.*--exit-code[= ]0'
         files: \.github/workflows/.*\.yml$
+
+      - id: forbid-or-true
+        name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
+        description: >
+          Rejects the `or-true` idiom (and its whitespace variants) in shell,
+          YAML, Dockerfile, justfile, and HCL sources. Refactor to an explicit
+          `if`-guard, a real conditional, or a documented `set +e`/`set -e`
+          bracket. Ports the regression guard from HomericIntelligence/Odysseus#280.
+        language: pygrep
+        entry: '\|\|\s*true(\s*$|\s+#)'
+        files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
+        types: [text]
+        pass_filenames: true
+
+      - id: forbid-continue-on-error
+        name: "forbid continue-on-error workflow opt-out"
+        description: >
+          GitHub Actions `continue-on-error true` (truthy form) hides real CI
+          failures. Fix the underlying job/step instead. Ports the regression
+          guard from HomericIntelligence/Odysseus#280.
+        language: pygrep
+        entry: '^\s*continue-on-error:\s*true\s*$'
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: true

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ health:
 
 # One-command developer setup: copy .env, install deps, regenerate lock file
 bootstrap:
-    cp -n .env.example .env || true
+    if [ ! -f .env ]; then cp .env.example .env; fi
     pixi install --frozen || pixi update
     @echo "Ready! Run 'just dev' to start."
 


### PR DESCRIPTION
## Summary

Ports the pygrep regression guard from HomericIntelligence/Odysseus#280 to
ProjectHermes so that `|| true` and `continue-on-error: true` cannot be
re-introduced once removed from the codebase.

## Changes

- **`.pre-commit-config.yaml`**: two new local `pygrep` hooks
  - `forbid-or-true` — rejects `|| true` (and `|| true #comment` variants) in
    `*.sh`, `*.bash`, `*.yml`, `*.yaml`, `*.hcl`, `Dockerfile*`, `[Jj]ustfile`
  - `forbid-continue-on-error` — rejects `continue-on-error: true` in
    `.github/workflows/*.y(a)ml`
- **`.github/workflows/_required.yml`**: new `forbid-suppressions` job running
  the same two `grep -nE` checks against `git ls-files` output, so the rule
  is enforced in CI even if a contributor skips pre-commit.
- **`justfile`**: refactor the single offending `cp -n .env.example .env || true`
  in the `bootstrap` recipe to an explicit `if [ ! -f .env ]` guard.

## Verification

- `pixi run pre-commit run forbid-or-true --all-files` -> `Passed`
- `pixi run pre-commit run forbid-continue-on-error --all-files` -> `Passed`
- `python3 -c "import yaml; yaml.safe_load(...)"` on both YAML files -> OK
- `just --evaluate` and `just --list` -> OK

## Test plan

- [ ] CI `forbid-suppressions` job passes on this PR
- [ ] Pre-commit `forbid-or-true` and `forbid-continue-on-error` hooks pass
- [ ] All other required checks remain green

## Reference

HomericIntelligence/Odysseus#280 — the source PR introducing the same guard
in the Odysseus meta-repo.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>