### PR TITLE
chore(tests): remove dead pytest_collection_modifyitems stub (#472)

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,12 +39,6 @@ def _sign(body: bytes) -> str:
 # ---------------------------------------------------------------------------
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Skip all integration tests if NATS is unreachable."""
-    # Evaluated lazily at collection time via a custom marker skip mechanism
-    pass
-
-
 @pytest.fixture(scope="module", autouse=True)
 def require_nats() -> None:  # type: ignore[return]
     """Skip the entire module when NATS is not reachable."""


### PR DESCRIPTION
## Summary
- Removes a no-op `pytest_collection_modifyitems` stub in `tests/test_integration.py`. The function body was only `pass` with a comment saying evaluation was deferred. Actual skip-when-NATS-unavailable behaviour is provided by the autouse `require_nats` module fixture.
- Closes #472

## Test plan
- [x] pytest collects and runs unchanged (stub did nothing)
- [x] No remaining callers / refs (grep confirmed)

Generated with [Claude Code](https://claude.com/claude-code)