### PR TITLE
fix: restore stdout as default stream for setup_logging() — issue #462

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,14 @@ Configure external services to POST to `http://<hermes-host>:<HERMES_PORT>/webho
    hyphens, dots become hyphens, and wildcards (`*` and `>`) are stripped entirely. Tokens are
    lowercased and subject strings are typically capped at 64 characters.
 
+## Logging
+
+`setup_logging()` (in `src/hermes/logging_config.py`) configures the root logger
+and writes to `sys.stdout` by default, matching the pre-#328
+`logging.basicConfig(stream=sys.stdout)` behaviour that downstream pipelines and
+log collectors depend on. Callers that need stderr can pass
+`stream=sys.stderr` explicitly. See issue #462.
+
 ## Future Integrations
 
 ### Agamemnon (deferred — fields removed per #324)

--- a/src/hermes/logging_config.py
+++ b/src/hermes/logging_config.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 import json
 import logging
 import logging.handlers
+import sys
 from datetime import datetime, timezone
-from typing import Any
+from typing import IO, Any
 
 # Pre-compute the set of standard LogRecord attributes to exclude from extras.
 # We build this from a throwaway record so it stays in sync with the stdlib.
@@ -43,12 +44,25 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(entry, default=str)
 
 
-def setup_logging(level: int = logging.INFO, json_format: bool = False) -> None:
+def setup_logging(
+    level: int = logging.INFO,
+    json_format: bool = False,
+    stream: IO[str] | None = None,
+) -> None:
     """Configure the root logger with either JSON or plain-text formatting.
 
     Safe to call multiple times — replaces existing StreamHandlers rather than
     stacking duplicates.
+
+    ``stream`` selects the destination for the root StreamHandler. When
+    ``None`` (the default), records are routed to ``sys.stdout``, restoring
+    the pre-#328 ``logging.basicConfig(stream=sys.stdout)`` behaviour. The
+    sentinel is resolved lazily so callers (and tests using ``capsys``) see
+    the current ``sys.stdout`` rather than the value captured at import time.
+    Pass ``sys.stderr`` to send logs to stderr.
     """
+    target_stream: IO[str] = sys.stdout if stream is None else stream
+
     formatter: logging.Formatter = (
         JsonFormatter()
         if json_format
@@ -68,6 +82,6 @@ def setup_logging(level: int = logging.INFO, json_format: bool = False) -> None:
     for h in existing_stream_handlers:
         root.removeHandler(h)
 
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(stream=target_stream)
     handler.setFormatter(formatter)
     root.addHandler(handler)

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -7,6 +7,8 @@ import json
 import logging
 import sys
 
+import pytest
+
 from hermes.logging_config import JsonFormatter, setup_logging
 
 
@@ -223,14 +225,10 @@ class TestSetupLoggingStream:
         logging.getLogger().warning("hello-462")
         assert "hello-462" in buf.getvalue()
 
-    def test_none_resolves_lazily(self) -> None:
+    def test_none_resolves_lazily(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Passing stream=None must resolve sys.stdout at call time, not import time."""
         self._clear_root_handlers()
         sentinel = io.StringIO()
-        original = sys.stdout
-        try:
-            sys.stdout = sentinel
-            setup_logging(stream=None)
-            assert self._stream_handler().stream is sentinel
-        finally:
-            sys.stdout = original
+        monkeypatch.setattr(sys, "stdout", sentinel)
+        setup_logging(stream=None)
+        assert self._stream_handler().stream is sentinel

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import io
 import json
 import logging
+import sys
 
 from hermes.logging_config import JsonFormatter, setup_logging
 
@@ -185,3 +187,50 @@ class TestSetupLogging:
         self._clear_root_handlers()
         setup_logging(level=logging.DEBUG)
         assert logging.getLogger().level == logging.DEBUG
+
+
+class TestSetupLoggingStream:
+    """Regression coverage for issue #462: default destination must be stdout."""
+
+    def _clear_root_handlers(self) -> None:
+        root = logging.getLogger()
+        for h in list(root.handlers):
+            root.removeHandler(h)
+
+    def _stream_handler(self) -> logging.StreamHandler:
+        root = logging.getLogger()
+        return next(
+            h
+            for h in root.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        )
+
+    def test_default_stream_is_stdout(self) -> None:
+        """Issue #462: bare setup_logging() must route to stdout, not stderr."""
+        self._clear_root_handlers()
+        setup_logging()
+        assert self._stream_handler().stream is sys.stdout
+
+    def test_explicit_stderr_is_honoured(self) -> None:
+        self._clear_root_handlers()
+        setup_logging(stream=sys.stderr)
+        assert self._stream_handler().stream is sys.stderr
+
+    def test_custom_stream_receives_records(self) -> None:
+        self._clear_root_handlers()
+        buf = io.StringIO()
+        setup_logging(stream=buf)
+        logging.getLogger().warning("hello-462")
+        assert "hello-462" in buf.getvalue()
+
+    def test_none_resolves_lazily(self) -> None:
+        """Passing stream=None must resolve sys.stdout at call time, not import time."""
+        self._clear_root_handlers()
+        sentinel = io.StringIO()
+        original = sys.stdout
+        try:
+            sys.stdout = sentinel
+            setup_logging(stream=None)
+            assert self._stream_handler().stream is sentinel
+        finally:
+            sys.stdout = original


### PR DESCRIPTION
## Summary

Fix issue #462: `setup_logging()` was routing logs to stderr instead of the expected stdout. This breaks shell pipelines and log collectors that depend on consuming stdout.

- Added `stream: IO[str] | None = None` parameter to `setup_logging()`
- Uses `sys.stdout` as the default (resolved lazily to support pytest's `capsys` fixture)
- Passing `stream=` explicitly to `logging.StreamHandler()`
- Added 4 regression tests covering default stdout, explicit stderr, custom streams, and lazy resolution

All existing call sites in production code remain unchanged and automatically get the corrected stdout behaviour.

## Test plan

- ✅ All 4 new tests pass (`test_default_stream_is_stdout`, `test_explicit_stderr_is_honoured`, `test_custom_stream_receives_records`, `test_none_resolves_lazily`)
- ✅ All 20 tests in `test_main.py` pass (verifying call sites remain compatible)
- ✅ All 545 tests in the full suite pass (97.85% coverage)
- ✅ Lint and format checks pass

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)