### PR TITLE
chore: easy-issue sweep bundle (2026-05-16)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
 
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: "Reject silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
         run: |
@@ -110,7 +110,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Run markdownlint-cli2
         uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265  # v20.0.0
         with:
@@ -125,7 +125,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Skip if no pixi.toml
         id: detect
         run: |
@@ -159,7 +159,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Skip if no justfile
         id: detect
         run: |
@@ -188,7 +188,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Run symlink check
         run: bash scripts/check-symlinks.sh
 
@@ -202,7 +202,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Assert no :latest image tags
         run: bash scripts/check-no-latest-tags.sh
 
@@ -211,7 +211,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
@@ -273,7 +273,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: Run read-only filesystem smoke test
         env:
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
@@ -302,7 +302,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout (full history)
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
 
@@ -343,7 +343,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
@@ -361,7 +361,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: Install check-jsonschema
         run: pip install check-jsonschema
@@ -377,7 +377,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout (full history)
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           fetch-depth: 0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - pydantic-settings
 
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.3
+    rev: v8.30.1
     hooks:
       - id: gitleaks
 

--- a/openapi.json
+++ b/openapi.json
@@ -454,14 +454,7 @@
             "default": 0.0
           },
           "timeouts": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/TimeoutSettings"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/components/schemas/TimeoutSettings"
           },
           "nats_reconnect_count": {
             "type": "integer",
@@ -487,7 +480,8 @@
         "type": "object",
         "required": [
           "status",
-          "nats_connected"
+          "nats_connected",
+          "timeouts"
         ],
         "title": "HealthResponse",
         "description": "Response body for GET /health."

--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -67,7 +67,7 @@ class HealthResponse(BaseModel):
     dead_letter_queue_depth: int = 0
     dead_letter_queue_capacity: int = 0
     dead_letter_queue_alert_threshold_pct: float = 0.0
-    timeouts: TimeoutSettings | None = None
+    timeouts: TimeoutSettings
     nats_reconnect_count: int = 0
     nats_last_error: str = ""
     nats_retry_attempts: int = 3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import os
 from collections.abc import AsyncGenerator, Generator
-from datetime import datetime, timezone
 
 import nats
 import pytest
@@ -15,8 +14,7 @@ import hermes.server as _server
 from hermes.config import get_settings
 from hermes.models import WebhookPayload
 from hermes.publisher import Publisher
-
-_FIXED_TS = datetime(2026, 4, 22, tzinfo=timezone.utc)
+from tests.helpers import FIXED_TS as _FIXED_TS
 
 
 @pytest.fixture(autouse=True)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import hashlib
 import hmac as hmac_mod
+from datetime import datetime, timezone
 
 TEST_SECRET = "test-webhook-secret-padding-xxxxx"
+
+# Canonical fixed timestamp shared by tests/conftest.py and tests/test_integration.py.
+# Follow-up from #330; closes #471.
+FIXED_TS = datetime(2026, 4, 22, tzinfo=timezone.utc)
 
 
 def sign_body(body: bytes, secret: str) -> str:

--- a/tests/test_inflight.py
+++ b/tests/test_inflight.py
@@ -3,24 +3,18 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import hmac as hmac_mod
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 
-_TEST_SECRET = "test-webhook-secret-padding-xxxxx"
+from tests.helpers import TEST_SECRET, sign_body
 
 _AGENT_PAYLOAD = {
     "event": "agent.created",
     "data": {"host": "h", "name": "n"},
     "timestamp": "2026-04-22T00:00:00Z",
 }
-
-
-def _sign(body: bytes) -> str:
-    return hmac_mod.new(_TEST_SECRET.encode(), body, hashlib.sha256).hexdigest()
 
 
 def _make_mock_publisher(*, connected: bool = True) -> MagicMock:
@@ -49,7 +43,7 @@ def _build_client(publisher: MagicMock | None = None) -> TestClient:
     if publisher is None:
         publisher = _make_mock_publisher()
     app.state.publisher = publisher
-    get_settings().webhook_secret = _TEST_SECRET
+    get_settings().webhook_secret = TEST_SECRET
     limiter._storage.reset()  # type: ignore[attr-defined]
     return TestClient(app, raise_server_exceptions=True)
 
@@ -74,7 +68,7 @@ class TestInflightIncrementDecrement:
         client.post(
             "/webhook",
             content=body,
-            headers={"X-Webhook-Signature": _sign(body), "Content-Type": "application/json"},
+            headers={"X-Webhook-Signature": sign_body(body, TEST_SECRET), "Content-Type": "application/json"},
         )
         assert srv._inflight == 0
 
@@ -97,7 +91,7 @@ class TestInflightIncrementDecrement:
         resp = client.post(
             "/webhook",
             content=body,
-            headers={"X-Webhook-Signature": _sign(body), "Content-Type": "application/json"},
+            headers={"X-Webhook-Signature": sign_body(body, TEST_SECRET), "Content-Type": "application/json"},
         )
 
         assert resp.status_code == 202
@@ -112,7 +106,7 @@ class TestInflightIncrementDecrement:
         resp = client.post(
             "/webhook",
             content=body,
-            headers={"X-Webhook-Signature": _sign(body), "Content-Type": "application/json"},
+            headers={"X-Webhook-Signature": sign_body(body, TEST_SECRET), "Content-Type": "application/json"},
         )
         assert resp.status_code == 202
         assert srv._inflight == 0
@@ -147,7 +141,7 @@ class TestInflightDecrementOnErrors:
             "/webhook",
             content=malformed,
             headers={
-                "X-Webhook-Signature": _sign(malformed),
+                "X-Webhook-Signature": sign_body(malformed, TEST_SECRET),
                 "Content-Type": "application/json",
             },
         )
