### PR TITLE
fix(reconnect): exponential backoff on retry (#525)

### DIFF
--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -61,6 +61,17 @@ class Settings(BaseSettings):
     publish_retry_base_delay: float = Field(default=0.1, gt=0)
     nats_reconnect_interval: float = Field(default=5.0, gt=0)
     nats_reconnect_hard_timeout: float = Field(default=5.0, gt=0)
+    # Cap for the exponential backoff between failed reconnect attempts.  Once the
+    # computed delay (``nats_reconnect_interval * 2**attempt``) reaches this value,
+    # further failures wait at most ``nats_reconnect_max_interval`` seconds between
+    # attempts.  This prevents reconnect storms when NATS is down for extended
+    # periods and tames the linear growth of ``NATS_RECONNECTS{result='failed'}``.
+    nats_reconnect_max_interval: float = Field(default=60.0, gt=0)
+    # Multiplicative jitter applied to the computed backoff delay; the final delay
+    # is sampled uniformly from ``[delay * (1 - jitter), delay * (1 + jitter)]``.
+    # Set to ``0`` to disable jitter (deterministic backoff).  Bounded to ``< 1``
+    # so the lower bound stays positive.
+    nats_reconnect_jitter: float = Field(default=0.1, ge=0, lt=1)
 
     @field_validator("hermes_public_url", mode="before")
     @classmethod
@@ -73,6 +84,21 @@ class Settings(BaseSettings):
         if parsed.scheme not in ("http", "https"):
             raise ValueError(f"HERMES_PUBLIC_URL must be http or https, got: {v!r}")
         return v.rstrip("/")
+
+    @model_validator(mode="after")
+    def _validate_reconnect_backoff_bounds(self) -> "Settings":
+        """Ensure the backoff cap is at least as large as the base interval.
+
+        A cap below the base would clamp the very first retry, producing the same
+        constant-interval reconnect storm this setting was introduced to prevent.
+        """
+        if self.nats_reconnect_max_interval < self.nats_reconnect_interval:
+            raise ValueError(
+                "NATS_RECONNECT_MAX_INTERVAL must be >= NATS_RECONNECT_INTERVAL "
+                f"(got max={self.nats_reconnect_max_interval}, "
+                f"base={self.nats_reconnect_interval})"
+            )
+        return self
 
     @model_validator(mode="after")
     def _set_public_url_default(self) -> "Settings":
@@ -104,9 +130,7 @@ class Settings(BaseSettings):
     def _validate_rate_limit_key(cls, v: str) -> str:
         allowed = {"ip", "endpoint"}
         if v not in allowed:
-            raise ValueError(
-                f"WEBHOOK_RATE_LIMIT_KEY must be one of {sorted(allowed)}, got: {v!r}"
-            )
+            raise ValueError(f"WEBHOOK_RATE_LIMIT_KEY must be one of {sorted(allowed)}, got: {v!r}")
         return v
 
     @field_validator("webhook_secret")

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -96,6 +96,8 @@ class Publisher:
                 connect_timeout,
                 settings.nats_reconnect_interval,
                 settings.nats_reconnect_hard_timeout,
+                max_interval=settings.nats_reconnect_max_interval,
+                jitter=settings.nats_reconnect_jitter,
             )
         )
 
@@ -132,30 +134,64 @@ class Publisher:
         connect_timeout: float,
         reconnect_interval: float,
         hard_timeout: float,
+        max_interval: float | None = None,
+        jitter: float = 0.0,
     ) -> None:
-        """Background task: detect NATS connection loss and attempt to reconnect."""
+        """Background task: detect NATS connection loss and attempt to reconnect.
+
+        Uses bounded exponential backoff between *failed* reconnect attempts:
+        ``delay = min(reconnect_interval * 2**failed_attempts, max_interval)``
+        with optional multiplicative jitter.  The ``failed_attempts`` counter
+        is reset to zero whenever a reconnect succeeds or whenever the
+        connection is observed to be alive at the top of an iteration, so a
+        single transient blip does not penalise subsequent recoveries.
+
+        ``max_interval=None`` disables the cap (falls back to
+        ``reconnect_interval``, matching the legacy fixed-interval behaviour
+        on the first attempt).  ``jitter=0`` produces a deterministic delay.
+        """
+        cap = max_interval if max_interval is not None else reconnect_interval
+        # ``failed_attempts`` is the *exponent* used for the next sleep.  We
+        # bump it after a failed reconnect (so the next wait is longer) and
+        # reset it on success or when the connection is observed healthy.
+        failed_attempts = 0
         while not self._stop_event.is_set():
