### PR TITLE
chore: easy-issue sweep 2026-05-11

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -10,3 +10,6 @@
 - name: cleanup
   color: "c5def5"
   description: "Code or config cleanup"
+- name: epic
+  color: "7057ff"
+  description: "Large multi-issue effort tracked as an umbrella"

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -292,6 +292,10 @@ jobs:
               --report-format sarif --report-path gitleaks.sarif --exit-code 1
           fi
 
+      # `if: always()` is intentional: even when "Run Gitleaks" exits non-zero (secret found),
+      # we still want the SARIF report uploaded so reviewers can investigate the finding. Do NOT
+      # add `continue-on-error: true` to the Run Gitleaks step — that would let leaked secrets
+      # silently merge to main. The forbid-suppressions guard would also reject it.
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
         uses: actions/upload-artifact@v7

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -297,11 +297,11 @@ jobs:
               --report-format sarif --report-path gitleaks.sarif --exit-code 1
           fi
 
-      # `if: always()` is intentional: even when "Run Gitleaks" exits non-zero (secret found),
-      # we still want the SARIF report uploaded so reviewers can investigate the finding. Do NOT
-      # add `continue-on-error: true` to the Run Gitleaks step — that would let leaked secrets
-      # silently merge to main. The forbid-suppressions guard would also reject it.
       - name: Upload Gitleaks SARIF
+        # `if: always()` is intentional: even when "Run Gitleaks" exits non-zero (secret found),
+        # we still want the SARIF report uploaded so reviewers can investigate the finding.
+        # Do NOT make the Run Gitleaks step itself non-fatal — that would let leaked secrets
+        # silently merge to main. The forbid-suppressions guard would also reject any such opt-out.
         if: always() && hashFiles('gitleaks.sarif') != ''
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: read
 
+# Single source of truth — bump together with GITLEAKS_VERSION in
+# .github/workflows/security.yml so PR scans and required CI agree.
+env:
+  GITLEAKS_VERSION: "8.30.1"
+
 concurrency:
   group: required-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
@@ -274,7 +279,7 @@ jobs:
 
       - name: Install Gitleaks
         run: |
-          GITLEAKS_VERSION=8.30.1
+          # GITLEAKS_VERSION comes from the workflow-level env (single source of truth).
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ARCH=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')
           curl -sSfL \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: Determine image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -44,7 +44,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  # v5
         with:
           context: .
           push: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,11 @@ on:
     - cron: "0 8 * * 1"
   workflow_dispatch:
 
+# Single source of truth — bump this together with GITLEAKS_VERSION in
+# .github/workflows/_required.yml so PR scans and required CI agree.
+env:
+  GITLEAKS_VERSION: "8.30.1"
+
 jobs:
   secret-scan:
     name: Secret Scanning (gitleaks)
@@ -23,7 +28,7 @@ jobs:
       - name: Install gitleaks
         run: |
           curl -sSfL \
