### PR TITLE
Expose reconnect loop health in /health endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -475,6 +475,28 @@
             "type": "number",
             "title": "Nats Retry Interval",
             "default": 5.0
+          },
+          "last_reconnect_attempt_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Reconnect Attempt At"
+          },
+          "consecutive_reconnect_failures": {
+            "type": "integer",
+            "title": "Consecutive Reconnect Failures",
+            "default": 0
+          },
+          "nats_reconnect_loop_active": {
+            "type": "boolean",
+            "title": "Nats Reconnect Loop Active",
+            "default": false
           }
         },
         "type": "object",

--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -74,7 +74,7 @@ class HealthResponse(BaseModel):
     nats_retry_interval: float = 5.0
     last_reconnect_attempt_at: datetime | None = None
     consecutive_reconnect_failures: int = 0
-    reconnect_loop_running: bool = False
+    nats_reconnect_loop_active: bool = False
 
 
 class WebhookAcceptedResponse(BaseModel):

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -82,8 +82,8 @@ class Publisher:
         self._reconnect_task: asyncio.Task[None] | None = None
 
     @property
-    def reconnect_loop_running(self) -> bool:
-        """Return True when the background reconnect loop is active."""
+    def reconnect_loop_active(self) -> bool:
+        """Return True when the background reconnect loop task is alive (not None, not done)."""
         task = self._reconnect_task
         return task is not None and not task.done()
 

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -358,7 +358,7 @@ async def health(response: Response) -> HealthResponse:
         nats_retry_interval=float(cfg.nats_retry_interval),
         last_reconnect_attempt_at=publisher.last_reconnect_attempt_at,
         consecutive_reconnect_failures=publisher.consecutive_reconnect_failures,
-        reconnect_loop_running=publisher.reconnect_loop_running,
+        nats_reconnect_loop_active=publisher.reconnect_loop_active,
     )
 
 

--- a/tests/test_inflight.py
+++ b/tests/test_inflight.py
@@ -31,7 +31,7 @@ def _make_mock_publisher(*, connected: bool = True) -> MagicMock:
     mock.last_error = ""
     mock.last_reconnect_attempt_at = None
     mock.consecutive_reconnect_failures = 0
-    mock.reconnect_loop_running = False
+    mock.reconnect_loop_active = False
     return mock
 
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -86,7 +86,7 @@ def test_lifespan_degraded_health_returns_503(mock_publisher: MagicMock) -> None
     mock_publisher.last_error = ""
     mock_publisher.last_reconnect_attempt_at = None
     mock_publisher.consecutive_reconnect_failures = 0
