### PR TITLE
chore(settings): swap hephaestus plugin → Athena marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,28 @@
 {
   "enabledPlugins": {
-    "hephaestus@ProjectHephaestus": true
+    "advise@Athena": true,
+    "brainstorm@Athena": true,
+    "code-review@Athena": true,
+    "create-reusable-utilities@Athena": true,
+    "finish-branch@Athena": true,
+    "git-worktrees@Athena": true,
+    "github-actions-python-cicd@Athena": true,
+    "learn@Athena": true,
+    "myrmidon-swarm@Athena": true,
+    "python-repo-modernization@Athena": true,
+    "repo-analyze@Athena": true,
+    "repo-analyze-full@Athena": true,
+    "repo-analyze-quick@Athena": true,
+    "repo-analyze-quick-full@Athena": true,
+    "repo-analyze-strict@Athena": true,
+    "repo-analyze-strict-full@Athena": true,
+    "review-pr-strict@Athena": true,
+    "skill-advisor@Athena": true,
+    "systematic-debugging@Athena": true,
+    "test-driven-development@Athena": true,
+    "tidy@Athena": true,
+    "verification@Athena": true,
+    "worktree-cleanup@Athena": true
   },
   "permissions": {
     "deny": [
@@ -33,5 +55,13 @@
       "Edit(~/.aws/**)",
       "Edit(~/.gnupg/**)"
     ]
+  },
+  "extraKnownMarketplaces": {
+    "Athena": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/HomericIntelligence/Athena.git"
+      }
+    }
   }
 }


### PR DESCRIPTION
The `hephaestus@ProjectHephaestus` plugin ref no longer resolves after the Hephaestus Claude Code skills were carved out into the standalone `HomericIntelligence/Athena` marketplace (23 per-skill plugins).

This migrates `.claude/settings.json`:
- Removes the stale `hephaestus@ProjectHephaestus` key from `enabledPlugins`.
- Enables the 23 `<skill>@Athena` per-skill plugins.
- Registers the Athena marketplace under `extraKnownMarketplaces`.
- Preserves `permissions` (byte-identical) and all other settings.

Verified with jq: valid JSON, hephaestus ref gone, exactly 23 `@Athena` keys, Athena marketplace URL present, `permissions.deny` unchanged (28 entries).

Closes #716