### PR TITLE
docs(readme): add standardized CI/CD badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # ProjectHermes
 
 [![codecov](https://img.shields.io/codecov/c/github/HomericIntelligence/ProjectHermes?logo=codecov)](https://codecov.io/gh/HomericIntelligence/ProjectHermes)
+[![CI](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/ci.yml)
+[![Publish](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/publish.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/publish.yml)
+[![Security](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/security.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/security.yml)
 
 ProjectHermes bridges external webhooks (GitHub, Slack, third-party APIs) to
 [NATS JetStream](https://docs.nats.io/nats-concepts/jetstream) for pub/sub fan-out and event


### PR DESCRIPTION
Part of HomericIntelligence/Odysseus#352

Adds CI, Publish, and Security workflow badges to README.md, standardizing CI/CD badge presentation across the HomericIntelligence ecosystem.

Generated with [Claude Code](https://claude.com/claude-code)