### PR TITLE
fix: switch TestJetStreamAck to ephemeral consumer to avoid collision

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1154,7 +1154,6 @@ class TestJetStreamAck:
         try:
             sub = await js.pull_subscribe(
                 "hi.agents.js-ack-host.js-ack-agent.created",
-                durable="test-ack-consumer-221",
                 stream="homeric-agents",
             )
 


### PR DESCRIPTION
## Summary

Fixes issue #418 (durable consumer name collision in parallel CI runs).

The test `TestJetStreamAck::test_webhook_delivers_jetstream_ack` previously created a durable consumer with a fixed name (`test-ack-consumer-221`). If a CI run was killed mid-test (e.g., SIGKILL), the consumer would be orphaned on the NATS server, and the next run would fail with `ConsumerNameAlreadyInUse`.

This fix switches to an ephemeral consumer (by removing the `durable=` kwarg) so that JetStream auto-cleans it on subscription unbind. This eliminates cross-run state entirely and is immune to process termination.

## Verification

- ✓ Single test passes end-to-end
- ✓ Back-to-back runs don't collide
- ✓ No orphaned consumers left on the stream after test completion
- ✓ Full integration suite regression check (43/44 tests pass; pre-existing flaky test unrelated to this change)
- ✓ nats-py API contract confirmed (v2.14.0, durable default is None)

## Implementation Details

**Change:** 1 line deleted from `tests/test_integration.py:1157`

Before:
```python
sub = await js.pull_subscribe(
    "hi.agents.js-ack-host.js-ack-agent.created",
    durable="test-ack-consumer-221",  # ← removed
    stream="homeric-agents",
)
```

After:
```python
sub = await js.pull_subscribe(
    "hi.agents.js-ack-host.js-ack-agent.created",
    stream="homeric-agents",
)
```

The ephemeral consumer's lifecycle is bound to the `sub` object. When the subscription is dereferenced (on function exit), JetStream unbinds and auto-removes the consumer.

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)