-    mock_publisher.reconnect_loop_running = False
+    mock_publisher.reconnect_loop_active = False
 
     with (
         patch("hermes.server.Publisher", return_value=mock_publisher),

--- a/tests/test_publisher_reconnect.py
+++ b/tests/test_publisher_reconnect.py
@@ -334,18 +334,31 @@ class TestReconnectLoopHealthState:
         pub = Publisher()
         assert pub.last_reconnect_attempt_at is None
         assert pub.consecutive_reconnect_failures == 0
-        assert pub.reconnect_loop_running is False
+        assert pub.reconnect_loop_active is False
 
     @pytest.mark.asyncio
-    async def test_reconnect_loop_running_true_after_connect(self) -> None:
+    async def test_reconnect_loop_active_true_after_connect(self) -> None:
         pub = Publisher()
         mock_nc = _make_mock_nc()
         await _do_connect(pub, mock_nc)
         try:
-            assert pub.reconnect_loop_running is True
+            assert pub.reconnect_loop_active is True
         finally:
             await pub.disconnect()
-        assert pub.reconnect_loop_running is False
+        assert pub.reconnect_loop_active is False
+
+    @pytest.mark.asyncio
+    async def test_reconnect_loop_active_false_when_task_done(self) -> None:
+        """Issue #446: a completed/crashed _reconnect_task must report inactive."""
+        pub = Publisher()
+
+        async def _noop() -> None:
+            return
+
+        pub._reconnect_task = asyncio.ensure_future(_noop())
+        await pub._reconnect_task
+        assert pub._reconnect_task.done()
+        assert pub.reconnect_loop_active is False
 
     @pytest.mark.asyncio
     async def test_failed_reconnect_increments_failure_counter(self) -> None:

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -27,7 +27,7 @@ def _make_mock_publisher(*, connected: bool = True) -> MagicMock:
     mock.last_error = ""
     mock.last_reconnect_attempt_at = None
     mock.consecutive_reconnect_failures = 0
-    mock.reconnect_loop_running = False
+    mock.reconnect_loop_active = False
     return mock
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -21,7 +21,7 @@ def _build_client(
     last_error: str = "",
     last_reconnect_attempt_at: object = None,
     consecutive_reconnect_failures: int = 0,
-    reconnect_loop_running: bool = False,
+    reconnect_loop_active: bool = False,
 ) -> TestClient:
     """Build a TestClient with a mocked Publisher and a known webhook secret."""
     from hermes.config import Settings, get_settings
@@ -39,7 +39,7 @@ def _build_client(
     mock_publisher.last_error = last_error
     mock_publisher.last_reconnect_attempt_at = last_reconnect_attempt_at
     mock_publisher.consecutive_reconnect_failures = consecutive_reconnect_failures
-    mock_publisher.reconnect_loop_running = reconnect_loop_running
+    mock_publisher.reconnect_loop_active = reconnect_loop_active
 
     # Inject the mock before the test client starts
     app.state.publisher = mock_publisher
@@ -126,7 +126,7 @@ class TestHealthEndpoint:
         mock_publisher.last_error = ""
         mock_publisher.last_reconnect_attempt_at = None
         mock_publisher.consecutive_reconnect_failures = 0
-        mock_publisher.reconnect_loop_running = False
+        mock_publisher.reconnect_loop_active = False
         mock_publisher.publish = AsyncMock()
         app.state.publisher = mock_publisher
 
@@ -186,7 +186,7 @@ class TestHealthEndpoint:
         # ``__init__``, so we must set them explicitly here.
         mock_publisher.last_reconnect_attempt_at = None
         mock_publisher.consecutive_reconnect_failures = 0
-        mock_publisher.reconnect_loop_running = False
+        mock_publisher.reconnect_loop_active = False
         mock_publisher.publish = AsyncMock()
         app.state.publisher = mock_publisher
 
@@ -216,8 +216,8 @@ class TestHealthEndpoint:
         assert body["last_reconnect_attempt_at"] is None
         assert "consecutive_reconnect_failures" in body
         assert body["consecutive_reconnect_failures"] == 0
-        assert "reconnect_loop_running" in body
-        assert body["reconnect_loop_running"] is False
+        assert "nats_reconnect_loop_active" in body
+        assert body["nats_reconnect_loop_active"] is False
 
     def test_health_surfaces_reconnect_loop_state(self) -> None:
         """Issue #528: /health reflects publisher reconnect-loop state."""
@@ -227,12 +227,12 @@ class TestHealthEndpoint:
         client = _build_client(
             last_reconnect_attempt_at=ts,
             consecutive_reconnect_failures=4,
-            reconnect_loop_running=True,
+            reconnect_loop_active=True,
         )
         body = client.get("/health").json()
         assert body["last_reconnect_attempt_at"].startswith("2026-05-12T10:30:00")
         assert body["consecutive_reconnect_failures"] == 4
-        assert body["reconnect_loop_running"] is True
+        assert body["nats_reconnect_loop_active"] is True
 
 
 class TestReadyEndpoint:


### PR DESCRIPTION
## Summary

Rename the existing reconnect loop health field from `reconnect_loop_running` to the issue-mandated name `nats_reconnect_loop_active`. The field is already implemented correctly at `Publisher.reconnect_loop_active` and returns `task is not None and not task.done()` — the exact derivation specified in the issue.

- Rename Publisher property and HealthResponse field atomically
- Update all test mocks and assertions
- Add regression test for done-task scenario
- Regenerate OpenAPI spec
- All 498 non-integration tests pass

## Test plan

- ✅ `test_reconnect_loop_active_true_after_connect` — field is True while loop is alive
- ✅ `test_reconnect_loop_active_false_when_task_done` — field is False when task.done() is True
- ✅ `test_health_includes_reconnect_loop_fields_defaults` — /health includes the field with safe default (False)
- ✅ `test_health_surfaces_reconnect_loop_state` — /health reflects publisher state
- ✅ Full test suite: 498 tests pass, linting passes

Closes #446