### PR TITLE
fix(deadletter): update existing stream TTL on startup (#530)

### DIFF
--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -64,7 +64,9 @@ class Publisher:
         s = get_settings()
         self._nc: NATSClient | None = None
         self._js: JetStreamContext | None = None
-        self._max_subjects: int = max_subjects if max_subjects is not None else s.active_subjects_max
+        self._max_subjects: int = (
+            max_subjects if max_subjects is not None else s.active_subjects_max
+        )
         self._active_subjects: OrderedDict[str, None] = OrderedDict()
         self._stream_names: list[str] = []
         self._dead_letters: deque[dict[str, Any]] = deque(maxlen=s.dead_letter_max_size)
@@ -166,9 +168,7 @@ class Publisher:
         jsm = self._nc.jsm()
 
         dead_letter_ttl = (
-            timedelta(seconds=s.dead_letter_ttl_seconds)
-            if s.dead_letter_ttl_seconds > 0
-            else None
+            timedelta(seconds=s.dead_letter_ttl_seconds) if s.dead_letter_ttl_seconds > 0 else None
         )
 
         stream_configs: list[tuple[str, list[str], dict[str, Any]]] = [
@@ -182,11 +182,27 @@ class Publisher:
         ]
 
         for name, subjects, extra in stream_configs:
+            desired_config = StreamConfig(name=name, subjects=subjects, **extra)
             try:
-                await jsm.stream_info(name)
+                info = await jsm.stream_info(name)
             except NotFoundError:
-                await jsm.add_stream(StreamConfig(name=name, subjects=subjects, **extra))
+                await jsm.add_stream(desired_config)
                 logger.info("Created JetStream stream: %s (%s)", name, subjects)
+            else:
+                # Migrate existing deployments: if max_age on disk differs from
+                # the desired value, push the updated config to NATS.  Without
+                # this, deployments created before a TTL change keep the old
+                # retention window (see issue #530, follow-up from #347).
+                desired_max_age = extra.get("max_age", 0) or 0
+                current_max_age = getattr(info.config, "max_age", 0) or 0
+                if float(desired_max_age) != float(current_max_age):
+                    await jsm.update_stream(desired_config)
+                    logger.info(
+                        "Updated JetStream stream %s: max_age %s -> %s",
+                        name,
+                        current_max_age,
+                        desired_max_age,
+                    )
             if name not in self._stream_names:
                 self._stream_names.append(name)
 

--- a/tests/test_dead_letter_limits.py
+++ b/tests/test_dead_letter_limits.py
@@ -222,9 +222,7 @@ class TestEnsureStreamsDeadLetterTTL:
         await pub._ensure_streams()
 
         calls = mock_jsm.add_stream.call_args_list
-        dead_letter_call = next(
-            c for c in calls if c.args[0].name == "homeric-deadletter"
-        )
+        dead_letter_call = next(c for c in calls if c.args[0].name == "homeric-deadletter")
         cfg = dead_letter_call.args[0]
         assert cfg.max_age == timedelta(seconds=3600).total_seconds()
 
@@ -250,11 +248,94 @@ class TestEnsureStreamsDeadLetterTTL:
         await pub._ensure_streams()
 
         calls = mock_jsm.add_stream.call_args_list
-        dead_letter_call = next(
-            c for c in calls if c.args[0].name == "homeric-deadletter"
-        )
+        dead_letter_call = next(c for c in calls if c.args[0].name == "homeric-deadletter")
         cfg = dead_letter_call.args[0]
         assert cfg.max_age is None
+
+
+# ---------------------------------------------------------------------------
+# Publisher: _ensure_streams updates existing dead-letter stream TTL (#530)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureStreamsDeadLetterTTLMigration:
+    """_ensure_streams calls update_stream when the existing TTL differs (#530)."""
+
+    @pytest.mark.asyncio
+    async def test_update_called_when_existing_max_age_differs(self) -> None:
+        from hermes.config import get_settings
+        from hermes.publisher import Publisher
+
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_ttl_seconds = 3600
+
+        pub = Publisher()
+        mock_nc = MagicMock()
+        mock_jsm = AsyncMock()
+
+        # Existing stream returns a different max_age (e.g. previously 1800).
+        # stream_info must succeed (no NotFoundError) so the update path is taken.
+        existing_info = MagicMock()
+        existing_info.config = MagicMock(max_age=1800.0)
+
+        async def _stream_info(name: str) -> MagicMock:
+            return existing_info
+
+        mock_jsm.stream_info = AsyncMock(side_effect=_stream_info)
+        mock_jsm.add_stream = AsyncMock()
+        mock_jsm.update_stream = AsyncMock()
+        mock_nc.jsm = MagicMock(return_value=mock_jsm)
+        pub._nc = mock_nc
+
+        await pub._ensure_streams()
+
+        # add_stream should NOT be called for an existing stream
+        assert mock_jsm.add_stream.call_args_list == []
+
+        # update_stream must be called for the homeric-deadletter stream with
+        # the desired max_age (3600s).
+        update_calls = mock_jsm.update_stream.call_args_list
+        deadletter_updates = [c for c in update_calls if c.args[0].name == "homeric-deadletter"]
+        assert len(deadletter_updates) == 1
+        cfg = deadletter_updates[0].args[0]
+        assert cfg.max_age == timedelta(seconds=3600).total_seconds()
+
+    @pytest.mark.asyncio
+    async def test_update_skipped_when_existing_max_age_matches(self) -> None:
+        from hermes.config import get_settings
+        from hermes.publisher import Publisher
+
+        get_settings.cache_clear()
+        s = get_settings()
+        s.dead_letter_ttl_seconds = 3600
+
+        pub = Publisher()
+        mock_nc = MagicMock()
+        mock_jsm = AsyncMock()
+
+        # Existing stream already has the desired max_age — no update needed.
+        existing_info = MagicMock()
+        existing_info.config = MagicMock(max_age=float(timedelta(seconds=3600).total_seconds()))
+
+        # homeric-agents / homeric-tasks have no extra config (max_age == 0/None).
+        # Return matching info for those too so update_stream is never called.
+        zero_info = MagicMock()
+        zero_info.config = MagicMock(max_age=0)
+
+        async def _stream_info(name: str) -> MagicMock:
+            return existing_info if name == "homeric-deadletter" else zero_info
+
+        mock_jsm.stream_info = AsyncMock(side_effect=_stream_info)
+        mock_jsm.add_stream = AsyncMock()
+        mock_jsm.update_stream = AsyncMock()
+        mock_nc.jsm = MagicMock(return_value=mock_jsm)
+        pub._nc = mock_nc
+
+        await pub._ensure_streams()
+
+        assert mock_jsm.update_stream.call_args_list == []
+        assert mock_jsm.add_stream.call_args_list == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_ensure_streams()` previously skipped existing streams entirely, so a change to `dead_letter_ttl_seconds` was never applied to deployments where `homeric-deadletter` already existed (follow-up from #347).
- This PR compares the live stream's `max_age` against the desired value and calls `jsm.update_stream()` when they differ; matching values short-circuit with no extra round-trip.
- Adds two unit tests in `tests/test_dead_letter_limits.py` exercising both the divergent and matching paths via mocked `JetStreamManager`.

Closes #530

## Test plan
- [x] `pixi run pytest tests/test_dead_letter_limits.py tests/test_publisher.py --no-cov` — 77 passed
- [x] `pixi run pytest tests/ --no-cov --ignore=tests/test_integration.py` — 467 passed
- [x] `pixi run ruff check` / `ruff format --check` — clean
- [x] `pixi run mypy src/hermes/publisher.py` — no issues
- [ ] CI green on the PR

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)