### PR TITLE
Add Prometheus metric for in-flight request count

### DIFF
--- a/src/hermes/metrics.py
+++ b/src/hermes/metrics.py
@@ -51,6 +51,11 @@ DEAD_LETTER_QUEUE_DEPTH: Gauge = Gauge(
     "Current number of items in the in-memory dead-letter queue",
 )
 
+INFLIGHT_REQUESTS: Gauge = Gauge(
+    "hermes_inflight_requests",
+    "Number of webhook requests currently being processed",
+)
+
 DEAD_LETTER_QUEUE_ALERTS: Counter = Counter(
     "hermes_dead_letter_queue_alerts_total",
     "Number of times the dead-letter queue depth crossed the alert threshold",

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -24,7 +24,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from hermes import __version__
 from hermes.config import Settings, get_settings
 from hermes.logging_config import setup_logging
-from hermes.metrics import WEBHOOKS_FAILED, WEBHOOKS_RECEIVED
+from hermes.metrics import INFLIGHT_REQUESTS, WEBHOOKS_FAILED, WEBHOOKS_RECEIVED
 from hermes.middleware import PayloadSizeLimitMiddleware
 from hermes.models import (
     DeadLettersResponse,
@@ -72,11 +72,13 @@ async def _inflight_context() -> AsyncGenerator[None, None]:
     global _inflight
     async with _inflight_lock:
         _inflight += 1
+    INFLIGHT_REQUESTS.inc()
     try:
         yield
     finally:
         async with _inflight_lock:
             _inflight -= 1
+        INFLIGHT_REQUESTS.dec()
 
 
 async def _connect_with_retries(publisher: Publisher, settings: "Settings") -> Exception | None:
@@ -147,6 +149,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     _shutdown_event = asyncio.Event()
     _inflight = 0
+    INFLIGHT_REQUESTS.set(0)
 
     setup_logging(json_format=settings.log_json)
 

--- a/tests/test_inflight_metric.py
+++ b/tests/test_inflight_metric.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the hermes_inflight_requests Prometheus gauge."""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes.metrics import INFLIGHT_REQUESTS
+from hermes.server import _inflight_context
+
+
+class TestInflightRequestsGauge:
+    @pytest.mark.asyncio
+    async def test_gauge_increments_inside_context(self) -> None:
+        INFLIGHT_REQUESTS.set(0)
+        async with _inflight_context():
+            assert INFLIGHT_REQUESTS._value.get() == 1.0
+        assert INFLIGHT_REQUESTS._value.get() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_gauge_decrements_on_exception(self) -> None:
+        INFLIGHT_REQUESTS.set(0)
+        with pytest.raises(RuntimeError):
+            async with _inflight_context():
+                assert INFLIGHT_REQUESTS._value.get() == 1.0
+                raise RuntimeError("boom")
+        assert INFLIGHT_REQUESTS._value.get() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_gauge_tracks_concurrent_requests(self) -> None:
+        INFLIGHT_REQUESTS.set(0)
+        async with _inflight_context():
+            async with _inflight_context():
+                assert INFLIGHT_REQUESTS._value.get() == 2.0
+            assert INFLIGHT_REQUESTS._value.get() == 1.0
+        assert INFLIGHT_REQUESTS._value.get() == 0.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -48,6 +48,7 @@ class TestMetricsEndpoint:
         assert "hermes_dead_letters_total" in text
         assert "hermes_publish_duration_seconds" in text
         assert "hermes_active_subjects_count" in text
+        assert "hermes_inflight_requests" in text
 
 
 class TestDeadLettersEndpoint:


### PR DESCRIPTION
## Summary
- Add `hermes_inflight_requests` Gauge to expose the existing `_inflight` counter as a Prometheus metric
- Synchronize gauge with `_inflight_context()` to track concurrent webhook requests
- Reset gauge on app lifespan startup for test isolation
- Update `/metrics` integration test to assert new gauge is present

## Test plan
- [x] Unit tests verify gauge increments/decrements around request lifecycle
- [x] Unit tests verify gauge decrements even on exception path
- [x] Unit tests verify concurrent requests tracked correctly
- [x] Integration test confirms gauge appears in `/metrics` output
- [x] All existing tests pass

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)