### PR TITLE
ci: prepare Hermes for merge queue

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,6 +3,8 @@ name: Security Scan
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   schedule:
     # Weekly on Monday at 08:00 UTC
     - cron: "0 8 * * 1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,6 +294,36 @@ gh pr create --title "[Type] Brief description" --body "Closes #<issue-number>"
 - Single-concern PRs: squash-and-merge
 - Multi-commit story-arc PRs: rebase-and-merge
 
+### Merge Queue Rollout
+
+The workflows that emit required `main` checks also handle
+`merge_group` / `checks_requested`, so queued merge groups run the same gates as pull requests.
+The queue is activated separately from workflow-readiness changes: a maintainer must wait until
+the readiness PR has merged and a representative smoke check is ready. Existing merge behavior
+remains unchanged until activation; after activation, queued merges use squash regardless of the
+pre-queue strategy above.
+
+When activation is approved, add a `merge_queue` rule to the active
+`homeric-main-baseline` repository ruleset targeting `refs/heads/main` with these exact parameters:
+
+```json
+{
+  "check_response_timeout_minutes": 60,
+  "grouping_strategy": "ALLGREEN",
+  "max_entries_to_build": 10,
+  "max_entries_to_merge": 5,
+  "merge_method": "SQUASH",
+  "min_entries_to_merge": 1,
+  "min_entries_to_merge_wait_minutes": 5
+}
+```
+
+Apply the rule with a read-modify-write operation that preserves every existing required status
+context and all unrelated protection fields. After activation, queue one representative PR and
+record the `merge_group` workflow runs and merge result in
+[Hermes #720](https://github.com/HomericIntelligence/Hermes/issues/720) before declaring the
+repository complete.
+
 ### Never Push Directly to Main
 
 The `main` branch is protected. All changes must go through pull requests.

--- a/tests/test_merge_queue_ci.py
+++ b/tests/test_merge_queue_ci.py
@@ -1,0 +1,77 @@
+"""Regression coverage for merge-queue required-check workflow support."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO = Path(__file__).resolve().parent.parent
+_WORKFLOWS = _REPO / ".github" / "workflows"
+
+# These names mirror the required contexts in Hermes's active main rulesets.
+# Keep this map in sync when a required context is added, removed, or renamed.
+_REQUIRED_CONTEXTS_BY_WORKFLOW = {
+    "_required.yml": {
+        "lint",
+        "unit-tests",
+        "integration-tests",
+        "security/dependency-scan",
+        "security/secrets-scan",
+        "build",
+        "schema-validation",
+        "deps/version-sync",
+        "test",
+        "package",
+        "install",
+        "release",
+        "justfile-check",
+    },
+    "security.yml": {"Secret Scanning (gitleaks)"},
+}
+
+
+def _load_workflow(name: str) -> dict:
+    document = yaml.safe_load((_WORKFLOWS / name).read_text())
+    assert isinstance(document, dict)
+    return document
+
+
+def _trigger(document: dict) -> dict:
+    # PyYAML 1.1 parses the bare GitHub Actions `on` key as boolean True.
+    trigger = document.get("on", document.get(True))
+    assert isinstance(trigger, dict)
+    return trigger
+
+
+@pytest.mark.parametrize("workflow_name", _REQUIRED_CONTEXTS_BY_WORKFLOW)
+def test_required_context_workflows_handle_merge_group_checks_requested(
+    workflow_name: str,
+) -> None:
+    """Every workflow that gates main must also run for merge-queue groups."""
+    merge_group = _trigger(_load_workflow(workflow_name)).get("merge_group")
+    assert merge_group == {"types": ["checks_requested"]}, (
+        f"{workflow_name} must handle merge_group/checks_requested so its required "
+        "contexts are emitted for merge-queue groups"
+    )
+
+
+@pytest.mark.parametrize(
+    ("workflow_name", "required_contexts"),
+    _REQUIRED_CONTEXTS_BY_WORKFLOW.items(),
+)
+def test_required_context_names_remain_emitted(
+    workflow_name: str, required_contexts: set[str]
+) -> None:
+    """Merge-queue trigger changes must not drop or rename existing gates."""
+    document = _load_workflow(workflow_name)
+    emitted_names = {
+        job.get("name", job_id)
+        for job_id, job in document.get("jobs", {}).items()
+        if isinstance(job, dict)
+    }
+    assert required_contexts <= emitted_names, (
+        f"{workflow_name} no longer emits required contexts: "
+        f"{sorted(required_contexts - emitted_names)}"
+    )


### PR DESCRIPTION
## Summary

- Run every workflow that supplies a required `main` context for
  `merge_group: checks_requested` while preserving existing push, pull-request, schedule, and
  manual behavior.
- Add focused regression coverage that pins all 14 required contexts to their source workflows
  and verifies both workflows emit them for merge groups.
- Document the staged post-merge activation policy and exact approved queue parameters.

## Live baseline and staged activation

Read-only inspection found two active repository rulesets on `main`:
`homeric-main-baseline` (12 required contexts) and `homeric-main-extras` (2 required contexts).
Neither has a `merge_queue` rule, and Hermes has no canonical repository-owned ruleset
configuration file.

This PR does **not** mutate live GitHub rulesets or enable the queue. After this PR merges and the
representative smoke check is ready, an administrator must add this rule to the active
`homeric-main-baseline` ruleset targeting `refs/heads/main` using a full read-modify-write that
preserves both required-context sets and every unrelated field:

```json
{
  "type": "merge_queue",
  "parameters": {
    "check_response_timeout_minutes": 60,
    "grouping_strategy": "ALLGREEN",
    "max_entries_to_build": 10,
    "max_entries_to_merge": 5,
    "merge_method": "SQUASH",
    "min_entries_to_merge": 1,
    "min_entries_to_merge_wait_minutes": 5
  }
}
```

After activation, queue one representative PR and record the `merge_group` check runs and queued
merge result on #720.

## Validation

- `just test`: 647 passed, 47 skipped; 98.31% coverage.
- `just lint`: passed.
- `just typecheck`: passed.
- Focused merge-queue test: 4 passed.
- Changed-file pre-commit hooks: passed.
- GitHub workflow JSON-schema validation: passed.
- `markdownlint-cli2 v0.20.0 CONTRIBUTING.md`: 0 errors.
- Focused Ruff format check for the new test: passed. The repository-wide format check reports 15
  pre-existing unrelated files and this PR leaves them untouched.

Closes #720

Umbrella rollout: [Odysseus #386](https://github.com/HomericIntelligence/Odysseus/issues/386)
