### PR TITLE
ci: pyproject/pixi deps version sync check (#594)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -379,27 +379,27 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-      - name: Check pyproject.toml version
-        run: |
-          python3 -c "
-          import tomllib
-          d = tomllib.load(open('pyproject.toml', 'rb'))
-          v = d['project']['version']
-          print(f'pyproject.toml version: {v}')
-          "
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.12"
 
-      - name: Check version consistency (pyproject.toml vs pixi.toml)
+      - name: Check package version (pyproject.toml vs pixi.toml)
         run: |
-          set -e
-          PYPROJECT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          PIXI_VERSION=$(grep '^version = ' pixi.toml | sed 's/version = "\(.*\)"/\1/')
+          set -euo pipefail
+          PYPROJECT_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          PIXI_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pixi.toml','rb'))['workspace']['version'])")
 
           if [ "$PYPROJECT_VERSION" != "$PIXI_VERSION" ]; then
             echo "Version mismatch: pyproject.toml ($PYPROJECT_VERSION) != pixi.toml ($PIXI_VERSION)"
             exit 1
           fi
+          echo "Package version check passed: $PYPROJECT_VERSION"
 
-          echo "Version check passed: $PYPROJECT_VERSION"
+      - name: Check dependency ranges (pyproject.toml vs pixi.toml)
+        # Asserts every entry in pixi.toml [pypi-dependencies] has a matching
+        # version range in pyproject.toml [project.dependencies]. See #594.
+        run: python3 scripts/check_dep_sync.py
 
       - name: Check pixi.lock is not modified (uncommitted)
         run: |

--- a/pixi.lock
+++ b/pixi.lock
@@ -543,18 +543,19 @@ packages:
 - pypi: ./
   name: hermes
   version: 0.1.0
-  sha256: fc5717775e631012bbf2da270472c2e4ed19226511598c75f374e9855b26f442
+  sha256: 037d95ce71d0099db91311ea1304fd7a18f183b3b6e05a7d6e315a02e764fc58
   requires_dist:
   - fastapi>=0.115,<1
   - starlette>=0.46.0,<1.0
   - uvicorn[standard]>=0.46.0,<1
-  - nats-py>=2.14.0,<3
+  - nats-py>=2.9,<3
   - pydantic>=2.0,<3
-  - pydantic-settings>=2.14.0,<3
+  - pydantic-settings>=2.0,<3
   - httpx>=0.27,<1
   - slowapi>=0.1.9,<1
   - limits>=5.8.0,<6
-  - prometheus-client>=0.25.0,<1
+  - prometheus-client>=0.20,<1
+  - urllib3>=2.7.0,<3
   - pytest>=9.0,<10 ; extra == 'dev'
   - pytest-asyncio>=1.0,<2 ; extra == 'dev'
   - pytest-cov>=5.0,<7 ; extra == 'dev'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 # pixi.toml [pypi-dependencies] is the authoritative source — keep these ranges in sync.
+# scripts/check_dep_sync.py enforces parity between this list and pixi.toml in CI.
 dependencies = [
     "fastapi>=0.115,<1",
     # Pin starlette<1.0 — starlette 1.0.0 has a BaseHTTPMiddleware regression that
@@ -28,13 +29,15 @@ dependencies = [
     # starlette ships a fix and fastapi's resolver picks it up.
     "starlette>=0.46.0,<1.0",
     "uvicorn[standard]>=0.46.0,<1",
-    "nats-py>=2.14.0,<3",
+    "nats-py>=2.9,<3",
     "pydantic>=2.0,<3",
-    "pydantic-settings>=2.14.0,<3",
+    "pydantic-settings>=2.0,<3",
     "httpx>=0.27,<1",
     "slowapi>=0.1.9,<1",
     "limits>=5.8.0,<6",
-    "prometheus-client>=0.25.0,<1",
+    "prometheus-client>=0.20,<1",
+    # Pinned to remediate CVE-2026-44431 / CVE-2026-44432 (transitive via cachecontrol/requests).
+    "urllib3>=2.7.0,<3",
 ]
 
 # Mirror of pixi.toml [feature.dev.pypi-dependencies] so pip-based workflows

--- a/scripts/check_dep_sync.py
+++ b/scripts/check_dep_sync.py
@@ -31,10 +31,10 @@ if sys.version_info >= (3, 11):
     import tomllib
 else:
     try:
-        import tomllib  # type: ignore[no-redef]
+        import tomllib
     except ImportError:
         try:
-            import tomli as tomllib  # type: ignore[no-redef]
+            import tomli as tomllib  # type: ignore[import-not-found,no-redef]
         except ImportError:
             print("ERROR: tomli is required on Python < 3.11 (pip install tomli)", file=sys.stderr)
             sys.exit(1)
@@ -102,7 +102,8 @@ def parse_pixi(table: dict[str, Any]) -> dict[str, str]:
 
 def _load(path: Path) -> dict[str, Any]:
     with path.open("rb") as fh:
-        return tomllib.load(fh)
+        data: dict[str, Any] = tomllib.load(fh)
+    return data
 
 
 def check_upper_bounds(deps: list[str]) -> list[str]:

--- a/scripts/check_dep_sync.py
+++ b/scripts/check_dep_sync.py
@@ -34,7 +34,7 @@ else:
         import tomllib
     except ImportError:
         try:
-            import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+            import tomli as tomllib  # type: ignore[import-not-found,no-redef,unused-ignore]
         except ImportError:
             print("ERROR: tomli is required on Python < 3.11 (pip install tomli)", file=sys.stderr)
             sys.exit(1)

--- a/scripts/check_dep_sync.py
+++ b/scripts/check_dep_sync.py
@@ -1,38 +1,138 @@
 #!/usr/bin/env python3
-"""CI guardrail: verify [project.dependencies] in pyproject.toml has upper bounds.
+"""CI guardrail: verify dependency version ranges are consistent.
 
-Exits non-zero if any runtime dependency is missing a < upper bound or if the
-[project.dependencies] section is absent.
+Two checks are performed:
+
+1. Every entry in pyproject.toml ``[project.dependencies]`` has a ``<`` upper
+   bound. Without an upper bound, ``pip install .`` may pull a breaking major
+   release.
+
+2. Every production dependency declared in pixi.toml ``[pypi-dependencies]``
+   appears in pyproject.toml ``[project.dependencies]`` with the **same**
+   version range. This prevents drift where one file is updated but not the
+   other (see HomericIntelligence/ProjectHermes#594).
+
+The script exits non-zero on any failure, printing the offending entries with
+the file each one came from so reviewers can pinpoint the drift.
 """
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).parent.parent
 PYPROJECT = ROOT / "pyproject.toml"
+PIXI = ROOT / "pixi.toml"
 
 if sys.version_info >= (3, 11):
     import tomllib
 else:
     try:
-        import tomllib
+        import tomllib  # type: ignore[no-redef]
     except ImportError:
         try:
-            import tomli as tomllib
+            import tomli as tomllib  # type: ignore[no-redef]
         except ImportError:
             print("ERROR: tomli is required on Python < 3.11 (pip install tomli)", file=sys.stderr)
             sys.exit(1)
 
 
+# Project package itself in pixi (path-installed); has no version range to compare.
+SELF_PACKAGE = "hermes"
+
+# Strip any PEP 508 extras and environment markers from a pyproject entry.
+# Examples handled:
+#   "uvicorn[standard]>=0.46.0,<1"     -> ("uvicorn", ">=0.46.0,<1")
+#   "fastapi>=0.115,<1"                -> ("fastapi", ">=0.115,<1")
+#   "httpx>=0.27,<1 ; python_version<'4'" -> ("httpx", ">=0.27,<1")
+_NAME_RE = re.compile(r"^\s*([A-Za-z0-9_.\-]+)(?:\[[^\]]*\])?\s*(.*?)\s*$")
+
+
+def _canon(name: str) -> str:
+    """PEP 503 canonical name (lowercase, runs of [-_.] collapsed to '-')."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def parse_pyproject(deps: list[str]) -> dict[str, str]:
+    """Return {canonical_name: version_spec} from PEP 508 entries."""
+    out: dict[str, str] = {}
+    for entry in deps:
+        # Drop environment marker, if any.
+        head = entry.split(";", 1)[0]
+        m = _NAME_RE.match(head)
+        if not m:
+            raise SystemExit(f"pyproject.toml: cannot parse dependency entry {entry!r}")
+        name, spec = m.group(1), m.group(2).strip()
+        out[_canon(name)] = spec
+    return out
+
+
+def parse_pixi(table: dict[str, Any]) -> dict[str, str]:
+    """Return {canonical_name: version_spec} from a pixi pypi-dependencies table.
+
+    Pixi entries can be either bare strings (``"fastapi" = ">=0.115,<1"``) or
+    inline tables (``{ version = ">=0.46.0,<1", extras = ["standard"] }``).
+    The self-install entry (``{ path = ".", editable = true }``) is skipped
+    since it carries no version to compare.
+    """
+    out: dict[str, str] = {}
+    for name, value in table.items():
+        cname = _canon(name)
+        if cname == SELF_PACKAGE:
+            continue
+        if isinstance(value, str):
+            out[cname] = value.strip()
+        elif isinstance(value, dict):
+            if "path" in value or "git" in value or "url" in value:
+                # Local / VCS install — no PyPI version range to compare.
+                continue
+            ver = value.get("version")
+            if not isinstance(ver, str):
+                raise SystemExit(
+                    f"pixi.toml: entry {name!r} has no 'version' string under [pypi-dependencies]"
+                )
+            out[cname] = ver.strip()
+        else:
+            raise SystemExit(f"pixi.toml: unexpected value type for {name!r}: {type(value).__name__}")
+    return out
+
+
+def _load(path: Path) -> dict[str, Any]:
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def check_upper_bounds(deps: list[str]) -> list[str]:
+    return [f"  {entry!r} — missing '<' upper bound" for entry in deps if "<" not in entry]
+
+
+def check_parity(py: dict[str, str], pixi: dict[str, str]) -> list[str]:
+    """Return human-readable failure lines for any drift between the two maps."""
+    failures: list[str] = []
+    for name, pixi_spec in sorted(pixi.items()):
+        py_spec = py.get(name)
+        if py_spec is None:
+            failures.append(
+                f"  {name}: declared in pixi.toml ({pixi_spec!r}) but missing from "
+                f"pyproject.toml [project.dependencies]"
+            )
+            continue
+        if py_spec != pixi_spec:
+            failures.append(
+                f"  {name}: pyproject.toml has {py_spec!r}, pixi.toml has {pixi_spec!r}"
+            )
+    return failures
+
+
 def main() -> int:
-    with PYPROJECT.open("rb") as f:
-        data = tomllib.load(f)
+    py_data = _load(PYPROJECT)
+    pixi_data = _load(PIXI)
 
-    deps: list[str] | None = data.get("project", {}).get("dependencies")
-
-    if not deps:
+    py_deps_raw: list[str] | None = py_data.get("project", {}).get("dependencies")
+    if not py_deps_raw:
         print(
             "FAIL: [project.dependencies] is missing or empty in pyproject.toml.\n"
             "      Add version-bounded runtime dependencies so 'pip install .' is reproducible.",
@@ -40,27 +140,42 @@ def main() -> int:
         )
         return 1
 
-    failures: list[str] = []
-    for entry in deps:
-        if "<" not in entry:
-            failures.append(f"  {entry!r} — missing < upper bound")
-
-    if failures:
+    bound_failures = check_upper_bounds(py_deps_raw)
+    if bound_failures:
         print(
             "FAIL: The following [project.dependencies] entries have no upper bound (<).\n"
             "      Without an upper bound, 'pip install .' may pull breaking major versions.\n",
             file=sys.stderr,
         )
-        for line in failures:
+        for line in bound_failures:
+            print(line, file=sys.stderr)
+        print('\nFix by adding an upper bound, e.g.:\n  "some-package>=1.2,<2"', file=sys.stderr)
+        return 1
+
+    py_deps = parse_pyproject(py_deps_raw)
+    pixi_table = pixi_data.get("pypi-dependencies", {})
+    pixi_deps = parse_pixi(pixi_table)
+
+    parity_failures = check_parity(py_deps, pixi_deps)
+    if parity_failures:
+        print(
+            "FAIL: pixi.toml [pypi-dependencies] and pyproject.toml [project.dependencies] "
+            "have drifted.\n"
+            "      Production dependency version ranges must be identical in both files.\n",
+            file=sys.stderr,
+        )
+        for line in parity_failures:
             print(line, file=sys.stderr)
         print(
-            "\nFix by adding an upper bound, e.g.:\n"
-            "  \"some-package>=1.2,<2\"",
+            "\nFix by updating one file so both declare the same version range.",
             file=sys.stderr,
         )
         return 1
 
-    print(f"OK: {len(deps)} dependencies in [project.dependencies], all have upper bounds.")
+    print(
+        f"OK: {len(py_deps_raw)} dependencies in [project.dependencies], all upper-bounded "
+        f"and consistent with pixi.toml [pypi-dependencies] ({len(pixi_deps)} prod entries)."
+    )
     return 0
 
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -33,8 +33,8 @@ def test_project_dependencies_section_exists(pyproject: dict) -> None:
 
 def test_project_dependencies_count(pyproject: dict) -> None:
     deps = pyproject["project"]["dependencies"]
-    assert len(deps) == 10, (
-        f"Expected 10 runtime dependencies, found {len(deps)}: {deps}"
+    assert len(deps) == 11, (
+        f"Expected 11 runtime dependencies, found {len(deps)}: {deps}"
     )
 
 


### PR DESCRIPTION
## Summary

- Extends `scripts/check_dep_sync.py` so it now also enforces parity between `pyproject.toml [project.dependencies]` and `pixi.toml [pypi-dependencies]`. The existing upper-bound check is preserved.
- Wires the script into the `deps/version-sync` job in `.github/workflows/_required.yml`, replacing a thin inline version-string grep that only compared the package `version` field.
- Resolves the drift the new check surfaces: `nats-py`, `pydantic-settings`, `prometheus-client` ranges in `pyproject.toml` were lagging `pixi.toml`, and the `urllib3` CVE pin lived only in `pixi.toml`. All four are now identical in both files.

Closes #594.

## Test plan

- [x] Local: `python3 scripts/check_dep_sync.py` exits 0 on the corrected state.
- [x] Local negative test: temporarily perturbing one `pyproject.toml` range produces a clear `pyproject.toml has ... pixi.toml has ...` failure, exit 1.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/_required.yml'))"` parses clean.
- [ ] CI `deps/version-sync` passes on this branch.

Out of scope: dev/optional dependency parity (that lands with #596).

Generated with [Claude Code](https://claude.com/claude-code)