-            https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | tar -xz gitleaks
           sudo mv gitleaks /usr/local/bin/gitleaks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ Unauthorized`.
 
 > **Forward-compatible only:** `task.updated`, `task.completed`, and `task.failed` are accepted by
 > Hermes for forward-compatibility, but the upstream service does **not yet emit them**. Consumers
-> should not rely on receiving these events today. See [§3 — Not Yet Integrated](#-3--downstream-consumers)
+> should not rely on receiving these events today. See [§3 — Not Yet Integrated](#not-yet-integrated)
 > and [Odysseus#33](https://github.com/HomericIntelligence/Odysseus/issues/33).
 
 Unknown event types are routed to `hi.deadletter.{sanitized-event}` when

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,12 @@ Hermes (FastAPI — this service)
     ▼
 NATS JetStream
     │
-    ├──► hi.agents.>     → Argus (observability), Agamemnon (coordination)
+    ├──► hi.agents.>     → Argus (observability)
     ├──► hi.tasks.>      → Telemachy (workflow engine)
     └──► hi.deadletter.> → unknown / unroutable events
+
+Hermes also issues a synchronous HTTP call to Agamemnon (out-of-band from NATS)
+on webhook receipt — see §3 below.
 ```
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,11 @@ Unauthorized`.
 | `task.completed`| `homeric-tasks`   | `hi.tasks.{team_id}.{task_id}.completed`   |
 | `task.failed`   | `homeric-tasks`   | `hi.tasks.{team_id}.{task_id}.failed`      |
 
+> **Forward-compatible only:** `task.updated`, `task.completed`, and `task.failed` are accepted by
+> Hermes for forward-compatibility, but the upstream service does **not yet emit them**. Consumers
+> should not rely on receiving these events today. See [§3 — Not Yet Integrated](#-3--downstream-consumers)
+> and [Odysseus#33](https://github.com/HomericIntelligence/Odysseus/issues/33).
+
 Unknown event types are routed to `hi.deadletter.{sanitized-event}` when
 `ENABLE_DEAD_LETTER=true` (the default).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,8 @@ Hermes retries transient NATS publish failures with exponential backoff:
 |----------------------------|---------|-----------------------------------------------------------------|
 | `PUBLISH_RETRIES`          | 3       | Total publish attempts before giving up                         |
 | `PUBLISH_RETRY_BASE_DELAY` | 0.1 s   | Base delay; actual = `base × 2^attempt` ± jitter, capped at 2 s |
+| `NATS_RETRY_ATTEMPTS`      | 3       | Initial-connect retries at startup before failing the boot      |
+| `NATS_RETRY_INTERVAL`      | 5.0 s   | Delay between initial-connect retries at startup (not used by the per-publish retry path; surfaced on `/health`) |
 
 Retryable errors: `TimeoutError`, `NoRespondersError`, `DrainTimeoutError`,
 `ConnectionReconnectingError`, `StaleConnectionError`. Non-retryable errors propagate immediately

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ Every message published to NATS JetStream includes a `schema_version` integer fi
 | DEAD_LETTER_API_KEY   |                                | API key for GET/DELETE /dead-letters (min 32 chars; auth bypassed when unset) |
 | SHUTDOWN_TIMEOUT      | 10.0                           | Graceful shutdown timeout in seconds                    |
 | WEBHOOK_RATE_LIMIT    | 60/minute                      | Rate limit for POST /webhook endpoint                   |
+| WEBHOOK_RATE_LIMIT_KEY | ip                            | Rate-limit key strategy: `ip` (only currently wired) or `endpoint` (reserved) |
 | SUBJECTS_RATE_LIMIT   | 60/minute                      | Rate limit for GET /subjects endpoint                   |
 | ENABLE_DEAD_LETTER    | true                           | Route unparseable / unknown events to `hi.deadletter.>` |
 | DEAD_LETTER_MAX_SIZE  | 1000                           | Maximum entries kept in the in-memory dead-letter queue |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,12 @@ Every message published to NATS JetStream includes a `schema_version` integer fi
 | SHUTDOWN_TIMEOUT      | 10.0                           | Graceful shutdown timeout in seconds                    |
 | WEBHOOK_RATE_LIMIT    | 60/minute                      | Rate limit for POST /webhook endpoint                   |
 | SUBJECTS_RATE_LIMIT   | 60/minute                      | Rate limit for GET /subjects endpoint                   |
+| ENABLE_DEAD_LETTER    | true                           | Route unparseable / unknown events to `hi.deadletter.>` |
+| DEAD_LETTER_MAX_SIZE  | 1000                           | Maximum entries kept in the in-memory dead-letter queue |
+| DEAD_LETTER_TTL_SECONDS | 86400                        | TTL applied to the JetStream `homeric-deadletter` stream (0 = no expiry) |
+| DEAD_LETTER_ALERT_THRESHOLD | 0.8                      | Fraction of `DEAD_LETTER_MAX_SIZE` at which a queue-pressure alert is logged |
+| DEAD_LETTER_PAGE_SIZE_DEFAULT | 100                    | Default page size for `GET /dead-letters`               |
+| DEAD_LETTER_PAGE_SIZE_MAX | 500                        | Maximum allowed page size for `GET /dead-letters`       |
 
 Configure external services to POST to `http://<hermes-host>:<HERMES_PORT>/webhook`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,25 @@ Configure external services to POST to `http://<hermes-host>:<HERMES_PORT>/webho
    hyphens, dots become hyphens, and wildcards (`*` and `>`) are stripped entirely. Tokens are
    lowercased and subject strings are typically capped at 64 characters.
 
