### PR TITLE
ci(security): SHA-pin actions/upload-artifact@v7 (#482)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -303,7 +303,7 @@ jobs:
         # Do NOT make the Run Gitleaks step itself non-fatal — that would let leaked secrets
         # silently merge to main. The forbid-suppressions guard would also reject any such opt-out.
         if: always() && hashFiles('gitleaks.sarif') != ''
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: gitleaks-report
           path: gitleaks.sarif


### PR DESCRIPTION
## Summary
- Replaces `actions/upload-artifact@v7` (a non-existent floating tag) with the same SHA-pinned `v4.6.2` ref already used in `unit-tests` of `_required.yml`, in the `security/secrets-scan` job's Gitleaks SARIF upload step.
- Trailing `# v4.6.2` comment preserved so dependabot can still propose bumps.
- Closes #482

## Test plan
- [x] Both `actions/upload-artifact` refs in `_required.yml` are now SHA-pinned to `ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
- [x] CI passes
- [x] dependabot can still propose bumps via the trailing version comment

Generated with [Claude Code](https://claude.com/claude-code)