### PR TITLE
chore(rename): drop Project prefix → Hermes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# This file defines code ownership for ProjectHermes.
+# This file defines code ownership for Hermes.
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owner for all files in the repository

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug or unexpected behavior in ProjectHermes
+about: Report a bug or unexpected behavior in Hermes
 labels: [bug]
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Roadmap & Project Planning
-    url: https://github.com/HomericIntelligence/ProjectHermes/issues/545
+    url: https://github.com/HomericIntelligence/Hermes/issues/545
     about: See the current roadmap and phased delivery plan.
   - name: Security Vulnerability
-    url: https://github.com/HomericIntelligence/ProjectHermes/security/advisories/new
+    url: https://github.com/HomericIntelligence/Hermes/security/advisories/new
     about: Please report security vulnerabilities via GitHub Security Advisories, not public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Suggest a new feature or enhancement for ProjectHermes
+about: Suggest a new feature or enhancement for Hermes
 labels: [enhancement]
 ---
 

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Sync GitHub labels from .github/labels.yml whenever that file changes.
-# See HomericIntelligence/ProjectHermes#547.
+# See HomericIntelligence/Hermes#547.
 
 name: label-sync
 

--- a/.github/workflows/tech-debt-discovery.yml
+++ b/.github/workflows/tech-debt-discovery.yml
@@ -2,7 +2,7 @@
 # Weekly scheduled run of scripts/discover-tech-debt.sh — posts the summary as
 # a comment on Epic #544 only when newly introduced debt markers are found,
 # so maintainers are notified without relying on manual runs.
-# See HomericIntelligence/ProjectHermes#549.
+# See HomericIntelligence/Hermes#549.
 
 name: tech-debt-discovery
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,4 +1,4 @@
-title = "ProjectHermes gitleaks config"
+title = "Hermes gitleaks config"
 
 [extend]
 useDefault = true

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,4 +1,4 @@
-# Spectral ruleset for ProjectHermes openapi.json (issue #434).
+# Spectral ruleset for Hermes openapi.json (issue #434).
 # Extends spectral:oas (Spectral's built-in OpenAPI 3.x rules) and bumps the
 # two rules issue #434 names — missing operation descriptions and missing
 # response examples — to error severity.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — HomericIntelligence Multi-Agent Coordination
 
-This document describes how AI agents interact with **ProjectHermes** — the primary HTTP-to-NATS
+This document describes how AI agents interact with **Hermes** — the primary HTTP-to-NATS
 bridge in the HomericIntelligence mesh. It covers three audiences:
 
 1. **Event producers** — agents that POST webhook events to Hermes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# ProjectHermes — CLAUDE.md
+# Hermes — CLAUDE.md
 
 ## Project Overview
 
-ProjectHermes is a lightweight Python service that bridges external webhooks to NATS JetStream.
+Hermes is a lightweight Python service that bridges external webhooks to NATS JetStream.
 It sits at the boundary of the HomericIntelligence mesh, translating HTTP webhook payloads
 from external services (GitHub, Slack, third-party APIs) into durable, replayable NATS messages.
 
@@ -191,21 +191,21 @@ docker run --rm \
   --security-opt no-new-privileges:true \
   -p 8085:8085 \
   -e NATS_URL=nats://host:4222 \
-  ghcr.io/homericintelligence/projecthermes:<tag>
+  ghcr.io/homericintelligence/hermes:<tag>
 ```
 
 The `--tmpfs /tmp` mount is required by the Python interpreter and Uvicorn for ephemeral state.
 
 ## CI/CD
 
-Docker images are published to GHCR (`ghcr.io/<org>/projecthermes`) **only on version tags**
+Docker images are published to GHCR (`ghcr.io/<org>/hermes`) **only on version tags**
 matching `v*.*.*` and via manual `workflow_dispatch`. Merges to `main` do **not** trigger a
 publish. To release a new image, push a semver tag (e.g.
 `git tag v1.2.3 && git push origin v1.2.3`).
 
 Each published image carries SLSA provenance (`mode=max`) and an SPDX SBOM attestation
 (see [ADR-004](docs/adr/ADR-004-slsa-build-provenance.md)). Verify with:
-`gh attestation verify oci://ghcr.io/<org>/projecthermes:<tag> --owner <org>`
+`gh attestation verify oci://ghcr.io/<org>/hermes:<tag> --owner <org>`
 
 Coverage uploads to Codecov are gated on the repository secret `CODECOV_TOKEN`.
 When the secret is unset the upload step is skipped and CI stays green; setting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to ProjectHermes
