### PR TITLE
test(init): cover missing __init__.py lines (#477)

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
 from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
@@ -61,3 +63,56 @@ def test_server_app_version_is_not_hardcoded_string() -> None:
         source = inspect.getsource(server_module)
         assert '"0.1.0"' not in source, "server.py must not contain the hardcoded version string"
         assert "__version__" in source, "server.py must reference __version__"
+
+
+def _reload_hermes_pkg() -> object:
+    """Reload the ``hermes`` package module so its top-level code re-executes.
+
+    This is required to actually exercise the ``try/except PackageNotFoundError``
+    block at the top of ``src/hermes/__init__.py`` (lines 10-11), which only runs
+    at module import time.
+    """
+    # Drop the cached module so ``importlib.reload`` re-executes the module body.
+    sys.modules.pop("hermes", None)
+    return importlib.import_module("hermes")
+
+
+def test_hermes_init_sets_version_from_metadata_on_import() -> None:
+    """Importing ``hermes`` with metadata available sets ``__version__`` from it.
+
+    This exercises line 9 of ``src/hermes/__init__.py`` (the successful
+    ``version("hermes")`` call) at actual import time, not via re-implementation.
+    """
+    original = sys.modules.get("hermes")
+    try:
+        with patch("importlib.metadata.version", return_value="7.7.7"):
+            hermes_mod = _reload_hermes_pkg()
+            assert hermes_mod.__version__ == "7.7.7"
+    finally:
+        # Restore a clean import for subsequent tests.
+        sys.modules.pop("hermes", None)
+        if original is not None:
+            sys.modules["hermes"] = original
+        importlib.import_module("hermes")
+
+
+def test_hermes_init_falls_back_to_unknown_on_import_when_metadata_missing() -> None:
+    """Importing ``hermes`` without package metadata sets ``__version__='unknown'``.
+
+    This exercises lines 10-11 of ``src/hermes/__init__.py`` (the
+    ``except PackageNotFoundError`` fallback) at actual import time, which is the
+    code path flagged as uncovered in issue #477.
+    """
+    original = sys.modules.get("hermes")
+    try:
+        with patch(
+            "importlib.metadata.version",
+            side_effect=PackageNotFoundError("hermes"),
+        ):
+            hermes_mod = _reload_hermes_pkg()
+            assert hermes_mod.__version__ == "unknown"
+    finally:
+        sys.modules.pop("hermes", None)
+        if original is not None:
+            sys.modules["hermes"] = original
+        importlib.import_module("hermes")


### PR DESCRIPTION
## Summary
- Adds two tests in `tests/test_version.py` that reload the `hermes` package with `importlib.metadata.version` mocked, so the module-level `try/except PackageNotFoundError` block in `src/hermes/__init__.py` (lines 10-11) actually executes during the test run.
- Existing version tests re-implemented the fallback logic in the test body rather than triggering it at import time, leaving `src/hermes/__init__.py` at 75% line coverage (lowest in the package, with floor 70%).
- After this change `src/hermes/__init__.py` reaches 100% line coverage; full unit-suite total coverage is 97.15%.
- Closes #477

## Test plan
- [x] `pixi run pytest tests/test_version.py` — 7 passed (the 2 new tests plus existing 5)
- [x] `pixi run pytest -m "not integration"` — 442 passed, 57 deselected
- [x] `src/hermes/__init__.py` coverage = 100.00% (was 75%)

Generated with [Claude Code](https://claude.com/claude-code)