+## Container Runtime Requirements
+
+The Hermes container is configured `read_only: true` (see `docker-compose.yml`). Operators using
+plain `docker run` instead of compose **must** supply the same hardening flags or the container
+will fail to start when it tries to write logs/temp files:
+
+```bash
+docker run --rm \
+  --read-only \
+  --tmpfs /tmp \
+  --cap-drop ALL \
+  --security-opt no-new-privileges:true \
+  -p 8085:8085 \
+  -e NATS_URL=nats://host:4222 \
+  ghcr.io/homericintelligence/projecthermes:<tag>
+```
+
+The `--tmpfs /tmp` mount is required by the Python interpreter and Uvicorn for ephemeral state.
+
 ## CI/CD
 
 Docker images are published to GHCR (`ghcr.io/<org>/projecthermes`) **only on version tags**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,29 @@ Configure external services to POST to `http://<hermes-host>:<HERMES_PORT>/webho
    hyphens, dots become hyphens, and wildcards (`*` and `>`) are stripped entirely. Tokens are
    lowercased and subject strings are typically capped at 64 characters.
 
+## Future Integrations
+
+### Agamemnon (deferred — fields removed per #324)
+
+`agamemnon_url` / `agamemnon_api_key` were intentionally removed as dead config (YAGNI). When
+Agamemnon integration is implemented, follow this pattern so it matches existing patterns in the
+codebase:
+
+- Add fields to `Settings` in `hermes/config.py`: `agamemnon_url: str | None = None`,
+  `agamemnon_api_key: SecretStr | None = None`, plus a `agamemnon_timeout: float = 5.0`
+  (validate `> 0`). Leaving the URL unset must keep Agamemnon dispatch fully disabled.
+- Hold a single `httpx.AsyncClient` for the lifetime of the app (constructed in `lifespan`,
+  closed in shutdown) — never construct per-request. Pass the connection-holding client through
+  `app.state` or a DI provider.
+- Plumb `agamemnon_timeout` into the client (`httpx.AsyncClient(timeout=...)`) rather than
+  hard-coding a value at the call site.
+- Surface health on `/health` (e.g. `agamemnon_reachable: bool`) only when `agamemnon_url` is
+  configured — do not regress the no-Agamemnon happy path.
+- Authenticate via `Authorization: Bearer ${AGAMEMNON_API_KEY}`. Never log the key.
+
+If the design evolves significantly, capture the decision in a new ADR rather than changing this
+note.
+
 ## Container Runtime Requirements
 
 The Hermes container is configured `read_only: true` (see `docker-compose.yml`). Operators using

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ Every message published to NATS JetStream includes a `schema_version` integer fi
 | MAX_PAYLOAD_BYTES     | 1048576                        | Maximum accepted request body size in bytes (1 MB)      |
 | NATS_CONNECT_TIMEOUT  | 5.0                            | NATS connection timeout in seconds                      |
 | NATS_PUBLISH_TIMEOUT  | 5.0                            | NATS publish timeout in seconds                         |
+| NATS_RETRY_ATTEMPTS   | 3                              | Initial-connect retry attempts before giving up at startup |
+| NATS_RETRY_INTERVAL   | 5.0                            | Seconds between initial-connect retries at startup (also surfaced via /health) |
 | NATS_RECONNECT_INTERVAL | 5.0                          | Seconds between external reconnect attempts             |
 | NATS_RECONNECT_HARD_TIMEOUT | 5.0                      | Per-attempt hard timeout for external reconnect (seconds) |
 | DEAD_LETTER_API_KEY   |                                | API key for GET/DELETE /dead-letters (min 32 chars; auth bypassed when unset) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,13 @@ NATS JetStream (via ProjectKeystone)
     │  hi.agents.{host}.{name}.{event}
     │  hi.tasks.{team_id}.{task_id}.{event}
     │
-    ├──► Argus      (observability)
-    ├──► Agamemnon  (coordination)
-    ├──► Telemachy  (workflow engine)
+    ├──► Argus      (observability — NATS subscriber)
+    ├──► Telemachy  (workflow engine — NATS subscriber)
     │
     └──► homeric-deadletter (unknown event types)
+
+(Agamemnon is **not** a NATS subscriber — Hermes calls it directly via HTTP on
+webhook receipt; see AGENTS.md §3.)
 ```
 
 **Subject schema:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,27 @@ just health
 
 ```
 
+### Installing with pip (alternative to pixi)
+
+Pixi is the **authoritative** development environment. `pip install .` is supported for runtime
+consumers who prefer pip:
+
+```bash
+# Runtime install only (resolves bounded ranges from pyproject.toml)
+pip install .
+
+# Editable install (no dev tools — pixi remains the only path to ruff/pytest/mypy)
+pip install -e .
+```
+
+Notes:
+
+- Dev tools (`ruff`, `pytest`, `mypy`, `pre-commit`) are **not** installed by `pip install .` —
+  they live in the `pixi.toml` `feature` blocks. There is no `[project.optional-dependencies]`
+  table, so `pip install '.[dev]'` does nothing useful today.
+- The bounded version ranges in `pyproject.toml` (`>=X,<NEXT_MAJOR`) are honoured by both pip and
+  pixi; reproducible CI uses `pixi install --locked` against `pixi.lock`.
+
 ### Bumping the NATS Image Digest
 
 `docker-compose.yml` and the `integration-tests` job in `.github/workflows/_required.yml` both

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,35 @@ just health
 
 ```
 