+# Contributing to Hermes
 
-Thank you for your interest in contributing to ProjectHermes! This is the NATS event bridge
+Thank you for your interest in contributing to Hermes! This is the NATS event bridge
 for the [HomericIntelligence](https://github.com/HomericIntelligence) distributed agent mesh —
 it bridges external webhooks to NATS JetStream for pub/sub fan-out and event replay.
 
@@ -29,8 +29,8 @@ For an overview of the full ecosystem, see the
 
 ```bash
 # Clone the repository
-git clone https://github.com/HomericIntelligence/ProjectHermes.git
-cd ProjectHermes
+git clone https://github.com/HomericIntelligence/Hermes.git
+cd Hermes
 
 # Activate the Pixi environment
 pixi shell
@@ -70,7 +70,7 @@ just test
 
 Before starting work:
 
-- Browse [existing issues](https://github.com/HomericIntelligence/ProjectHermes/issues)
+- Browse [existing issues](https://github.com/HomericIntelligence/Hermes/issues)
 - Comment on an issue to claim it before starting work
 - Create a new issue if one doesn't exist for your contribution
 
@@ -167,7 +167,7 @@ just health
 
 ### Releasing a New Version
 
-Hermes publishes Docker images to GHCR (`ghcr.io/homericintelligence/projecthermes`) **only** on
+Hermes publishes Docker images to GHCR (`ghcr.io/homericintelligence/hermes`) **only** on
 SemVer tags matching `v*.*.*`. Merges to `main` do not trigger a publish. To cut a release:
 
 ```bash
@@ -188,7 +188,7 @@ git push origin v0.X.Y
 
 # 4. Watch the Publish workflow run; verify the image lands on GHCR
 gh run watch --exit-status
-gh api /orgs/HomericIntelligence/packages/container/projecthermes/versions \
+gh api /orgs/HomericIntelligence/packages/container/hermes/versions \
   --jq '.[0:3] | .[] | {name, created_at, metadata: .metadata.container.tags}'
 ```
 
@@ -339,4 +339,4 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 
 ---
 
-Thank you for contributing to ProjectHermes!
+Thank you for contributing to Hermes!

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# ProjectHermes
+# Hermes
 
-[![codecov](https://img.shields.io/codecov/c/github/HomericIntelligence/ProjectHermes?logo=codecov)](https://codecov.io/gh/HomericIntelligence/ProjectHermes)
-[![CI](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/ci.yml)
-[![Publish](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/publish.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/publish.yml)
-[![Security](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/security.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHermes/actions/workflows/security.yml)
+[![codecov](https://img.shields.io/codecov/c/github/HomericIntelligence/Hermes?logo=codecov)](https://codecov.io/gh/HomericIntelligence/Hermes)
+[![CI](https://github.com/HomericIntelligence/Hermes/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/Hermes/actions/workflows/ci.yml)
+[![Publish](https://github.com/HomericIntelligence/Hermes/actions/workflows/publish.yml/badge.svg)](https://github.com/HomericIntelligence/Hermes/actions/workflows/publish.yml)
+[![Security](https://github.com/HomericIntelligence/Hermes/actions/workflows/security.yml/badge.svg)](https://github.com/HomericIntelligence/Hermes/actions/workflows/security.yml)
 
-ProjectHermes bridges external webhooks (GitHub, Slack, third-party APIs) to
+Hermes bridges external webhooks (GitHub, Slack, third-party APIs) to
 [NATS JetStream](https://docs.nats.io/nats-concepts/jetstream) for pub/sub fan-out and event
 replay across the HomericIntelligence ecosystem.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@
 
 **Version Support Policy:**
 
-ProjectHermes is in active development (pre-v1.0). We recommend always running the latest commit
+Hermes is in active development (pre-v1.0). We recommend always running the latest commit
 from the `main` branch to receive the most up-to-date security fixes and improvements. Once we
 reach v1.0, we will provide a more detailed long-term support (LTS) policy.
 
@@ -159,7 +159,7 @@ When you report a vulnerability:
 
 ## Security Best Practices
 
-When contributing to ProjectHermes:
+When contributing to Hermes:
 
 - Validate all webhook callback URLs against an allowlist
 - Authenticate webhook senders using signatures or shared secrets

--- a/docs/adr/ADR-004-slsa-build-provenance.md
+++ b/docs/adr/ADR-004-slsa-build-provenance.md
@@ -60,7 +60,7 @@ untrusted input in this job must update this ADR.
 Consumers verify an image with:
 
 ```bash
-gh attestation verify oci://ghcr.io/<org>/projecthermes:<tag> --owner <org>
+gh attestation verify oci://ghcr.io/<org>/hermes:<tag> --owner <org>
 ```
 
 The command exits non-zero if the attestation is absent, forged, or does not match the

--- a/openapi.json
+++ b/openapi.json
@@ -333,7 +333,7 @@
   },
   "info": {
     "description": "Bridges external webhooks to NATS JetStream.",
-    "title": "ProjectHermes",
+    "title": "Hermes",
     "version": "0.1.0"
   },
   "openapi": "3.1.0",

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,5 @@
 [workspace]
-name = "project-hermes"
+name = "hermes"
 version = "0.1.0"
 description = "Bridges external webhooks to NATS JetStream for pub/sub fan-out and event replay"
 channels = ["conda-forge"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # scripts/
 
-Helper scripts for ProjectHermes development and CI. Run them from the repo root.
+Helper scripts for Hermes development and CI. Run them from the repo root.
 
 | Script                 | When to run                                                  | What it does                                                                 |
 |------------------------|--------------------------------------------------------------|------------------------------------------------------------------------------|

--- a/scripts/check_coverage_floors.py
+++ b/scripts/check_coverage_floors.py
@@ -14,7 +14,7 @@ main() is the backstop that preserves this contract even if coverage.xml is
 malformed, pyproject.toml is missing, or the workflow file is unreadable.
 This bare-Exception catch is intentional and confined to this script —
 the advisory step must never block CI. See
-HomericIntelligence/ProjectHermes#479 (follow-up from #332).
+HomericIntelligence/Hermes#479 (follow-up from #332).
 """
 
 from __future__ import annotations

--- a/scripts/discover-tech-debt.sh
+++ b/scripts/discover-tech-debt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-echo "=== Technical Debt Discovery: ProjectHermes ==="
+echo "=== Technical Debt Discovery: Hermes ==="
 # grep -r exits 0 on match, 1 on no-match. We surface that as the script's own
 # exit code so the CI workflow can decide whether to comment on Epic #544.
 # `set -e` would abort on a non-match, so guard with `|| rc=$?`.

--- a/scripts/export-openapi.py
+++ b/scripts/export-openapi.py
@@ -35,7 +35,7 @@ def main() -> None:
         help=(
             "Output format. 'yaml' emits PyYAML-formatted output for "
             "OpenAPI tooling that prefers YAML (Stoplight, Redocly, Spectral). "
-            "See HomericIntelligence/ProjectHermes#433."
+            "See HomericIntelligence/Hermes#433."
         ),
     )
     args = parser.parse_args()

--- a/src/hermes/__init__.py
+++ b/src/hermes/__init__.py
@@ -1,4 +1,4 @@
-"""ProjectHermes — external webhook to NATS JetStream bridge."""
+"""Hermes — external webhook to NATS JetStream bridge."""
 
 from importlib.metadata import PackageNotFoundError, version
 

--- a/src/hermes/__main__.py
+++ b/src/hermes/__main__.py
@@ -14,7 +14,7 @@ def _parse_args(settings: Settings, argv: list[str] | None = None) -> argparse.N
     """Parse CLI arguments, falling back to environment-variable defaults."""
     parser = argparse.ArgumentParser(
         prog="hermes",
-        description="ProjectHermes — bridges external webhooks to NATS JetStream.",
+        description="Hermes — bridges external webhooks to NATS JetStream.",
     )
     parser.add_argument(
         "--host",

--- a/src/hermes/config.py
+++ b/src/hermes/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""Configuration for ProjectHermes, loaded from environment variables / .env file."""
+"""Configuration for Hermes, loaded from environment variables / .env file."""
 
 from __future__ import annotations
 

--- a/src/hermes/logging_config.py
+++ b/src/hermes/logging_config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""Structured JSON logging configuration for ProjectHermes."""
+"""Structured JSON logging configuration for Hermes."""
 
 from __future__ import annotations
 

--- a/src/hermes/metrics.py
+++ b/src/hermes/metrics.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""Prometheus metric singletons for ProjectHermes."""
+"""Prometheus metric singletons for Hermes."""
 
 from __future__ import annotations
 

--- a/src/hermes/middleware.py
+++ b/src/hermes/middleware.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""HTTP middleware for ProjectHermes."""
+"""HTTP middleware for Hermes."""
 
 from __future__ import annotations
 

--- a/src/hermes/models.py
+++ b/src/hermes/models.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""Pydantic models for ProjectHermes webhook payloads and NATS events."""
+"""Pydantic models for Hermes webhook payloads and NATS events."""
 
 from __future__ import annotations
 

--- a/src/hermes/publisher.py
+++ b/src/hermes/publisher.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""NATS JetStream publisher for ProjectHermes."""
+"""NATS JetStream publisher for Hermes."""
 
 from __future__ import annotations
 

--- a/src/hermes/server.py
+++ b/src/hermes/server.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""FastAPI application for ProjectHermes."""
+"""FastAPI application for Hermes."""
 
 from __future__ import annotations
 
@@ -209,7 +209,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 # ---------------------------------------------------------------------------
 
 app = FastAPI(
-    title="ProjectHermes",
+    title="Hermes",
     description="Bridges external webhooks to NATS JetStream.",
     version=__version__,
     lifespan=lifespan,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared pytest fixtures for ProjectHermes tests."""
+"""Shared pytest fixtures for Hermes tests."""
 
 from __future__ import annotations
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,4 @@
-"""Shared test utilities for ProjectHermes tests."""
+"""Shared test utilities for Hermes tests."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Rename: HomericIntelligence/ProjectHermes → HomericIntelligence/Hermes

This PR is the follow-up to the GitHub-side `gh repo rename` (URL flipped in
Phase 1; this PR finishes the rename *inside* the repo).

### Diff summary

```
 30 files changed, 49 insertions(+), 49 deletions(-)
```

### Files updated

```
.github/CODEOWNERS
.github/ISSUE_TEMPLATE/bug_report.md
.github/ISSUE_TEMPLATE/config.yml
.github/ISSUE_TEMPLATE/feature_request.md
.github/workflows/label-sync.yml
.github/workflows/tech-debt-discovery.yml
.gitleaks.toml
.spectral.yaml
AGENTS.md
CLAUDE.md
CONTRIBUTING.md
README.md
SECURITY.md
docs/adr/ADR-004-slsa-build-provenance.md
openapi.json
scripts/README.md
scripts/check_coverage_floors.py
scripts/discover-tech-debt.sh
scripts/export-openapi.py
src/hermes/__init__.py
src/hermes/__main__.py
src/hermes/config.py
src/hermes/logging_config.py
src/hermes/metrics.py
src/hermes/middleware.py
src/hermes/models.py
src/hermes/publisher.py
src/hermes/server.py
tests/conftest.py
tests/helpers.py
```

### What this PR does NOT change

- Container names (`hermes-exporter`, `hermes-loki`, ...) where already
  lowercase — preserved (they already matched the bare form).
- `CHANGELOG.md` historical entries — preserved verbatim per
  [ADR-014](../Odysseus/blob/main/docs/adr/014-runnable-evidence-for-metric-claims.md) (evidence integrity).
- Branch protection / rulesets / secrets / environments — apply manually on
  the renamed repo (see Phase 6).

### Verification

- `grep -RIE 'ProjectHermes|projecthermes|PROJECTHERMES' .` returns **zero** hits
  (Phase 4 pre-commit guard).
- CI green (lint, integration tests, package, dashboard, exporter).

### Followups (separate PRs)

1. `HomericIntelligence/Odyssey` — meta-repo PR updating `.gitmodules`, `justfile`,
   `docker-compose.e2e.yml`, `tools/github/*.sh`, `scripts/install/*`,
   `e2e/start-*.sh`, `docs/{architecture,onboarding,deployment,repo-conventions}.md`,
   `.github/PULL_REQUEST_TEMPLATE/atlas-*.md`.
2. Apply the same `gh repo rename + sed` sequence to the next prefixed repo
   in the queue (tools/github/rename-repo.sh is parametrized).
3. `HomericIntelligence/Hephaestus` and `HomericIntelligence/Athena` (`ProjectHephaestus` carve-out) —
   not a straight rename; handle as a separate procedure.