### PR TITLE
build(docker): add tmpfs for /app/__pycache__ (#569)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,9 @@ services:
     read_only: true
     tmpfs:
       - /tmp
+      # Defense-in-depth: if PYTHONDONTWRITEBYTECODE is overridden at runtime,
+      # Python would otherwise fail to write .pyc files under the read-only FS.
+      - /app/__pycache__
     cap_drop:
       - ALL
     security_opt:


### PR DESCRIPTION
## Summary
- Mounts `/app/__pycache__` as tmpfs in `docker-compose.yml` so the container starts cleanly even if `PYTHONDONTWRITEBYTECODE` is overridden at runtime.
- Defense-in-depth complement to the existing `ENV PYTHONDONTWRITEBYTECODE=1` in the Dockerfile (from #357).
- Closes #569

## Test plan
- [x] Container starts under `read_only: true`
- [x] No `__pycache__` write failures even if `-e PYTHONDONTWRITEBYTECODE=` is passed