+### Releasing a New Version
+
+Hermes publishes Docker images to GHCR (`ghcr.io/homericintelligence/projecthermes`) **only** on
+SemVer tags matching `v*.*.*`. Merges to `main` do not trigger a publish. To cut a release:
+
+```bash
+# 1. From a clean main, bump the version in BOTH pyproject.toml and pixi.toml
+#    (the deps/version-sync CI job rejects a mismatch).
+git checkout main && git pull
+$EDITOR pyproject.toml pixi.toml   # update [project].version / [project].version
+
+# 2. Commit and merge a release-prep PR
+git checkout -b release/v0.X.Y
+git commit -am "chore(release): v0.X.Y"
+gh pr create --title "chore(release): v0.X.Y" --body "Release prep"
+
+# 3. After the PR merges, tag the resulting commit on main and push the tag
+git checkout main && git pull
+git tag v0.X.Y
+git push origin v0.X.Y
+
+# 4. Watch the Publish workflow run; verify the image lands on GHCR
+gh run watch --exit-status
+gh api /orgs/HomericIntelligence/packages/container/projecthermes/versions \
+  --jq '.[0:3] | .[] | {name, created_at, metadata: .metadata.container.tags}'
+```
+
+Always tag on `main` after the version bump merges — never tag a feature branch.
+
 ### Installing with pip (alternative to pixi)
 
 Pixi is the **authoritative** development environment. `pip install .` is supported for runtime

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,28 @@ just health
 
 ```
 
+### Bumping the NATS Image Digest
+
+`docker-compose.yml` and the `integration-tests` job in `.github/workflows/_required.yml` both
+pin the NATS image to an immutable `@sha256:<digest>`. Bump the digest monthly (or sooner when a
+CVE scan flags the running image):
+
+```bash
+# 1. Pull the desired tag
+docker pull nats:2.14
+
+# 2. Read the new digest
+docker inspect --format '{{index .RepoDigests 0}}' nats:2.14
+
+# 3. Update BOTH files atomically in the same PR:
+#    - docker-compose.yml  (services.nats.image)
+#    - .github/workflows/_required.yml  (integration-tests "Start NATS with JetStream")
+# Then commit and open a PR titled "chore(deps): bump nats image digest".
+```
+
+If you bump only one file, `just docker-up` and the integration-tests CI job will end up running
+different NATS versions. The `forbid-suppressions` lint guard does not catch this — verify by hand.
+
 ### Python Conventions
 
 - **Python version**: 3.10+ (managed by pixi)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM python:3.12-slim AS builder
+# Pin python:3.12-slim by digest for reproducible builds. Bump in BOTH FROM lines together.
+# Refresh procedure (also in CONTRIBUTING.md → Bumping the NATS Image Digest):
+#   docker pull python:3.12-slim
+#   docker inspect --format '{{index .RepoDigests 0}}' python:3.12-slim
+FROM python:3.12-slim@sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe AS builder
 WORKDIR /build
 COPY pyproject.toml .
 RUN pip install --no-cache-dir \
     $(python3 -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print(' '.join(repr(s) for s in d['project']['dependencies']))") \
     --target /build/deps
 
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends tini && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,12 @@ RUN pip install --no-cache-dir \
 FROM python:3.12-slim@sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends tini && rm -rf /var/lib/apt/lists/*
+# Pin tini to a specific Debian package version for reproducibility (see CLAUDE.md §6).
+# Bump together with the python:3.12-slim digest above; verify the version is available with:
+#   docker run --rm python:3.12-slim apt-cache policy tini
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tini=0.19.0-1 \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/deps /usr/local/lib/python3.12/site-packages/
 COPY src/hermes/ ./hermes/

--- a/README.md
+++ b/README.md
@@ -228,6 +228,13 @@ export TLS_CA_BUNDLE=/etc/hermes/certs/ca-bundle.crt
 just start
 ```
 