@@ -164,7 +158,7 @@ class TestInflightDecrementOnErrors:
         resp = client.post(
             "/webhook",
             content=body,
-            headers={"X-Webhook-Signature": _sign(body), "Content-Type": "application/json"},
+            headers={"X-Webhook-Signature": sign_body(body, TEST_SECRET), "Content-Type": "application/json"},
         )
         assert resp.status_code == 503
         assert srv._inflight == 0
@@ -181,7 +175,7 @@ class TestInflightDecrementOnErrors:
         resp = client.post(
             "/webhook",
             content=body,
-            headers={"X-Webhook-Signature": _sign(body), "Content-Type": "application/json"},
+            headers={"X-Webhook-Signature": sign_body(body, TEST_SECRET), "Content-Type": "application/json"},
         )
         assert resp.status_code == 503
         assert srv._inflight == 0
@@ -199,7 +193,7 @@ class TestInflightDecrementOnErrors:
             client.post(
                 "/webhook",
                 content=body,
-                headers={"X-Webhook-Signature": _sign(body), "Content-Type": "application/json"},
+                headers={"X-Webhook-Signature": sign_body(body, TEST_SECRET), "Content-Type": "application/json"},
             )
         assert srv._inflight == 0
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,8 +11,6 @@ import asyncio
 import json
 import logging
 import os
-from datetime import datetime, timezone
-
 import nats
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -20,18 +18,16 @@ from httpx import ASGITransport, AsyncClient
 from hermes.models import WebhookPayload
 from hermes.publisher import Publisher
 
-from tests.helpers import sign_body
-
-_FIXED_TS = datetime(2026, 4, 22, tzinfo=timezone.utc)
+from tests.helpers import FIXED_TS as _FIXED_TS, sign_body
 
 pytestmark = pytest.mark.integration
 
 _NATS_URL = os.environ.get("TEST_NATS_URL", "nats://localhost:4222")
-_TEST_SECRET = "integration-test-secret-for-hermes-webhook"
+INTEGRATION_TEST_SECRET = "integration-test-secret-for-hermes-webhook"
 
 
 def _sign(body: bytes) -> str:
-    return sign_body(body, _TEST_SECRET)
+    return sign_body(body, INTEGRATION_TEST_SECRET)
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +165,7 @@ class TestWebhookIntegration:
         """POST /webhook with a valid payload results in a NATS message being delivered."""
         from hermes.server import app
 
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", INTEGRATION_TEST_SECRET)
         monkeypatch.setenv("NATS_URL", nats_url)
 
         received: list[nats.aio.msg.Msg] = []
@@ -218,7 +214,7 @@ class TestWebhookIntegration:
         """POST /webhook returns 503 when the publisher is not connected."""
         from hermes.server import app
 
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", INTEGRATION_TEST_SECRET)
 
         disconnected = Publisher()  # never connected
         app.state.publisher = disconnected
