### PR TITLE
fix(reconnect): reuse _stop_event across connect() calls (#524)

### DIFF
--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -83,13 +83,37 @@ class Publisher:
     # ------------------------------------------------------------------
 
     async def connect(self, url: str, connect_timeout: float = 5.0) -> None:
-        """Connect to NATS, ensure streams exist, and start the background reconnect loop."""
+        """Connect to NATS, ensure streams exist, and start the background reconnect loop.
+
+        ``_stop_event`` is owned by the Publisher instance for its full lifetime
+        (see issue #524).  It is cleared — not replaced — on each ``connect()`` so
+        that any pre-existing references (for example, from a stale
+        ``_reconnect_task`` left over after a failed startup) still observe
+        ``set()`` from ``disconnect()``.  If a previous reconnect task is still
+        running, it is cancelled before a new one is started so we never have two
+        concurrent loops racing on the same event.
+        """
         from hermes.config import get_settings
 
         settings = get_settings()
         await self._connect_internal(url, connect_timeout)
         logger.info("Connected to NATS at %s", url)
-        self._stop_event = asyncio.Event()
+
+        # Cancel any pre-existing reconnect task (e.g. from a previous connect()
+        # that was not followed by disconnect()) to avoid two loops running on
+        # the same _stop_event.
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+            try:
+                await self._reconnect_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._reconnect_task = None
+
+        # Reuse the existing Event (created in __init__) — only clear it.
+        # Never rebind self._stop_event here, otherwise a stale task started
+        # in a previous connect() would hold the old Event forever.
+        self._stop_event.clear()
         self._reconnect_task = asyncio.ensure_future(
             self._reconnect_loop(
                 url,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1195,3 +1195,77 @@ class TestJetStreamAck:
             await msg.ack()
         finally:
             await pub.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Issue #524 — _stop_event reuse across connect() calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestStopEventReuseIntegration:
+    """Cover the ``connect()`` stale-task cancellation and ``_stop_event`` reuse
+    branches against a live NATS server (issue #524).  The pure-unit tests in
+    ``tests/test_publisher_reconnect.py`` already verify the same logic with
+    mocks, but they do not contribute to the ``integration-tests`` coverage
+    gate — these complement them.
+    """
+
+    async def test_double_connect_reuses_stop_event_and_cancels_stale_task(
+        self, nats_url: str
+    ) -> None:
+        """A second ``connect()`` without intervening ``disconnect()`` must
+        reuse the same ``_stop_event`` instance AND cancel the prior
+        reconnect task (publisher.py lines 105-111 + 116).
+        """
+        pub = Publisher()
+        original_event = pub._stop_event
+        try:
+            await pub.connect(nats_url)
+            first_task = pub._reconnect_task
+            assert first_task is not None
+            assert not first_task.done()
+            assert pub._stop_event is original_event
+
+            # Second connect() exercises the cancel-stale-task branch.
+            await pub.connect(nats_url)
+            second_task = pub._reconnect_task
+            assert second_task is not None
+            assert second_task is not first_task
+            assert first_task.done(), "stale reconnect task must be cancelled"
+            assert pub._stop_event is original_event, (
+                "second connect() must not rebind _stop_event"
+            )
+            assert not pub._stop_event.is_set(), (
+                "connect() must clear the reused Event so the new loop can run"
+            )
+        finally:
+            await pub.disconnect()
+        # disconnect() sets the shared event, so the (still-original) Event
+        # instance must reflect that — proves identity preservation end-to-end.
+        assert pub._stop_event is original_event
+        assert pub._stop_event.is_set()
+
+    async def test_reconnect_after_disconnect_clears_stop_event(
+        self, nats_url: str
+    ) -> None:
+        """``connect()`` after ``disconnect()`` must clear the existing Event
+        so the new ``_reconnect_loop`` does not exit immediately
+        (publisher.py line 116, post-disconnect rearm path).
+        """
+        pub = Publisher()
+        original_event = pub._stop_event
+        await pub.connect(nats_url)
+        await pub.disconnect()
+        assert pub._stop_event.is_set()
+        assert pub._reconnect_task is None
+
+        # Reconnect: must re-arm (clear) the same Event so the new loop runs.
+        await pub.connect(nats_url)
+        try:
+            assert pub._stop_event is original_event
+            assert not pub._stop_event.is_set()
+            assert pub._reconnect_task is not None
+            assert not pub._reconnect_task.done()
+        finally:
+            await pub.disconnect()

--- a/tests/test_publisher_reconnect.py
+++ b/tests/test_publisher_reconnect.py
@@ -364,3 +364,79 @@ class TestConnectInternalExtracted:
 
         mock_conn.assert_called_once()
         await pub.disconnect()
+
+
+class TestStopEventLifetime:
+    """Regression coverage for #524 — _stop_event identity must survive reconnect()."""
+
+    @pytest.mark.asyncio
+    async def test_stop_event_identity_preserved_across_reconnect(self) -> None:
+        """Calling connect() twice without disconnect() must reuse the same Event.
+
+        Otherwise a stale _reconnect_task spawned by the first connect() holds a
+        reference to the old Event and would never observe stop_event.set().
+        """
+        pub = Publisher()
+        original_event = pub._stop_event
+
+        mock_nc1 = _make_mock_nc()
+        await _do_connect(pub, mock_nc1)
+        assert pub._stop_event is original_event, (
+            "connect() must not replace _stop_event"
+        )
+
+        # Second connect() without intervening disconnect() (simulates retry
+        # after a startup failure described in #524).
+        mock_nc2 = _make_mock_nc()
+        await _do_connect(pub, mock_nc2)
+        assert pub._stop_event is original_event, (
+            "second connect() must not replace _stop_event"
+        )
+
+        # And disconnect() must still cleanly stop the (latest) loop via the
+        # shared Event.
+        await pub.disconnect()
+        assert pub._stop_event is original_event
+        assert pub._stop_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_double_connect_cancels_stale_reconnect_task(self) -> None:
+        """A second connect() must cancel the prior _reconnect_task.
+
+        Two concurrent loops sharing _stop_event would race on reconnect attempts
+        and double-increment metrics on every flap.
+        """
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+        await _do_connect(pub, mock_nc)
+        first_task = pub._reconnect_task
+        assert first_task is not None
+
+        await _do_connect(pub, _make_mock_nc())
+        second_task = pub._reconnect_task
+        assert second_task is not None
+        assert second_task is not first_task
+        assert first_task.done(), "stale reconnect task must be cancelled"
+
+        await pub.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_stop_event_cleared_on_reconnect(self) -> None:
+        """connect() after a prior disconnect() must re-arm (clear) the Event.
+
+        Otherwise the new _reconnect_loop sees stop_event already set and exits
+        immediately, leaving the publisher with no reconnect coverage.
+        """
+        pub = Publisher()
+        mock_nc = _make_mock_nc()
+        await _do_connect(pub, mock_nc)
+        await pub.disconnect()
+        assert pub._stop_event.is_set()
+
+        # Re-connect: stop_event must be cleared so the new loop can run.
+        await _do_connect(pub, _make_mock_nc())
+        assert not pub._stop_event.is_set()
+        assert pub._reconnect_task is not None
+        assert not pub._reconnect_task.done()
+
+        await pub.disconnect()


### PR DESCRIPTION
## Summary
- `Publisher.connect()` rebound `self._stop_event = asyncio.Event()` on every call, so a second `connect()` without an intervening `disconnect()` left the *first* `_reconnect_task` holding a reference to the now-orphaned `Event` — it would never observe `disconnect().set()` and would leak forever (issue #524).
- Fix: own `_stop_event` for the Publisher's lifetime. `connect()` now `clear()`s the existing Event (re-arming it) instead of rebinding it, and cancels any pre-existing `_reconnect_task` before starting a new one so two loops can never race on the same Event.

## Test plan
- [x] `pytest tests/test_publisher_reconnect.py` — 18/18 pass (including 3 new regression tests).
- [x] `pytest tests/test_publisher*.py tests/test_lifespan.py tests/test_shutdown.py` — 112/112 pass.
- [x] New regression coverage:
  - `_stop_event` identity preserved across two `connect()` calls without `disconnect()`.
  - Stale `_reconnect_task` is cancelled when `connect()` is called again.
  - `_stop_event` is re-armed (cleared) by `connect()` after a prior `disconnect()` so the new loop actually runs.

Closes #524

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code