### PR TITLE
build(docker): add curl for HEALTHCHECK (#561)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,13 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends tini=0.19.0-1 \
     && rm -rf /var/lib/apt/lists/*
 
+# Install curl for the HEALTHCHECK directive below. Intentionally NOT version-pinned
+# to avoid bumping in lockstep with the base image; the HEALTHCHECK only uses curl's
+# stable -f flag. See issue #561.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /build/deps /usr/local/lib/python3.12/site-packages/
 COPY src/hermes/ ./hermes/
 


### PR DESCRIPTION
## Summary
- Adds `curl` to the Dockerfile runtime stage so the existing `HEALTHCHECK` directive (`curl -f http://localhost:${HERMES_PORT:-8085}/ready`) actually works. Without it, `python:3.12-slim` lacks `curl` and the healthcheck silently fails, leaving containers permanently flagged unhealthy.
- Installed via a **separate** `apt-get install` layer (not bundled with the tini line) to keep concerns isolated and minimize blast radius of future rebases.
- **Not version-pinned** — only the long-stable `-f` flag is used; pinning would force lockstep bumps with the base image without benefit.

Closes #561

## Test plan
- [ ] CI green (existing `tests/test_dockerfile.py` regression tests cover Dockerfile shape)
- [ ] Built container reports `healthy` after the start-period

🤖 Generated with [Claude Code](https://claude.com/claude-code)