@@ -1042,7 +1038,7 @@ class TestRequestIdInNats:
         from hermes.server import app
 
         my_request_id = "test-req-id-231"
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", INTEGRATION_TEST_SECRET)
         monkeypatch.setenv("NATS_URL", nats_url)
 
         received: list[nats.aio.msg.Msg] = []
@@ -1146,7 +1142,7 @@ class TestJetStreamAck:
         """POST /webhook → HMAC check → Publisher.publish → JetStream ACK succeeds."""
         from hermes.server import app
 
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", INTEGRATION_TEST_SECRET)
         monkeypatch.setenv("NATS_URL", nats_url)
 
         js = nats_client.jetstream()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -10,11 +10,7 @@ from fastapi.testclient import TestClient
 
 from tests.helpers import TEST_SECRET, sign_body
 
-_TEST_SECRET = TEST_SECRET
 
-
-def _sign(body: bytes) -> str:
-    return sign_body(body, _TEST_SECRET)
 
 
 def _build_client(dead_letters: list | None = None) -> TestClient:
@@ -78,7 +74,7 @@ class TestWebhookMetricsInstrumentation:
     def test_valid_webhook_increments_received_counter(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",
@@ -95,7 +91,7 @@ class TestWebhookMetricsInstrumentation:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         after = _get_counter_value(
@@ -106,7 +102,7 @@ class TestWebhookMetricsInstrumentation:
     def test_invalid_payload_increments_failed_counter(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         body_bytes = json.dumps({"bad": "payload"}).encode()
 
@@ -116,7 +112,7 @@ class TestWebhookMetricsInstrumentation:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         after = _get_counter_value("hermes_webhooks_failed_total", {"reason": "invalid_payload"})
@@ -125,7 +121,7 @@ class TestWebhookMetricsInstrumentation:
     def test_nats_unavailable_increments_failed_counter(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         from hermes.server import app
         from hermes.publisher import Publisher
 
@@ -150,7 +146,7 @@ class TestWebhookMetricsInstrumentation:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         after = _get_counter_value("hermes_webhooks_failed_total", {"reason": "nats_not_connected"})

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -13,16 +13,12 @@ from fastapi.testclient import TestClient
 
 from tests.helpers import TEST_SECRET, sign_body
 
-_TEST_SECRET = TEST_SECRET
 _VALID_PAYLOAD = {
     "event": "agent.created",
     "data": {"host": "localhost", "name": "bot"},
     "timestamp": "2026-03-15T00:00:00Z",
 }
 
-
-def _sign(body: bytes) -> str:
-    return sign_body(body, _TEST_SECRET)
 
 
 @contextmanager
@@ -44,7 +40,7 @@ def _rate_limit_client(
     limiter._storage.reset()  # type: ignore[attr-defined]
 
     env_overrides = {
-        "WEBHOOK_SECRET": _TEST_SECRET,
+        "WEBHOOK_SECRET": TEST_SECRET,
         "WEBHOOK_RATE_LIMIT": rate_limit,
     }
     old_env = {k: os.environ.get(k) for k in env_overrides}
@@ -68,7 +64,7 @@ def _post_webhook(client: TestClient, payload: dict | None = None) -> object:
         content=body,
         headers={
             "Content-Type": "application/json",
-            "X-Webhook-Signature": _sign(body),
+            "X-Webhook-Signature": sign_body(body, TEST_SECRET),
         },
     )
 
@@ -128,7 +124,7 @@ class TestNatsPublishTimeout:
         limiter._storage.reset()  # type: ignore[attr-defined]
 
         env_overrides = {
-            "WEBHOOK_SECRET": _TEST_SECRET,
+            "WEBHOOK_SECRET": TEST_SECRET,
             "WEBHOOK_RATE_LIMIT": "100/minute",
         }
         old_env = {k: os.environ.get(k) for k in env_overrides}

--- a/tests/test_request_id_context.py
+++ b/tests/test_request_id_context.py
@@ -13,11 +13,7 @@ from fastapi.testclient import TestClient
 
 from tests.helpers import TEST_SECRET, sign_body
 
-_TEST_SECRET = TEST_SECRET
 
-
-def _sign(body: bytes) -> str:
-    return sign_body(body, _TEST_SECRET)
 
 
 def _build_client(*, connected: bool = True) -> TestClient:
@@ -32,7 +28,7 @@ def _build_client(*, connected: bool = True) -> TestClient:
     mock_publisher.publish = AsyncMock()
 
     app.state.publisher = mock_publisher
-    app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret=_TEST_SECRET)
+    app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret=TEST_SECRET)
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -58,7 +54,7 @@ class TestRequestIdInLogContext:
                 content=body_bytes,
                 headers={
                     "Content-Type": "application/json",
-                    "X-Webhook-Signature": _sign(body_bytes),
+                    "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
                     "X-Request-ID": fixed_id,
                 },
             )
@@ -88,7 +84,7 @@ class TestRequestIdInLogContext:
                 content=body_bytes,
                 headers={
                     "Content-Type": "application/json",
-                    "X-Webhook-Signature": _sign(body_bytes),
+                    "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
                     "X-Request-ID": fixed_id,
                 },
             )
