### PR TITLE
ci: add macOS to validation matrix for pixi.lock

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -117,13 +117,20 @@ jobs:
           globs: "**/*.md"
           config: ".markdownlint.yaml"
 
-  pixi-check:
-    name: pixi-check
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
+  pixi-check-matrix:
+    name: pixi-check-matrix (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     needs: lint
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - macos-14  # arm64 — validates osx-arm64 entries in pixi.lock (issue #501)
+          - macos-13  # x86_64 — validates osx-64 entries in pixi.lock (issue #501)
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Skip if no pixi.toml
@@ -150,6 +157,23 @@ jobs:
             echo "::warning::pixi.toml present but pixi.lock missing — running unlocked"
             pixi install
           fi
+
+  # Preserves the historical required-check name `pixi-check` so existing
+  # branch-protection rules continue to gate merges. Succeeds iff every leg
+  # of pixi-check-matrix succeeded. Repo admins can later add the per-OS
+  # leg names (pixi-check-matrix (macos-14), pixi-check-matrix (macos-13))
+  # as additional required checks at their pace; this aggregator works in
+  # the meantime so no protection window opens at merge time.
+  pixi-check:
+    name: pixi-check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    needs: pixi-check-matrix
+    permissions:
+      contents: read
+    steps:
+      - name: Aggregate pixi-check-matrix result
+        run: echo "All pixi-check-matrix legs succeeded."
 
   justfile-check:
     name: justfile-check


### PR DESCRIPTION
## Summary
Add macOS runners to the CI matrix to validate pixi.lock on osx-arm64 and osx-64 platforms, catching lock-file drift before it impacts contributors.

## Changes
- Extended `.github/workflows/_required.yml` validation matrix to include macOS runners
- Validates pixi.lock solves correctly on both osx-arm64 and osx-64 in addition to linux-64

## Testing
- CI runs on linux-64, osx-arm64, and osx-64 platforms
- Verify pixi.lock validation passes on all three platforms

## Closes
Closes #501

Generated by Claude Code via ProjectHephaestus automation.
