### PR TITLE
security(docker): harden nats service (#571)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,13 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary
- Apply `read_only: true`, `cap_drop: [ALL]`, `security_opt: [no-new-privileges:true]`, and `tmpfs: [/tmp]` to the `nats` service in `docker-compose.yml`.
- Same defense-in-depth pattern already applied to the `hermes` service in #357 / #570.
- Named volume `nats-data:/data` remains mounted writable for JetStream's `--store_dir`.

## Verification
Ran the pinned image locally with the hardening flags:

```
docker run --rm --read-only --tmpfs /tmp --cap-drop ALL \
  --security-opt no-new-privileges:true -v nats-test-data:/data \
  nats:2.14@sha256:79b3... --jetstream --store_dir /data
```

Result: `Server is ready`, JetStream initialized, store directory `/data/jetstream` created. No errors related to readonly FS or dropped capabilities.

## Test plan
- [x] `nats-server` starts cleanly under hardening (verified locally)
- [x] JetStream initializes against the named volume
- [ ] CI passes
- [ ] Compose integration tests still pass

Closes #571