@@ -114,7 +110,7 @@ class TestRequestIdInLogContext:
         mock_publisher.active_subjects = []
         mock_publisher.publish = AsyncMock(side_effect=asyncio.TimeoutError())
         app.state.publisher = mock_publisher
-        app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret=_TEST_SECRET)
+        app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret=TEST_SECRET)
 
         client = TestClient(app, raise_server_exceptions=False)
         payload = {
@@ -131,7 +127,7 @@ class TestRequestIdInLogContext:
                 content=body_bytes,
                 headers={
                     "Content-Type": "application/json",
-                    "X-Webhook-Signature": _sign(body_bytes),
+                    "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
                     "X-Request-ID": fixed_id,
                 },
             )
@@ -159,7 +155,7 @@ class TestRequestIdInErrorResponses:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
                 "X-Request-ID": fixed_id,
             },
         )
@@ -209,7 +205,7 @@ class TestRequestIdInErrorResponses:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
                 "X-Request-ID": fixed_id,
             },
         )
@@ -231,7 +227,7 @@ class TestRequestIdInErrorResponses:
         mock_publisher.active_subjects = []
         mock_publisher.publish = AsyncMock(side_effect=asyncio.TimeoutError())
         app.state.publisher = mock_publisher
-        app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret=_TEST_SECRET)
+        app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret=TEST_SECRET)
 
         client = TestClient(app, raise_server_exceptions=False)
         payload = {
@@ -247,7 +243,7 @@ class TestRequestIdInErrorResponses:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
                 "X-Request-ID": fixed_id,
             },
         )
@@ -266,7 +262,7 @@ class TestRequestIdInErrorResponses:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         assert response.status_code == 422
@@ -284,7 +280,7 @@ class TestRequestIdInErrorResponses:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         assert response.status_code == 422

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -11,11 +11,7 @@ from fastapi.testclient import TestClient
 
 from tests.helpers import TEST_SECRET, sign_body
 
-_TEST_SECRET = TEST_SECRET
 
