### PR TITLE
[Fix] Restore green main: sync nats-py range, regenerate pixi.lock, replace retired macos-13 runner

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -130,7 +130,10 @@ jobs:
         os:
           - ubuntu-24.04
           - macos-14  # arm64 — validates osx-arm64 entries in pixi.lock (issue #501)
-          - macos-13  # x86_64 — validates osx-64 entries in pixi.lock (issue #501)
+          # macos-13 runners were retired by GitHub (jobs queue forever and
+          # strand the workflow run); macos-15-intel is the remaining x86_64
+          # hosted label and keeps the osx-64 lock validation (issue #501).
+          - macos-15-intel  # x86_64 — validates osx-64 entries in pixi.lock (issue #501)
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Skip if no pixi.toml
@@ -161,7 +164,7 @@ jobs:
   # Preserves the historical required-check name `pixi-check` so existing
   # branch-protection rules continue to gate merges. Succeeds iff every leg
   # of pixi-check-matrix succeeded. Repo admins can later add the per-OS
-  # leg names (pixi-check-matrix (macos-14), pixi-check-matrix (macos-13))
+  # leg names (pixi-check-matrix (macos-14), pixi-check-matrix (macos-15-intel))
   # as additional required checks at their pace; this aggregator works in
   # the meantime so no protection window opens at merge time.
   pixi-check:

--- a/pixi.lock
+++ b/pixi.lock
@@ -94,6 +94,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/a8/b55606c7c621fb813c8ec78baf201d2c78bf6051091ec0c7ada572999e95/nats_py-2.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -104,7 +105,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       osx-64:
@@ -187,6 +187,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/a8/b55606c7c621fb813c8ec78baf201d2c78bf6051091ec0c7ada572999e95/nats_py-2.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
@@ -198,7 +199,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
@@ -281,6 +281,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/a8/b55606c7c621fb813c8ec78baf201d2c78bf6051091ec0c7ada572999e95/nats_py-2.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
@@ -290,7 +291,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
   lock:
     channels:
@@ -1340,7 +1340,7 @@ packages:
   - fastapi>=0.136.1,<1
   - starlette>=1.3.1,<2
   - uvicorn[standard]>=0.47.0,<1
-  - nats-py>=2.14.0,<3
+  - nats-py>=2.15.0,<3
   - pydantic>=2.13.4,<3
   - pydantic-settings>=2.14.2,<3
   - httpx>=0.28.1,<1
@@ -2252,6 +2252,15 @@ packages:
   version: 3.5.0
   sha256: a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/db/a8/b55606c7c621fb813c8ec78baf201d2c78bf6051091ec0c7ada572999e95/nats_py-2.15.0-py3-none-any.whl
+  name: nats-py
+  version: 2.15.0
+  sha256: 9f8d36aa52a9926a88b8f1d70cf1fdce0ad387941479b500ee9ab3e51073cefd
+  requires_dist:
+  - aiohttp ; extra == 'aiohttp'
+  - fast-mail-parser ; extra == 'fast-parse'
+  - nkeys ; extra == 'nkeys'
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
   name: typing-inspection
   version: 0.4.2
@@ -2397,15 +2406,6 @@ packages:
   requires_dist:
   - colorama>=0.4.6 ; extra == 'windows-terminal'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
-  name: nats-py
-  version: 2.14.0
-  sha256: 4116f5d2233ce16e63c3d5538fa40a5e207f75fcf42a741773929ddf1e29d19d
-  requires_dist:
-  - nkeys ; extra == 'nkeys'
-  - aiohttp ; extra == 'aiohttp'
-  - fast-mail-parser ; extra == 'fast-parse'
-  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl
   name: click
   version: 8.4.2

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,7 +21,8 @@ fastapi = ">=0.136.1,<1"
 # Keep in sync with pyproject.toml.
 starlette = ">=1.3.1,<2"
 uvicorn = {version = ">=0.47.0,<1", extras = ["standard"]}
-nats-py = ">=2.14.0,<3"
+# Keep in sync with pyproject.toml (deps/version-sync gate).
+nats-py = ">=2.15.0,<3"
 pydantic = ">=2.13.4,<3"
 # Bumped to >=2.14.2 to remediate GHSA-4xgf-cpjx-pc3j (pip-audit).
 pydantic-settings = ">=2.14.2,<3"

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -183,9 +183,9 @@ msgpack==1.2.1 \
     --hash=sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc \
     --hash=sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c
     # via hermes (pyproject.toml)
-nats-py==2.14.0 \
-    --hash=sha256:4116f5d2233ce16e63c3d5538fa40a5e207f75fcf42a741773929ddf1e29d19d \
-    --hash=sha256:4ed02cb8e3b55c68074a063aa2687087115d805d1513297da90cb2068fb07bed
+nats-py==2.15.0 \
+    --hash=sha256:6622c547d9a7d2313d9c147d46c386188f4ec2c7b5c9f9a0438a4d1b55f54a93 \
+    --hash=sha256:9f8d36aa52a9926a88b8f1d70cf1fdce0ad387941479b500ee9ab3e51073cefd
     # via hermes (pyproject.toml)
 packaging==26.2 \
     --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \

--- a/scripts/check-workflow-timeouts.sh
+++ b/scripts/check-workflow-timeouts.sh
@@ -12,7 +12,12 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)"
 cd "$ROOT"
 
-mapfile -t files < <(git ls-files -- \
+# NOTE: portable across bash 3.2 (macOS ships 3.2; `mapfile` needs bash 4+).
+# macos-tests runs tests/test_workflow_timeouts.py against this script.
+files=()
+while IFS= read -r f; do
+  files+=("$f")
+done < <(git ls-files -- \
   '.github/workflows/*.yml' '.github/workflows/*.yaml')
 
 if [ "${#files[@]}" -eq 0 ]; then


### PR DESCRIPTION
## Summary

main has been red since dc987ce bumped nats-py to `>=2.15.0,<3` in pyproject.toml only, leaving pixi.toml and pixi.lock stale. All 8 open PRs fail the identical check set because every CI job inherits the broken workspace.

Root causes fixed here:

1. **Stale pixi.lock** — `pixi install --locked` failed with `lock-file not up-to-date with the workspace` in lint, unit-tests, integration-tests, build, macos-tests, openapi-drift, and security/dependency-scan. Regenerated (only change: nats-py 2.14.0 → 2.15.0).
2. **nats-py range drift** — `deps/version-sync` (scripts/check_dep_sync.py) and `tests/test_check_dep_sync.py::test_main_real_repo_files_pass` failed because pixi.toml still declared `>=2.14.0,<3`. Synced to `>=2.15.0,<3`.
3. **Retired macos-13 runner** (non-required but strands runs) — the `pixi-check-matrix (macos-13)` leg queued ~21h per run waiting on a runner label GitHub retired. Replaced with `macos-15-intel`, keeping the osx-64 lock-validation intent of issue #501.

Credit: PR #707 correctly identified the stale lockfile and regenerated it; this PR supersedes it because a lock regen alone still fails deps/version-sync, unit-tests, and macos-tests on the version drift (see #707's checks).

## Verification (local, pixi 0.68.0 = CI-pinned version)

- `pixi install --locked` — OK
- `python3 scripts/check_dep_sync.py` — OK (12 deps consistent)
- `pixi run pytest -m "not integration"` — 624 passed (incl. test_check_dep_sync)
- `pixi run lint` — All checks passed
- `pixi run typecheck` — Success, no issues in 10 source files
- `pixi run pip-audit` — No known vulnerabilities found

Closes #718