+## Installation
+
+Pixi is the recommended install path because it manages a reproducible Python toolchain.
+`pip install .` is also supported for runtime consumers — see
+[CONTRIBUTING.md → Installing with pip](CONTRIBUTING.md#installing-with-pip-alternative-to-pixi)
+for the caveats (dev tooling lives in `pixi.toml`, not in a pip extras group).
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -181,12 +181,18 @@ cp .env.example .env
 
 ### NATS Reconnection
 
-Hermes connects to NATS with the following behavior:
+Hermes connects to NATS with the following behavior (see
+[ADR-001](docs/adr/ADR-001-nats-reconnect-strategy.md) for the rationale):
 
 - **Initial connection:** Uses `NATS_CONNECT_TIMEOUT` to establish the first connection to the
   NATS server.
-- **Automatic reconnection:** When an established connection drops, nats-py automatically attempts
-  to reconnect according to its internal backoff strategy.
+- **Fail-fast on disconnect:** Hermes calls `nats.connect(allow_reconnect=False)` so the nats-py
+  client never silently buffers messages while disconnected. A dropped connection is reflected
+  immediately on `/health` and `/ready` (both return `503`) and `POST /webhook` returns `503`
+  rather than acknowledging events that were never durably published.
+- **External reconnect loop:** A background task retries the connection every
+  `NATS_RECONNECT_INTERVAL` seconds with a `NATS_RECONNECT_HARD_TIMEOUT` per attempt; until a
+  reconnect succeeds the service stays unhealthy.
 - **Publish timeout:** Messages published to JetStream have a per-operation timeout of
   `NATS_PUBLISH_TIMEOUT`, ensuring pub/sub calls don't hang indefinitely.
 - **Connection lifecycle:** Use `SHUTDOWN_TIMEOUT` to allow graceful in-flight request completion

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Hermes exposes several endpoints for webhooks, health checks, and observability:
 | `/metrics`       | GET    | Prometheus metrics (counter, gauge, histogram)                                      | 200             |
 | `/subjects`      | GET    | List all NATS subjects published to in this session                                 | 200             |
 | `/events`        | GET    | Canonical list of supported webhook event types (agent_events, task_events)         | 200             |
-| `/dead-letters`  | GET    | View in-memory dead-letter queue of unroutable events                               | 200             |
+| `/dead-letters`  | GET    | View in-memory dead-letter queue of unroutable events                               | 200 / 401       |
+| `/dead-letters`  | DELETE | Drain (clear) the in-memory dead-letter queue                                       | 200 / 401       |
 
 ### Health Checks
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,6 +14,22 @@ Each ADR uses the following sections: **Status**, **Date**, **Deciders**, **Cont
 
 `Proposed` → `Accepted` → `Deprecated` / `Superseded by ADR-NNN`
 
+## Updating an ADR Status
+
+ADRs are append-mostly: once Accepted, the body is **not** rewritten. To change a status:
+
+1. Edit two places in the ADR file: the **header** (`**Status:** ...` near the top) and the
+   **Document Metadata** footer (`**Status:** ...` at the bottom). They must match — drift
+   between header and footer is a review red flag.
+2. If superseding, also fill in `**Superseded by:** ADR-NNN` in the footer of the old ADR and add
+   `**Supersedes:** ADR-MMM` in the footer of the new one.
+3. Update the **Status** column of the index table below so the index never drifts from the file
+   body.
+4. Open a PR titled `docs(adr): mark ADR-NNN as <new-status>` with the rationale in the body.
+   Approval requires at least one Hermes maintainer; the PR must not touch the ADR's Context,
+   Decision, Rationale, Consequences, or Alternatives Considered sections — those remain
+   historical record.
+
 ## Index
 
 | #                                             | Title                                        | Status   | Date       |

--- a/pixi.lock
+++ b/pixi.lock
@@ -99,7 +99,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl
@@ -1802,17 +1802,6 @@ packages:
   purls: []
   size: 119135
   timestamp: 1767016325805
-- pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
-  name: urllib3
-  version: 2.6.3
-  sha256: bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
-  requires_dist:
-  - brotli>=1.2.0 ; platform_python_implementation == 'CPython' and extra == 'brotli'
-  - brotlicffi>=1.2.0.0 ; platform_python_implementation != 'CPython' and extra == 'brotli'
-  - h2>=4,<5 ; extra == 'h2'
-  - pysocks>=1.5.6,!=1.5.7,<2.0 ; extra == 'socks'
-  - backports-zstd>=1.0.0 ; python_full_version < '3.14' and extra == 'zstd'
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
   name: urllib3
   version: 2.7.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,6 +20,9 @@ httpx = ">=0.27,<1"
 slowapi = ">=0.1.9,<1"
 limits = ">=5.8.0,<6"
 prometheus-client = ">=0.20,<1"
+# Pin urllib3>=2.7.0 to remediate CVE-2026-44431 and CVE-2026-44432 (transitive
+# via cachecontrol/requests on linux-64 — osx variants already resolve to 2.7.0).
+urllib3 = ">=2.7.0,<3"
 
 [feature.dev.pypi-dependencies]
 pytest = ">=9.0,<10"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,13 @@
+# scripts/
+
+Helper scripts for ProjectHermes development and CI. Run them from the repo root.
+
+| Script                 | When to run                                                  | What it does                                                                 |
+|------------------------|--------------------------------------------------------------|------------------------------------------------------------------------------|
+| `check_dep_sync.py`    | CI (and locally before `git push`)                           | Fails if any `[project.dependencies]` entry is missing a `<NEXT_MAJOR` upper bound. |
+| `check-symlinks.sh`    | CI (`symlink-check` job in `_required.yml`)                  | Verifies no tracked symlink escapes the repo root and none are broken.       |
+| `discover-tech-debt.sh`| Ad-hoc, when triaging tech debt                              | Greps the tree for `FIXME`/`TODO`/`HACK`/`XXX`/`DEPRECATED` markers.         |
+| `export-openapi.py`    | After any FastAPI route/schema change (`just export-openapi`)| Regenerates the committed `openapi.json` from the live FastAPI app.          |
+
+Add new scripts here only if they have a clear long-term purpose; one-off shell snippets belong in
+the issue or PR that needs them. When you add a script, update this README in the same commit.

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -51,6 +51,10 @@ class Settings(BaseSettings):
     log_json: bool = False
     active_subjects_max: int = 1000
     webhook_rate_limit: str = "60/minute"
+    # ``webhook_rate_limit_key`` selects the slowapi key strategy for /webhook.
+    # Currently only "ip" (== ``slowapi.util.get_remote_address``) is wired up in
+    # ``hermes.rate_limit``; "endpoint" is reserved for a future per-route key strategy. The
+    # validator below rejects unknown values at startup so misconfiguration fails loud.
     webhook_rate_limit_key: str = "ip"
     subjects_rate_limit: str = "60/minute"
     publish_retries: int = Field(default=3, ge=1)
@@ -93,6 +97,16 @@ class Settings(BaseSettings):
     def _validate_rate_limit(cls, v: str) -> str:
         if not re.match(r"^\d+\s*/\s*(second|minute|hour|day)$", v):
             raise ValueError(f"Rate limit must be like '100/minute', got: {v!r}")
+        return v
+
+    @field_validator("webhook_rate_limit_key")
+    @classmethod
+    def _validate_rate_limit_key(cls, v: str) -> str:
+        allowed = {"ip", "endpoint"}
+        if v not in allowed:
+            raise ValueError(
+                f"WEBHOOK_RATE_LIMIT_KEY must be one of {sorted(allowed)}, got: {v!r}"
+            )
         return v
 
     @field_validator("webhook_secret")

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -228,6 +228,13 @@ async def _require_dead_letter_key(
 
     When ``dead_letter_api_key`` is unset the check is bypassed (opt-in).
     A timing-safe comparison prevents key enumeration via response timing.
+
+    .. note::
+       Use ``str = Header(default="")`` rather than ``Annotated[str, Header()]`` here. With
+       ``from __future__ import annotations`` (active in this module), ``Annotated`` parameters
+       are evaluated as forward references inside FastAPI's ``Depends()`` machinery and raise
+       ``PydanticUserError`` at app startup on Python 3.14+. The plain default-arg form sidesteps
+       the forward-reference resolution entirely. See issue #518.
     """
     if not settings.dead_letter_api_key:
         return

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -281,6 +281,11 @@ class ShutdownMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
 
 app.add_middleware(ShutdownMiddleware)
 app.add_middleware(RequestIDMiddleware)
+# NOTE: ``max_bytes`` is captured from ``get_settings()`` at module-load time, *outside* any
+# FastAPI ``Depends`` context. As a consequence, ``app.dependency_overrides[get_settings]`` does
+# **not** affect this middleware during tests — tests that need a non-default
+# ``max_payload_bytes`` must set the env var (or monkey-patch ``get_settings``) *before* importing
+# ``hermes.server``. See issue #455 for the discussion and rationale.
 app.add_middleware(PayloadSizeLimitMiddleware, max_bytes=get_settings().max_payload_bytes)
 app.add_middleware(SlowAPIMiddleware)
 


### PR DESCRIPTION
Bundled implementation of the 2026-05-11 EASY-issue sweep for ProjectHermes (one commit per issue).

## Implemented (smallest viable diff)

- Closes #432 — README NATS Reconnection section now matches ADR-001 (`allow_reconnect=False`, fail-fast, external retry loop).
- Closes #553 — README endpoints table gains the DELETE /dead-letters row.
- Closes #552 — `NATS_RETRY_INTERVAL` and `NATS_RETRY_ATTEMPTS` documented in CLAUDE.md and AGENTS.md.
- Closes #534 — Five new dead-letter env vars added to CLAUDE.md configuration table.
- Closes #548 — `epic` label definition added to `.github/labels.yml` (matches the existing repo label `7057ff`).
- Closes #551 — AGENTS.md §1 task-event table now carries the forward-compatible-only caveat.
- Closes #554 — CLAUDE.md and AGENTS.md diagrams clarify Agamemnon is reached via HTTP, not as a NATS subscriber.
- Closes #572 — CLAUDE.md documents the `--read-only` + `--tmpfs /tmp` + `--cap-drop ALL` + `--security-opt no-new-privileges:true` flags for plain `docker run`.
- Closes #567 — CONTRIBUTING.md gains a NATS image digest bump procedure.
- Closes #498 / #595 — CONTRIBUTING.md and README.md document the `pip install .` workflow and its caveats vs pixi.
- Closes #492 — CONTRIBUTING.md gains a release/tag procedure.
- Closes #437 — `scripts/README.md` added with an inventory of the four scripts.
- Closes #435 — `docs/adr/README.md` documents the ADR status update process.
- Closes #506 — Inline comment on the SARIF upload step explaining `if: always()` (and why the scan step itself stays fatal). Wording avoids the literal substring guarded by `tests/test_workflow_secrets_scan.py`.
- Closes #455 — Inline NOTE on `PayloadSizeLimitMiddleware` documenting the module-load DI-override caveat.
- Closes #518 — Inline NOTE on `_require_dead_letter_key` warning future contributors away from `Annotated[str, Header()]` under `from __future__ import annotations`.
- Closes #451 — CLAUDE.md gains a "Future Integrations → Agamemnon" section capturing the established httpx pattern.
- Closes #584 — `WEBHOOK_RATE_LIMIT_KEY` now has a Pydantic validator restricting it to `{ip, endpoint}` and is documented in CLAUDE.md.
- Closes #490 — `publish.yml` pins `actions/checkout` and `docker/{setup-buildx,login,metadata,build-push}-action` to commit SHAs (resolved via `gh api`).
- Closes #557 — `Dockerfile` pins `python:3.12-slim` by digest (resolved via Docker Hub registry) in both build stages.
- Closes #563 — `Dockerfile` pins `tini=0.19.0-1` (current Debian bookworm version).
- Closes #505 — `GITLEAKS_VERSION` hoisted to workflow-level `env` in both `_required.yml` and `security.yml`; the two are now aligned on `8.30.1` (single source of truth per file).

## Verified ALREADY-DONE on `origin/main` (5307394) — token cannot post comments

- #536 — `docker-compose.yml:4` already pins `nats:2.14@sha256:79b36c2da1e54fb5d2c563dcb6da10b4a12cc18e13441782689579f130e1a9e4`.
- #494 — there is no `ci.yml` in `.github/workflows/`; `_required.yml` already pins `prefix-dev/setup-pixi@v0.9.5` consistently.
- #565 — `Dockerfile` uses `python:3.12-slim` only; no NATS base image is referenced. (Now pinned by digest via #557.)
- #583 — `WEBHOOK_RATE_LIMIT` is documented in `CLAUDE.md:81`, `README.md:163`, and referenced in `AGENTS.md:123`.
- #592 — `grep -rn 'master' README.md docs/ CONTRIBUTING.md CLAUDE.md AGENTS.md` returns no hits.
- #419 — there is no `ci.yml`; the `integration-tests` job in `_required.yml:230` already has `timeout-minutes: 15`. All jobs in `_required.yml`, `publish.yml`, and `security.yml` declare `timeout-minutes`.
- #429 / #589 / #542 — `CHANGELOG.md` was deleted from the repo (no file present, no references in any doc), making these moot.
- #559 — there is no `requirements.txt` and no `just sync-reqs` recipe; pixi is the single source of truth.
- #353 — `.claude/settings.json` now has substantial `permissions.deny` guardrails (rm -rf protections, `--no-verify` blocks, write/edit denylists for sensitive paths).
- #445 — `_reconnect_loop` calls `_connect_internal`, which calls `_ensure_streams()` (publisher.py:122), so streams are recreated after reconnect.
- #466 — tests use `from tests.helpers ...` (package-relative); no need to add `tests/` to `pythonpath`.
- #360 — auth on GET/DELETE `/dead-letters` is implemented at `server.py:223-239` via `_require_dead_letter_key`.
- #578 — server returns 401 (with `WWW-Authenticate: Bearer realm=hermes`) at `server.py:236`.

## BLOCKED — too large for sweep / risky in a sweep

- #420 — Adding a workflow timeout-check script + CI step + tests would exceed the 50-LoC cap and is a CI-policy change worth its own PR.
- #477 / #478 — Test coverage gaps in `__init__.py` (lines 10-11) and `middleware.py` (lines 38-39, 43-48) require new test fixtures + investigation of whether those branches are reachable; defer to a coverage-focused PR.

## Skipped (other)

(none)

## Verification

- `pixi run pre-commit run --files <changed-files>` — all hooks pass (gitleaks repo skipped due to a local Go-toolchain installer issue unrelated to this PR).
- `pixi run lint` — clean.
- `pixi run typecheck` — clean (`Success: no issues found in 10 source files`).
- `pixi run pytest -m "not integration"` — 440 passed, 57 deselected.