### PR TITLE
ci: forbid :latest image tags (#566)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -192,6 +192,20 @@ jobs:
       - name: Run symlink check
         run: bash scripts/check-symlinks.sh
 
+  no-latest-tags:
+    # Regression guard for #316: a bare `nats:latest` slipped into
+    # docker-compose.yml because nothing rejected unpinned tags. See #566.
+    name: no-latest-tags
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    needs: lint
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Assert no :latest image tags
+        run: bash scripts/check-no-latest-tags.sh
+
   unit-tests:
     name: unit-tests
     runs-on: ubuntu-24.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,15 @@ repos:
         entry: '^\s*continue-on-error:\s*true\s*$'
         files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: true
+
+      - id: no-latest-image-tags
+        name: "forbid :latest image tags in ops manifests"
+        description: >
+          Regression guard for #316/#566. Floating `:latest` tags (and
+          `uses: ...@latest` action refs) break reproducibility. Pin to an
+          explicit version (and digest where supported).
+        language: system
+        entry: bash scripts/check-no-latest-tags.sh
+        pass_filenames: false
+        # Run once per commit; the script scans the tracked file set itself.
+        always_run: true

--- a/scripts/check-no-latest-tags.sh
+++ b/scripts/check-no-latest-tags.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Assert no `:latest` image tags appear in ops manifests (Dockerfiles,
+# docker-compose, GitHub workflows, etc.).
+#
+# Background: issue #316 (and follow-up #566) — a bare `nats:latest` slipped
+# into docker-compose.yml because no automated check rejected unpinned tags.
+# Floating `:latest` tags break reproducibility and silently pull breaking
+# upstream changes. Pin to an explicit version (and ideally a digest).
+#
+# Scope: files that actually pull/build images, i.e. Dockerfiles,
+# docker-compose YAMLs, GitHub Actions workflows, and any other ops YAML.
+# Markdown/comments are ignored (you can document `:latest` is forbidden).
+#
+# justfile parameter defaults (e.g. `docker-build tag="hermes:latest"`) are
+# recipe arguments, not pulled images, and are out of scope here.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)"
+cd "$ROOT"
+
+# Files we scan. Keep this list intentionally narrow so docs/comments aren't
+# falsely flagged; broaden it as new ops manifest types appear in the repo.
+mapfile -t files < <(git ls-files -- \
+  'Dockerfile*' '**/Dockerfile*' \
+  'docker-compose*.yml' '**/docker-compose*.yml' \
+  'docker-compose*.yaml' '**/docker-compose*.yaml' \
+  'compose*.yml' '**/compose*.yml' \
+  'compose*.yaml' '**/compose*.yaml' \
+  '.github/workflows/*.yml' '.github/workflows/*.yaml')
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "check-no-latest-tags: no ops manifests found, nothing to scan"
+  exit 0
+fi
+
+# `<name>:latest` in image/FROM contexts. We require a leading character
+# that's part of an image-name token ([A-Za-z0-9._/-]) so prose like
+# "no :latest tags" or "the :latest spec" does NOT trigger. We also require
+# the `:latest` to be at a token boundary (end-of-line, whitespace, quote,
+# or `@<digest>`).
+pattern_image='[A-Za-z0-9._/-]:latest([[:space:]]|$|"|'\''|@)'
+
+# GitHub Actions floating action ref: `uses: owner/action@latest`.
+pattern_uses_latest='uses:[[:space:]]*[^[:space:]]+@latest([[:space:]]|$)'
+
+# Combined ERE for a single grep pass per file.
+combined="(${pattern_image})|(${pattern_uses_latest})"
+
+# `set +e` bracket is documented in CLAUDE.md as the approved alternative to
+# `|| true` (which the forbid-suppressions guard rejects). We need grep's
+# exit status here because "no match" (1) is the success case for us.
+fail=0
+for f in "${files[@]}"; do
+  set +e
+  raw=$(grep -nE "$combined" -- "$f" 2>/dev/null)
+  rc=$?
+  set -e
+  # rc==0: match; rc==1: no match (good); rc>=2: real grep error.
+  if [ "$rc" -ge 2 ]; then
+    echo "::error file=$f::grep failed (exit $rc) while scanning"
+    fail=1
+    continue
+  fi
+  if [ "$rc" -ne 0 ]; then
+    continue
+  fi
+  # Filter out full-line comments so a doc note like `# never use :latest`
+  # doesn't trip the check.
+  set +e
+  hits=$(printf '%s\n' "$raw" | grep -vE '^[[:digit:]]+:[[:space:]]*#')
+  hrc=$?
+  set -e
+  if [ "$hrc" -ne 0 ] || [ -z "$hits" ]; then
+    continue
+  fi
+  echo "::error file=$f::found ':latest' / '@latest' — pin to an explicit version (and digest)"
+  printf '%s\n' "$hits"
+  fail=1
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo ""
+  echo "check-no-latest-tags: FAIL — replace ':latest' / '@latest' with a pinned version."
+  exit 1
+fi
+
+echo "check-no-latest-tags: OK (${#files[@]} files scanned)"


### PR DESCRIPTION
## Summary
- Adds `scripts/check-no-latest-tags.sh` — fails if any tracked Dockerfile, docker-compose file, or GitHub workflow YAML contains `<name>:latest` or `uses: ...@latest`.
- Wires it into Required Checks as the `no-latest-tags` job and into `.pre-commit-config.yaml` as a local hook.
- Regression guard for #316 (bare `nats:latest` in docker-compose.yml); complements the Dependabot docker-compose ecosystem from #564.

## Design notes
- Scope is intentionally narrow: only ops manifests (Dockerfile / compose / `.github/workflows/*`). Markdown / comments are not scanned, and full-line comments inside scanned files are filtered out, so prose like `# never use :latest` does not trip the guard.
- The regex requires a leading image-name-token character before `:latest`, so sentences such as "no :latest image tags" are NOT flagged. Verified with unit-style cases (9/9 pass).
- justfile parameter defaults like `docker-build tag="hermes:latest"` are recipe arguments, not pulled images, so the justfile is out of scope.
- No `|| true`, no `continue-on-error: true`, no `--no-verify` — uses explicit `set +e` / `set -e` brackets so the forbid-suppressions guard accepts the script.

## Test plan
- [x] `bash scripts/check-no-latest-tags.sh` on clean repo: exits 0 (5 files scanned).
- [x] Synthesized `docker-compose.test-bad.yml` with `image: redis:latest`: script exits 1 with correct error.
- [x] Regex negative cases verified: `FROM nats:2.10`, `uses: actions/checkout@v4`, `FROM nats:2.10@sha256:...`, prose mentions of `:latest`.
- [x] Regex positive cases verified: Dockerfile `FROM`, compose `image:`, workflow `uses: ...@latest`.
- [ ] CI green on this PR (Required Checks).

Closes #566