### PR TITLE
fix(metrics): dedupe reconnect_count increments (#526)

### DIFF
--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -106,8 +106,11 @@ class Publisher:
             logger.warning("NATS disconnected")
 
         async def _on_reconnected() -> None:
+            # Note: with allow_reconnect=False this callback is never fired by
+            # nats-py in practice. The _reconnect_loop success path is the sole
+            # incrementer of reconnect_count to avoid double-counting if this
+            # assumption ever changes. See issue #526.
             self._connected = True
-            self.reconnect_count += 1
             logger.info("NATS reconnected (count=%d)", self.reconnect_count)
 
         self._nc = await nats.connect(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -661,16 +661,25 @@ class TestReconnectLifecycle:
         finally:
             await pub2.disconnect()
 
-    async def test_reconnect_count_increments_via_callback(self, nats_url: str) -> None:
-        """Manually invoking the reconnected callback increments reconnect_count."""
+    async def test_reconnect_count_not_incremented_by_nats_callback(
+        self, nats_url: str
+    ) -> None:
+        """Regression for issue #526.
+
+        The nats-py ``reconnected_cb`` must not touch ``reconnect_count``; only
+        the ``_reconnect_loop`` success path increments it. This prevents a
+        single reconnect from being counted twice if nats-py ever fires the
+        callback (e.g. if ``allow_reconnect`` is flipped to True).
+        """
         pub = Publisher()
         await pub.connect(nats_url)
         try:
             assert pub.reconnect_count == 0
-            # Simulate the nats-py internal reconnect callback being fired.
-            pub._connected = True
-            pub.reconnect_count += 1
-            assert pub.reconnect_count == 1
+            # The callback is closed over inside _connect_internal; we cannot
+            # reach it from outside, but the contract is verified in the unit
+            # test ``test_reconnected_cb_does_not_increment_reconnect_count``.
+            # Here we just assert the steady-state invariant.
+            assert pub.reconnect_count == 0
         finally:
             await pub.disconnect()
 

--- a/tests/test_publisher_callbacks.py
+++ b/tests/test_publisher_callbacks.py
@@ -79,7 +79,14 @@ class TestPublisherConnectionCallbacks:
         assert pub.is_connected is True
 
     @pytest.mark.asyncio
-    async def test_reconnected_cb_increments_reconnect_count(self) -> None:
+    async def test_reconnected_cb_does_not_increment_reconnect_count(self) -> None:
+        """Regression for issue #526.
+
+        The nats-py ``reconnected_cb`` must NOT increment ``reconnect_count``.
+        The ``_reconnect_loop`` success path is the sole incrementer; otherwise
+        a successful reconnect would be counted twice if nats-py ever fires the
+        callback (e.g. if ``allow_reconnect`` is changed in the future).
+        """
         pub = Publisher()
         mock_nc = MagicMock()
         mock_nc.jetstream.return_value = MagicMock()
@@ -98,9 +105,11 @@ class TestPublisherConnectionCallbacks:
 
         assert pub.reconnect_count == 0
         await captured_callbacks["reconnected_cb"]()  # type: ignore[operator]
-        assert pub.reconnect_count == 1
+        assert pub.reconnect_count == 0
         await captured_callbacks["reconnected_cb"]()  # type: ignore[operator]
-        assert pub.reconnect_count == 2
+        assert pub.reconnect_count == 0
+        # The callback still restores the connected flag.
+        assert pub.is_connected is True
 
     @pytest.mark.asyncio
     async def test_disconnected_cb_sets_last_error(self) -> None:

--- a/tests/test_publisher_reconnect.py
+++ b/tests/test_publisher_reconnect.py
@@ -168,7 +168,50 @@ class TestReconnectLoopRetriesOnLostConnection:
             pub._stop_event.set()
             await loop_task
 
-        assert pub.reconnect_count > initial_count
+        assert pub.reconnect_count == initial_count + 1
+
+    @pytest.mark.asyncio
+    async def test_reconnect_count_no_double_increment_if_callback_fires(self) -> None:
+        """Regression for issue #526.
+
+        A single successful reconnect must increment ``reconnect_count`` by
+        exactly 1, even if nats-py also invokes the ``reconnected_cb`` callback
+        (which it would do if ``allow_reconnect`` were ever changed to True).
+        """
+        pub = Publisher()
+        call_count = 0
+        reconnected: asyncio.Event = asyncio.Event()
+        captured_callbacks: dict[str, object] = {}
+
+        async def fake_connect(url: str, **kwargs: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            captured_callbacks.update(kwargs)
+            if call_count > 1:
+                reconnected.set()
+                pub._stop_event.set()
+            return _make_mock_nc(closed=False)
+
+        with patch("nats.connect", side_effect=fake_connect):
+            await pub.connect("nats://localhost:4222")
+            initial_count = pub.reconnect_count
+
+            # Simulate connection loss
+            pub._nc = _make_mock_nc(closed=True)
+
+            pub._stop_event = asyncio.Event()
+            loop_task = asyncio.ensure_future(
+                pub._reconnect_loop("nats://localhost:4222", 5.0, 0.05, 5.0)
+            )
+            await asyncio.wait_for(reconnected.wait(), timeout=5.0)
+            # Simulate nats-py firing the reconnected_cb in addition to the
+            # external reconnect loop succeeding (the double-fire scenario).
+            await captured_callbacks["reconnected_cb"]()  # type: ignore[operator]
+            pub._stop_event.set()
+            await loop_task
+
+        # Exactly one increment despite both the loop AND the callback firing.
+        assert pub.reconnect_count == initial_count + 1
 
     @pytest.mark.asyncio
     async def test_last_error_set_on_failed_reconnect(self) -> None:


### PR DESCRIPTION
## Summary

Closes #526.

`Publisher._on_reconnected()` (the nats-py callback registered in `_connect_internal`) previously incremented `reconnect_count` in addition to the `_reconnect_loop()` success path. Because `allow_reconnect=False`, the nats-py callback never fires in practice today — but if that assumption ever changes, a single reconnect would be counted twice.

This PR makes `_reconnect_loop()` the **sole** incrementer of `reconnect_count`. The `_on_reconnected` callback is preserved (it still restores the `_connected` flag and logs) but no longer touches the counter.

## Changes

- `src/hermes/publisher.py`: `_on_reconnected` no longer increments `reconnect_count`; comment explains why.
- `tests/test_publisher_callbacks.py`: existing assertion flipped to verify the callback does **not** bump the counter (regression test).
- `tests/test_publisher_reconnect.py`:
  - tightened `test_reconnect_count_increments_on_success` to assert exactly `+1` (not `> initial`).
  - new `test_reconnect_count_no_double_increment_if_callback_fires` — simulates both the external loop reconnecting **and** the nats-py `reconnected_cb` firing in the same window; asserts net delta is exactly `+1`.
- `tests/test_integration.py`: updated the integration test that previously documented the double-increment behavior to match the new contract.

## Test plan

- [ ] CI: `pytest tests/test_publisher_callbacks.py tests/test_publisher_reconnect.py` passes
- [ ] CI: integration suite still green
- [ ] Manual: review of `publisher.py` confirms `_reconnect_loop` is the only `reconnect_count += 1` site

🤖 Generated with [Claude Code](https://claude.com/claude-code)