+            delay = min(reconnect_interval * (2**failed_attempts), cap)
+            if jitter > 0:
+                delay *= random.uniform(1.0 - jitter, 1.0 + jitter)
             try:
-                await asyncio.wait_for(self._stop_event.wait(), timeout=reconnect_interval)
+                await asyncio.wait_for(self._stop_event.wait(), timeout=delay)
                 return  # stop_event fired during sleep
             except asyncio.TimeoutError:
                 pass
             if self._stop_event.is_set():
                 return
             if self._nc is not None and not self._nc.is_closed:
-                continue  # connection still alive
-            logger.warning("NATS connection lost; attempting reconnect")
+                failed_attempts = 0  # connection healthy — reset backoff
+                continue
+            logger.warning(
+                "NATS connection lost; attempting reconnect (failed_attempts=%d, last_delay=%.3fs)",
+                failed_attempts,
+                delay,
+            )
             try:
                 await asyncio.wait_for(
                     self._connect_internal(url, connect_timeout), timeout=hard_timeout
                 )
                 self.reconnect_count += 1
+                failed_attempts = 0
                 NATS_RECONNECTS.labels(result="success").inc()
                 logger.info("NATS reconnected via external loop (count=%d)", self.reconnect_count)
             except Exception as exc:
                 self.last_error = str(exc)
+                # Saturate the exponent once the cap is reached so 2**n doesn't
+                # overflow into absurd values during very long outages.  At
+                # base=5s and cap=60s the cap binds at attempt=4, so 32 leaves
+                # plenty of headroom while staying bounded.
+                if failed_attempts < 32:
+                    failed_attempts += 1
                 NATS_RECONNECTS.labels(result="failed").inc()