-
-def _sign(body: bytes) -> str:
-    return sign_body(body, _TEST_SECRET)
 
 
 def _build_client(
@@ -48,7 +44,7 @@ def _build_client(
     # Inject the mock before the test client starts
     app.state.publisher = mock_publisher
     # Override settings via FastAPI dependency injection
-    test_settings = Settings(webhook_secret=_TEST_SECRET)
+    test_settings = Settings(webhook_secret=TEST_SECRET)
     app.dependency_overrides[get_settings] = lambda: test_settings
     # Reset rate limiter so each test starts with a clean slate
     limiter._storage.reset()  # type: ignore[attr-defined]
@@ -268,7 +264,7 @@ class TestReadyEndpoint:
 
 class TestWebhookEndpoint:
     def test_valid_payload_returns_202(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",
@@ -281,7 +277,7 @@ class TestWebhookEndpoint:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         assert response.status_code == 202
@@ -293,7 +289,7 @@ class TestWebhookEndpoint:
         assert len(body["request_id"]) > 0
 
     def test_webhook_invalid_payload_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         body_bytes = json.dumps({"bad": "payload"}).encode()
         response = client.post(
@@ -301,13 +297,13 @@ class TestWebhookEndpoint:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         assert response.status_code == 422
 
     def test_webhook_missing_body_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         body_bytes = b"not json"
         response = client.post(
@@ -315,13 +311,13 @@ class TestWebhookEndpoint:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         assert response.status_code == 422
 
     def test_webhook_returns_event_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "task.updated",
@@ -334,14 +330,14 @@ class TestWebhookEndpoint:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         body = response.json()
         assert body["event"] == "task.updated"
 
     def test_webhook_bad_signature_returns_401(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",
@@ -364,7 +360,7 @@ class TestWebhookEndpoint:
     ) -> None:
         from prometheus_client import REGISTRY
 
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         labels = {"reason": "invalid_signature"}
         before = REGISTRY.get_sample_value("hermes_webhooks_failed_total", labels) or 0.0
@@ -398,7 +394,7 @@ class TestWebhookEndpoint:
 
         from hermes.config import Settings, get_settings
 
-        app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret=_TEST_SECRET)
+        app.dependency_overrides[get_settings] = lambda: Settings(webhook_secret=TEST_SECRET)
 
         client = TestClient(app, raise_server_exceptions=False)
         payload = {
@@ -412,7 +408,7 @@ class TestWebhookEndpoint:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         assert response.status_code == 503
@@ -425,7 +421,7 @@ class TestSignatureValidation:
     def test_missing_signature_header_returns_401_when_secret_configured(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",
@@ -438,7 +434,7 @@ class TestSignatureValidation:
     def test_empty_signature_header_returns_401_when_secret_configured(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",
@@ -473,7 +469,7 @@ class TestRequestIDMiddleware:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
                 "X-Request-ID": valid_id,
             },
         )
@@ -496,7 +492,7 @@ class TestRequestIDMiddleware:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
                 "X-Request-ID": invalid_id,
             },
         )
@@ -519,7 +515,7 @@ class TestRequestIDMiddleware:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         returned_id = response.headers.get("X-Request-ID")
@@ -542,7 +538,7 @@ class TestRequestIDMiddleware:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
                 "X-Request-ID": oversized_id,
             },
         )
@@ -569,7 +565,7 @@ class TestPayloadSizeLimit:
             headers={
                 "Content-Type": "application/octet-stream",
                 "Content-Length": str(2_000_000),
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         assert response.status_code == 413
@@ -582,7 +578,7 @@ class TestPayloadSizeLimit:
             content=body_bytes,
             headers={
                 "Content-Type": "application/octet-stream",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         assert response.status_code == 413
@@ -596,7 +592,7 @@ class TestPayloadSizeLimit:
             content=body_bytes,
             headers={
                 "Content-Type": "application/octet-stream",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         assert response.status_code != 413
@@ -630,7 +626,7 @@ class TestPayloadSizeLimit:
                 headers={
                     "Content-Type": "application/octet-stream",
                     "Content-Length": str(2_000_000),
-                    "X-Webhook-Signature": _sign(b"x" * 100),
+                    "X-Webhook-Signature": sign_body(b"x" * 100, TEST_SECRET),
                 },
             )
         assert any("2000000" in r.message and "1048576" in r.message for r in caplog.records)
@@ -646,7 +642,7 @@ class TestPayloadSizeLimit:
                 content=body_bytes,
                 headers={
                     "Content-Type": "application/octet-stream",
-                    "X-Webhook-Signature": _sign(body_bytes),
+                    "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
                 },
             )
         assert any("1048577" in r.message and "1048576" in r.message for r in caplog.records)
@@ -658,7 +654,7 @@ class TestWildcardInjectionSanitization:
     def test_wildcard_in_host_field_is_sanitized_before_publish(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
 
         published_subjects: list[str] = []
 
@@ -691,7 +687,7 @@ class TestWildcardInjectionSanitization:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
 
@@ -704,7 +700,7 @@ class TestWildcardInjectionSanitization:
     def test_wildcard_in_name_field_is_sanitized_before_publish(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
 
         published_subjects: list[str] = []
 
@@ -737,7 +733,7 @@ class TestWildcardInjectionSanitization:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
 
@@ -1064,7 +1060,7 @@ class TestWWWAuthenticate:
     def test_bad_signature_401_has_www_authenticate_header(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         payload = {
             "event": "agent.created",
@@ -1166,7 +1162,7 @@ class TestTimestampValidation:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         assert response.status_code == 422
@@ -1184,7 +1180,7 @@ class TestTimestampValidation:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         assert response.status_code in (202, 500)
@@ -1290,7 +1286,7 @@ class TestPublisherRaises:
         from hermes.publisher import Publisher
         from hermes.server import app
 
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
 
         mock_publisher = MagicMock(spec=Publisher)
         mock_publisher.is_connected = True
@@ -1311,7 +1307,7 @@ class TestPublisherRaises:
             content=body_bytes,
             headers={
                 "Content-Type": "application/json",
-                "X-Webhook-Signature": _sign(body_bytes),
+                "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
             },
         )
         assert response.status_code == 500
@@ -1326,7 +1322,7 @@ class TestExceptionDetailNotLeaked:
         """422 response body must only contain 'detail', no stack trace or internal info."""
         import logging
 
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         body_bytes = json.dumps({"bad": "payload"}).encode()
 
@@ -1336,7 +1332,7 @@ class TestExceptionDetailNotLeaked:
                 content=body_bytes,
                 headers={
                     "Content-Type": "application/json",
-                    "X-Webhook-Signature": _sign(body_bytes),
+                    "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
                 },
             )
 
@@ -1352,7 +1348,7 @@ class TestExceptionDetailNotLeaked:
         """A WARNING-level log must be emitted when the webhook payload is invalid."""
         import logging
 
-        monkeypatch.setenv("WEBHOOK_SECRET", _TEST_SECRET)
+        monkeypatch.setenv("WEBHOOK_SECRET", TEST_SECRET)
         client = _build_client()
         body_bytes = json.dumps({"bad": "payload"}).encode()
 
@@ -1362,7 +1358,7 @@ class TestExceptionDetailNotLeaked:
                 content=body_bytes,
                 headers={
                     "Content-Type": "application/json",
-                    "X-Webhook-Signature": _sign(body_bytes),
+                    "X-Webhook-Signature": sign_body(body_bytes, TEST_SECRET),
                 },
             )
 


### PR DESCRIPTION
## Summary

Easy-issue sweep bundle for ProjectHermes (2026-05-16 wave). Five bundled
fixes covering CI runtime hygiene, pre-commit version sync, test-helper
DRY cleanup, and a small Pydantic schema tightening. Each issue lands as
its own commit for bisect-friendliness.

## Bundled fixes

| Commit | Issue | Summary |
| --- | --- | --- |
| `a981725` | #638 | Bump `actions/checkout` to v5.0.0 (Node 24) across all workflows |
| `3f6533f` | #504 | Bump pre-commit gitleaks hook to v8.30.1 to match CI version |
| `68ca2e8` | #471 | Dedupe `_FIXED_TS` constant into `tests/helpers.FIXED_TS` |
| `5645f55` | #467, #470, #473 | Drop `_sign()` wrappers and `_TEST_SECRET = TEST_SECRET` aliases across 5 test modules |
| `bb37568` | #450 | Make `HealthResponse.timeouts` non-Optional (model + openapi.json) |

## Policy

- **Squash-only**: please use `gh pr merge --auto --squash` (no `--rebase`, no `--admin`).
- **Review required**: bundled PR, no auto-merge.
- One commit per logical issue cluster.

## Stale-check closures (closed in-place, NOT in this bundle)

Per per-issue stale-check pre-action, the following were confirmed
already implemented on `main` (`c0e6097`) and closed with citation:

- **#349** — `grep -i master CONTRIBUTING.md` returns no matches; default-branch refs already correct.
- **#417** — `tests/test_integration.py::require_nats` already uses `asyncio.run(...)` instead of `get_event_loop_policy()`.
- **#558** — Dockerfile now sources runtime deps from `pyproject.toml` which includes `slowapi` and `limits`.
- **#510** — Same Dockerfile rebuild covers `slowapi`/`limits`/`prometheus-client`.
- **#340** — `httpx` appears only once in `pixi.toml` (line 26, production); dev section no longer lists it. Wave-A dependabot already resolved.

## Quirks honored / discovered

- **Hermes CHANGELOG policy-deleted confirmed**: `gh api repos/.../contents/CHANGELOG.md` → 404. Brief was correct for Hermes. No "update CHANGELOG" issues to close in this wave.
- All commits use `--no-verify` per cold-worktree guidance (avoids 5+ min pre-commit hook install).
- Did NOT touch the `_required.yml` job structure beyond the SHA bump.
- Branch cut from current `origin/main` (`c0e6097`) post Wave-A merges.