-                logger.error("NATS reconnect failed: %s", exc)
+                logger.error("NATS reconnect failed (failed_attempts=%d): %s", failed_attempts, exc)
 
     async def _ensure_streams(self) -> None:
         """Create JetStream streams if they don't exist yet."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -685,6 +685,109 @@ class TestReconnectLifecycle:
 
 
 # ---------------------------------------------------------------------------
+# Issue #525 — exponential backoff in reconnect loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestReconnectBackoffIntegration:
+    """Drive ``Publisher._reconnect_loop`` against a real NATS server to cover
+    the new exponential-backoff code paths under the integration coverage
+    gate (issue #525).  These complement the pure-unit tests in
+    ``tests/test_publisher_reconnect_backoff.py`` that mock NATS entirely.
+    """
+
+    async def test_loop_resets_backoff_when_connection_healthy(
+        self, nats_url: str
+    ) -> None:
+        """A healthy NATS connection makes the loop hit the
+        ``failed_attempts = 0; continue`` reset branch on every iteration.
+
+        We start the loop with tiny intervals + jitter so the very first
+        iteration executes the jitter multiplication path (line 161), waits
+        briefly, observes the healthy ``nc`` (lines 169-171), and loops.
+        After a short delay we set ``_stop_event`` and assert clean shutdown
+        without any reconnect attempts (``reconnect_count`` stays at 0).
+        """
+        pub = Publisher()
+        await pub.connect(nats_url)
+        try:
+            pub._stop_event = asyncio.Event()
+            # Run a *fresh* loop with extremely short tick so we cover the
+            # delay/jitter/healthy-reset path many times in a few hundred ms.
+            loop_task = asyncio.create_task(
+                pub._reconnect_loop(
+                    nats_url,
+                    connect_timeout=1.0,
+                    reconnect_interval=0.01,
+                    hard_timeout=1.0,
+                    max_interval=0.05,
+                    jitter=0.1,
+                )
+            )
+            await asyncio.sleep(0.1)
+            assert not loop_task.done(), "loop terminated unexpectedly"
+            assert pub.reconnect_count == 0, (
+                "reset branch must not increment reconnect_count"
+            )
+            pub._stop_event.set()
+            await asyncio.wait_for(loop_task, timeout=2.0)
+        finally:
+            await pub.disconnect()
+
+    async def test_loop_recovers_after_transient_disconnect(
+        self, nats_url: str
+    ) -> None:
+        """Forcibly close the underlying NATS client so the loop enters the
+        reconnect-attempt branch (lines 172-194), then succeeds against the
+        live server and resets the backoff exponent (line 182).
+        """
+        pub = Publisher()
+        await pub.connect(nats_url)
+        try:
+            # Stop the existing reconnect task so we can drive a fresh loop.
+            pub._stop_event.set()
+            assert pub._reconnect_task is not None
+            try:
+                await asyncio.wait_for(pub._reconnect_task, timeout=2.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+            pub._reconnect_task = None
+
+            # Force the publisher into the "connection lost" state.
+            assert pub._nc is not None
+            await pub._nc.close()
+            assert pub._nc.is_closed
+
+            pub._stop_event = asyncio.Event()
+            loop_task = asyncio.create_task(
+                pub._reconnect_loop(
+                    nats_url,
+                    connect_timeout=2.0,
+                    reconnect_interval=0.02,
+                    hard_timeout=2.0,
+                    max_interval=0.1,
+                    jitter=0.0,
+                )
+            )
+
+            # Poll until the loop has successfully reconnected once.
+            deadline = asyncio.get_event_loop().time() + 5.0
+            while asyncio.get_event_loop().time() < deadline:
+                if pub.reconnect_count >= 1 and pub._nc is not None and not pub._nc.is_closed:
+                    break
+                await asyncio.sleep(0.05)
+
+            pub._stop_event.set()
+            await asyncio.wait_for(loop_task, timeout=2.0)
+
+            assert pub.reconnect_count >= 1, "loop never recorded a successful reconnect"
+        finally:
+            # ``disconnect`` is safe even if we already replaced _nc.
+            await pub.disconnect()
+
+
+# ---------------------------------------------------------------------------
 # Issue #147 — lifespan abort / degraded state
 # ---------------------------------------------------------------------------
 

--- a/tests/test_publisher_reconnect_backoff.py
+++ b/tests/test_publisher_reconnect_backoff.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: MIT
+"""Tests for exponential backoff in Publisher._reconnect_loop (issue #525).
+
+The reconnect loop must space out *failed* reconnect attempts using bounded
+exponential backoff with optional jitter, so that a long NATS outage does
+not produce a steady stream of fixed-interval reconnect attempts (and a
+linearly-growing ``NATS_RECONNECTS{result='failed'}`` counter).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hermes.publisher import Publisher
+
+
+def _make_mock_nc(*, closed: bool = False) -> MagicMock:
+    nc = MagicMock()
+    nc.is_closed = closed
+    nc.jetstream.return_value = MagicMock()
+    nc.jsm.return_value = AsyncMock()
+    nc.drain = AsyncMock()
+    return nc
+
+
+class TestReconnectBackoffDelaySequence:
+    """The sleep before each failed retry should grow exponentially, bounded by ``max_interval``.
+
+    These tests patch ``asyncio.wait_for`` in the publisher module so they capture
+    the requested ``timeout`` (the throttle) and return *immediately* without
+    actually waiting — keeping the suite fast and deterministic.  A
+    ``TimeoutError`` is raised so the loop falls through to the reconnect attempt
+    just as it would after a real timeout expiry.
+    """
+
+    @pytest.mark.asyncio
+    async def test_delay_sequence_is_increasing_and_bounded(self) -> None:
+        pub = Publisher()
+        # Always-closed connection so every iteration attempts (and fails) a reconnect.
+        pub._nc = _make_mock_nc(closed=True)
+
+        observed_delays: list[float] = []
+        max_iterations = 6
+        base, cap = 1.0, 8.0  # expected sequence (jitter=0): 1, 2, 4, 8, 8, 8
+
+        async def fast_wait_for(awaitable, timeout):  # type: ignore[no-untyped-def]
+            coro_name = getattr(awaitable, "__qualname__", "") or repr(awaitable)
+            if "Event.wait" in coro_name:
+                observed_delays.append(timeout)
+                # Close the awaitable so it doesn't dangle.
+                if hasattr(awaitable, "close"):
+                    awaitable.close()
+                if len(observed_delays) >= max_iterations:
+                    pub._stop_event.set()
+                    # Returning normally lets the loop exit cleanly via the
+                    # ``return  # stop_event fired during sleep`` branch.
+                    return None
+                raise asyncio.TimeoutError
+            # Other wait_for calls (hard_timeout wrapping _connect_internal) —
+            # invoke the awaitable directly with no timeout enforcement so the
+            # failing_connect side_effect raises promptly.
+            return await awaitable
+
+        async def failing_connect(url: str, **_: object) -> MagicMock:
+            raise OSError("connection refused")
+
+        pub._stop_event = asyncio.Event()
+        with (
+            patch("asyncio.wait_for", side_effect=fast_wait_for),
+            patch("nats.connect", side_effect=failing_connect),
+        ):
+            await asyncio.wait_for(
+                pub._reconnect_loop(
+                    "nats://localhost:4222",
+                    connect_timeout=0.01,
+                    reconnect_interval=base,
+                    hard_timeout=0.01,
+                    max_interval=cap,
+                    jitter=0.0,
+                ),
+                timeout=5.0,
+            )
+
+        assert len(observed_delays) >= 4, f"too few iterations: {observed_delays}"
+
+        # Every delay must be <= cap.
+        for d in observed_delays:
+            assert d <= cap + 1e-9, f"delay {d} exceeds cap {cap}"
+
+        # Non-decreasing (monotone backoff) all the way through.
+        for prev, curr in zip(observed_delays, observed_delays[1:]):
+            assert curr + 1e-9 >= prev, f"delay decreased: {prev} -> {curr}"
+
+        # Strictly grows at least once (proves it isn't flat).
+        assert observed_delays[-1] > observed_delays[0], f"backoff never grew: {observed_delays}"
+
+        # And the first delay equals the base (jitter=0).
+        assert observed_delays[0] == pytest.approx(base)
+
+    @pytest.mark.asyncio
+    async def test_delay_resets_after_successful_reconnect(self) -> None:
+        """After a successful reconnect, the backoff exponent must reset to 0."""
+        pub = Publisher()
+        pub._nc = _make_mock_nc(closed=True)
+
+        observed_delays: list[float] = []
+        # Fail twice, then succeed.  The post-success delay must equal the base
+        # interval (jitter=0), proving the exponent reset.
+        call_count = 0
+        target_observations = 4
+
+        async def fake_connect(url: str, **_: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count in (1, 2):
+                raise OSError("refused")
+            # Success — return a healthy mock; the next loop iteration will see
+            # ``is_closed=False`` and reset the backoff.
+            return _make_mock_nc(closed=False)
+
+        async def fast_wait_for(awaitable, timeout):  # type: ignore[no-untyped-def]
+            coro_name = getattr(awaitable, "__qualname__", "") or repr(awaitable)
+            if "Event.wait" in coro_name:
+                observed_delays.append(timeout)
+                if hasattr(awaitable, "close"):
+                    awaitable.close()
+                # After the successful reconnect (call_count == 3) the next
+                # iteration's wait_for will be observed; re-arm closed state so
+                # the iteration *after that* attempts another reconnect — that
+                # second post-reset delay confirms the exponent is back at 0.
+                if call_count == 3 and pub._nc is not None and not pub._nc.is_closed:
+                    pub._nc = _make_mock_nc(closed=True)
+                if len(observed_delays) >= target_observations:
+                    pub._stop_event.set()
+                    return None
+                raise asyncio.TimeoutError
+            return await awaitable
+
+        pub._stop_event = asyncio.Event()
+        with (
+            patch("asyncio.wait_for", side_effect=fast_wait_for),
+            patch("nats.connect", side_effect=fake_connect),
+        ):
+            await asyncio.wait_for(
+                pub._reconnect_loop(
+                    "nats://localhost:4222",
+                    connect_timeout=0.01,
+                    reconnect_interval=1.0,
+                    hard_timeout=0.01,
+                    max_interval=16.0,
+                    jitter=0.0,
+                ),
+                timeout=5.0,
+            )
+
+        # Expected (base=1, cap=16, jitter=0):
+        #   iter 1 (pre fail #1):   1
+        #   iter 2 (pre fail #2):   2
+        #   iter 3 (pre success):   4
+        #   iter 4 (post-success, sees healthy nc -> reset): 1
+        assert len(observed_delays) >= 4, f"too few iterations: {observed_delays}"
+        # After the success the exponent must reset, so a later delay must
+        # equal (or be smaller than) the first delay.
+        assert min(observed_delays[3:]) <= observed_delays[0] + 1e-9, (
+            f"backoff did not reset after success: {observed_delays}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_jitter_keeps_delay_within_bounds(self) -> None:
+        """With jitter=0.1, delays must stay within [0.9 * base, 1.1 * cap]."""
+        pub = Publisher()
+        pub._nc = _make_mock_nc(closed=True)
+
+        observed_delays: list[float] = []
+        base, cap, jitter = 2.0, 4.0, 0.1
+
+        async def fast_wait_for(awaitable, timeout):  # type: ignore[no-untyped-def]
+            coro_name = getattr(awaitable, "__qualname__", "") or repr(awaitable)
+            if "Event.wait" in coro_name:
+                observed_delays.append(timeout)
+                if hasattr(awaitable, "close"):
+                    awaitable.close()
+                if len(observed_delays) >= 5:
+                    pub._stop_event.set()
+                    return None
+                raise asyncio.TimeoutError
+            return await awaitable
+
+        async def failing_connect(url: str, **_: object) -> MagicMock:
+            raise OSError("refused")
+
+        pub._stop_event = asyncio.Event()
+        with (
+            patch("asyncio.wait_for", side_effect=fast_wait_for),
+            patch("nats.connect", side_effect=failing_connect),
+        ):
+            await asyncio.wait_for(
+                pub._reconnect_loop(
+                    "nats://localhost:4222",
+                    connect_timeout=0.01,
+                    reconnect_interval=base,
+                    hard_timeout=0.01,
+                    max_interval=cap,
+                    jitter=jitter,
+                ),
+                timeout=5.0,
+            )
+
+        # Every delay must lie in [base*(1-jitter), cap*(1+jitter)].
+        lo, hi = base * (1.0 - jitter), cap * (1.0 + jitter)
+        for d in observed_delays:
+            assert lo - 1e-9 <= d <= hi + 1e-9, f"delay {d} outside [{lo}, {hi}]"


### PR DESCRIPTION
## Summary
- Replaces the fixed-interval reconnect retry in ``Publisher._reconnect_loop`` with bounded exponential backoff: ``delay = min(base * 2**failed_attempts, max_interval)`` plus optional multiplicative jitter.
- Resets the backoff exponent on a successful reconnect *and* when the connection is observed healthy at the top of the loop, so a single transient blip does not penalise later recoveries.
- Exposes two new ``Settings`` knobs (``nats_reconnect_max_interval`` default 60s, ``nats_reconnect_jitter`` default 0.1) and validates ``max >= base`` to prevent the cap from clamping the very first retry.

## Why
Per issue #525 (follow-up from #346): a long NATS outage produced a steady stream of fixed-interval reconnect attempts and a linearly-growing ``NATS_RECONNECTS{result='failed'}`` counter, plus the risk of a reconnect storm when multiple Hermes instances restarted simultaneously. Bounded exponential backoff with jitter (recommended by the NATS docs and the AWS architecture guidance referenced in #346) tames both.

## Test plan
- [x] ``pixi run pytest -m "not integration"`` — 451 passed, 97.08% coverage (well above the 80% gate).
- [x] ``pixi run ruff check`` + ``pixi run ruff format --check`` — clean.
- [x] ``pixi run mypy src/hermes/publisher.py src/hermes/config.py`` — no issues.
- [x] New ``tests/test_publisher_reconnect_backoff.py`` asserts: (1) the delay sequence is monotone non-decreasing and bounded by ``max_interval``; (2) the exponent resets after a successful reconnect; (3) jittered delays stay within ``[base*(1-jitter), cap*(1+jitter)]``. Tests run in <1s by patching ``asyncio.wait_for`` to capture the timeout and return immediately — no real sleeping.

## Backwards compatibility
- ``_reconnect_loop`` adds two keyword-only-by-convention params (``max_interval=None``, ``jitter=0.0``) with defaults that reproduce the legacy fixed-interval behaviour; existing tests (``tests/test_publisher_reconnect.py``) still pass unchanged.

Closes #525

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>